### PR TITLE
Fix cmake format command

### DIFF
--- a/cmake/04_code_formatter.cmake
+++ b/cmake/04_code_formatter.cmake
@@ -37,8 +37,16 @@ endif()
 
 if(CMAKE_FORMAT_BIN AND ENABLE_FORMATTER)
   set(_cmake_files
-      "${PROJECT_SOURCE_DIR}/CMakeLists.txt;${PROJECT_SOURCE_DIR}/external/CMakeLists.txt;${PROJECT_SOURCE_DIR}/cmake/*.cmake;${PROJECT_SOURCE_DIR}/modules/**/*.txt;toolchains/*.cmake"
+      "${PROJECT_SOURCE_DIR}/CMakeLists.txt;${PROJECT_SOURCE_DIR}/external/CMakeLists.txt;${PROJECT_SOURCE_DIR}/modules/**/*.txt"
   )
+  if(EXISTS "${PROJECT_SOURCE_DIR}/cmake")
+    list(APPEND _cmake_files "${PROJECT_SOURCE_DIR}/cmake/*.cmake"
+  )
+  endif()
+  if (EXISTS  "${PROJECT_SOURCE_DIR}/toolchains/*.cmake")
+    list(APPEND _cmake_files "${PROJECT_SOURCE_DIR}/cmake/*.cmake")
+  endif()
+
   if(FORMAT_FAIL_ON_CHANGE)
     add_custom_command(
       TARGET ${FORMAT_TARGET}

--- a/cmake/04_code_formatter.cmake
+++ b/cmake/04_code_formatter.cmake
@@ -40,10 +40,9 @@ if(CMAKE_FORMAT_BIN AND ENABLE_FORMATTER)
       "${PROJECT_SOURCE_DIR}/CMakeLists.txt;${PROJECT_SOURCE_DIR}/external/CMakeLists.txt;${PROJECT_SOURCE_DIR}/modules/**/*.txt"
   )
   if(EXISTS "${PROJECT_SOURCE_DIR}/cmake")
-    list(APPEND _cmake_files "${PROJECT_SOURCE_DIR}/cmake/*.cmake"
-  )
+    list(APPEND _cmake_files "${PROJECT_SOURCE_DIR}/cmake/*.cmake")
   endif()
-  if (EXISTS  "${PROJECT_SOURCE_DIR}/toolchains/*.cmake")
+  if(EXISTS "${PROJECT_SOURCE_DIR}/toolchains/*.cmake")
     list(APPEND _cmake_files "${PROJECT_SOURCE_DIR}/cmake/*.cmake")
   endif()
 

--- a/cmake/05_modules.cmake
+++ b/cmake/05_modules.cmake
@@ -633,20 +633,20 @@ macro(define_module_test)
 
   add_dependencies(${TESTS_TARGET} ${TARGET_NAME}) # Set this to be built on `make tests`
 
-  if (NOT BUILD_AS_SUBPROJECT)
-  # Add to cmake tests (call using ctest)
-  add_test(
-    NAME ${TARGET_NAME}
-    COMMAND ${TARGET_NAME}
-    WORKING_DIRECTORY ${TARGET_ARG_WORKING_DIRECTORY}
-  )
+  if(NOT BUILD_AS_SUBPROJECT)
+    # Add to cmake tests (call using ctest)
+    add_test(
+      NAME ${TARGET_NAME}
+      COMMAND ${TARGET_NAME}
+      WORKING_DIRECTORY ${TARGET_ARG_WORKING_DIRECTORY}
+    )
 
-  gtest_discover_tests(
-    ${TARGET_NAME}
-    WORKING_DIRECTORY ${TARGET_ARG_WORKING_DIRECTORY}
-    PROPERTIES
-    TIMEOUT ${TEST_TIMEOUT_SECONDS}
-  )
+    gtest_discover_tests(
+      ${TARGET_NAME}
+      WORKING_DIRECTORY ${TARGET_ARG_WORKING_DIRECTORY}
+      PROPERTIES
+      TIMEOUT ${TEST_TIMEOUT_SECONDS}
+    )
   endif()
 
 endmacro()

--- a/modules/utils/src/version_impl.h
+++ b/modules/utils/src/version_impl.h
@@ -17,8 +17,8 @@ static constexpr std::uint8_t VERSION_MAJOR = 0;
 static constexpr std::uint8_t VERSION_MINOR = 0;
 static constexpr std::uint16_t VERSION_PATCH = 1;
 
-static constexpr std::string_view REPO_BRANCH = "main";
+static constexpr std::string_view REPO_BRANCH = "fix_format_submodule";
 static constexpr std::string_view BUILD_PROFILE = "RelWithDebInfo";
-static constexpr std::string_view REPO_HASH = "ede65d3";
+static constexpr std::string_view REPO_HASH = "4d99261";
 
 } // namespace heph::utils

--- a/modules/utils/src/version_impl.h
+++ b/modules/utils/src/version_impl.h
@@ -17,8 +17,8 @@ static constexpr std::uint8_t VERSION_MAJOR = 0;
 static constexpr std::uint8_t VERSION_MINOR = 0;
 static constexpr std::uint16_t VERSION_PATCH = 1;
 
-static constexpr std::string_view REPO_BRANCH = "update_zenohc";
+static constexpr std::string_view REPO_BRANCH = "main";
 static constexpr std::string_view BUILD_PROFILE = "RelWithDebInfo";
-static constexpr std::string_view REPO_HASH = "28cb39d";
+static constexpr std::string_view REPO_HASH = "ede65d3";
 
 } // namespace heph::utils


### PR DESCRIPTION
# Description
Cmake formatting command is broken whern hephaestus is imported as a submodule

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
