### PR TITLE
fix: Add the ability to serialize templated types.

### DIFF
--- a/modules/serdes/include/hephaestus/serdes/protobuf/concepts.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/concepts.h
@@ -8,7 +8,7 @@
 
 namespace heph::serdes::protobuf {
 
-template <class T>
+template <class T, class... Args>
 struct ProtoAssociation {
   using Type = void;
 };

--- a/modules/serdes/tests/tests.cpp
+++ b/modules/serdes/tests/tests.cpp
@@ -2,6 +2,8 @@
 // Copyright (C) 2023-2024 HEPHAESTUS Contributors
 //=================================================================================================
 
+#include <cstddef>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -31,11 +33,26 @@ struct Data {
   int a = NUMBER;
 };
 
+template <class T, size_t Size>
+struct TemplatedData {
+  std::array<T, Size> data;
+  TemplatedData() {
+    std::fill(data.begin(), data.end(), static_cast<T>(NUMBER));
+  }
+};
+
+using TemplatedData3d = TemplatedData<double, 3>;
+
 }  // namespace heph::serdes::tests
 
 namespace heph::serdes::protobuf {
 template <>
 struct ProtoAssociation<heph::serdes::tests::Data> {
+  using Type = heph::serdes::tests::MockProtoMessage;
+};
+
+template <class... Args>
+    struct ProtoAssociation < heph::serdes::tests::TemplatedData<Args...> {
   using Type = heph::serdes::tests::MockProtoMessage;
 };
 }  // namespace heph::serdes::protobuf


### PR DESCRIPTION
# Description
To allow serialization of templated types, we add variadic template parameters to `struct ProtoAssociation`.

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
