### PR TITLE
Fix for gcc compilation

### DIFF
--- a/modules/cli/include/hephaestus/cli/program_options.h
+++ b/modules/cli/include/hephaestus/cli/program_options.h
@@ -69,7 +69,7 @@ class ProgramDescription {
 public:
   /// @brief Creates object
   /// @param brief A brief text describing the program
-  constexpr explicit ProgramDescription(std::string brief);
+  explicit ProgramDescription(std::string brief);  // NOTE: GCC doesn't like this to be constexpr
 
   /// @brief Defines a required option (--key=value) on the command line
   /// @tparam T Value type
@@ -77,7 +77,7 @@ public:
   /// @param description A brief text describing the option
   /// @return Reference to the object. Enables daisy-chained calls
   template <StringStreamable T>
-  constexpr auto defineOption(const std::string& key, const std::string& description) -> ProgramDescription&;
+  auto defineOption(const std::string& key, const std::string& description) -> ProgramDescription&;
 
   /// @brief Defines a required option (--key=value) on the command line
   /// @tparam T Value type
@@ -86,8 +86,8 @@ public:
   /// @param description A brief text describing the option
   /// @return Reference to the object. Enables daisy-chained calls
   template <StringStreamable T>
-  constexpr auto defineOption(const std::string& key, char short_key,
-                              const std::string& description) -> ProgramDescription&;
+  auto defineOption(const std::string& key, char short_key,
+                    const std::string& description) -> ProgramDescription&;
 
   /// @brief Defines a command line option (--key=value) that is optional
   /// @tparam T Value type
@@ -96,8 +96,8 @@ public:
   /// @param default_value Default value to use if the option is not specified on the command line
   /// @return Reference to the object. Enables daisy-chained calls
   template <StringStreamable T>
-  constexpr auto defineOption(const std::string& key, const std::string& description,
-                              const T& default_value) -> ProgramDescription&;
+  auto defineOption(const std::string& key, const std::string& description,
+                    const T& default_value) -> ProgramDescription&;
 
   /// @brief Defines a command line option (--key=value) that is optional
   /// @tparam T Value type
@@ -107,8 +107,8 @@ public:
   /// @param default_value Default value to use if the option is not specified on the command line
   /// @return Reference to the object. Enables daisy-chained calls
   template <StringStreamable T>
-  constexpr auto defineOption(const std::string& key, char short_key, const std::string& description,
-                              const T& default_value) -> ProgramDescription&;
+  auto defineOption(const std::string& key, char short_key, const std::string& description,
+                    const T& default_value) -> ProgramDescription&;
 
   /// @brief Defines a boolean option (flag) (--key=value) on the command line. If the flag is
   /// passed the value of the option is true, false otherwise.
@@ -116,15 +116,15 @@ public:
   /// @param short_key Single char (can be used as alias for --key)
   /// @param description A brief text describing the option
   /// @return Reference to the object. Enables daisy-chained calls
-  constexpr auto defineFlag(const std::string& key, char short_key,
-                            const std::string& description) -> ProgramDescription&;
+  auto defineFlag(const std::string& key, char short_key,
+                  const std::string& description) -> ProgramDescription&;
 
   /// @brief Defines a boolean option (flag) (--key=value) on the command line. If the flag is
   /// passed the value of the option is true, false otherwise.
   /// @param key Key of the key-value pair
   /// @param description A brief text describing the option
   /// @return Reference to the object. Enables daisy-chained calls
-  constexpr auto defineFlag(const std::string& key, const std::string& description) -> ProgramDescription&;
+  auto defineFlag(const std::string& key, const std::string& description) -> ProgramDescription&;
 
   /// @brief Builds the container to parse command line options.
   /// @note: The resources in this object is moved into the returned object, making this object
@@ -155,7 +155,7 @@ private:
   std::vector<ProgramOptions::Option> options_;
 };
 
-constexpr ProgramDescription::ProgramDescription(std::string brief) : brief_(std::move(brief)) {
+ProgramDescription::ProgramDescription(std::string brief) : brief_(std::move(brief)) {
   options_.emplace_back(HELP_KEY, HELP_SHORT_KEY, "", utils::getTypeName<std::string>(), "", false, false);
 }
 
@@ -177,14 +177,14 @@ void ProgramDescription::checkOptionAlreadyExists(const std::string& key, char k
 }
 
 template <StringStreamable T>
-constexpr auto ProgramDescription::defineOption(const std::string& key,
-                                                const std::string& description) -> ProgramDescription& {
+auto ProgramDescription::defineOption(const std::string& key,
+                                      const std::string& description) -> ProgramDescription& {
   return defineOption<T>(key, '\0', description);
 }
 
 template <StringStreamable T>
-constexpr auto ProgramDescription::defineOption(const std::string& key, char short_key,
-                                                const std::string& description) -> ProgramDescription& {
+auto ProgramDescription::defineOption(const std::string& key, char short_key,
+                                      const std::string& description) -> ProgramDescription& {
   checkOptionAlreadyExists(key, short_key);
 
   options_.emplace_back(key, short_key, description, utils::getTypeName<T>(), "", true, false);
@@ -192,15 +192,14 @@ constexpr auto ProgramDescription::defineOption(const std::string& key, char sho
 }
 
 template <StringStreamable T>
-constexpr auto ProgramDescription::defineOption(const std::string& key, const std::string& description,
-                                                const T& default_value) -> ProgramDescription& {
+auto ProgramDescription::defineOption(const std::string& key, const std::string& description,
+                                      const T& default_value) -> ProgramDescription& {
   return defineOption<T>(key, '\0', description, default_value);
 }
 
 template <StringStreamable T>
-constexpr auto ProgramDescription::defineOption(const std::string& key, char short_key,
-                                                const std::string& description,
-                                                const T& default_value) -> ProgramDescription& {
+auto ProgramDescription::defineOption(const std::string& key, char short_key, const std::string& description,
+                                      const T& default_value) -> ProgramDescription& {
   checkOptionAlreadyExists(key, short_key);
 
   options_.emplace_back(key, short_key, description, utils::getTypeName<T>(),
@@ -208,16 +207,16 @@ constexpr auto ProgramDescription::defineOption(const std::string& key, char sho
   return *this;
 }
 
-constexpr auto ProgramDescription::defineFlag(const std::string& key, char short_key,
-                                              const std::string& description) -> ProgramDescription& {
+auto ProgramDescription::defineFlag(const std::string& key, char short_key,
+                                    const std::string& description) -> ProgramDescription& {
   checkOptionAlreadyExists(key, short_key);
 
   options_.emplace_back(key, short_key, description, utils::getTypeName<bool>(), "false", false, false);
   return *this;
 }
 
-constexpr auto ProgramDescription::defineFlag(const std::string& key,
-                                              const std::string& description) -> ProgramDescription& {
+auto ProgramDescription::defineFlag(const std::string& key,
+                                    const std::string& description) -> ProgramDescription& {
   return defineFlag(key, '\0', description);
 }
 

--- a/modules/ipc/include/hephaestus/ipc/common.h
+++ b/modules/ipc/include/hephaestus/ipc/common.h
@@ -41,7 +41,7 @@ struct MessageMetadata {
   std::size_t sequence_id{};
 };
 
-[[nodiscard]] constexpr auto getTypeInfoServiceTopic(const std::string& topic) -> std::string {
+[[nodiscard]] static inline auto getTypeInfoServiceTopic(const std::string& topic) -> std::string {
   return fmt::format("type_info/{}", topic);
 }
 

--- a/modules/ipc/include/hephaestus/ipc/zenoh/utils.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/utils.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <chrono>
-#include <expected>
 #include <numeric>
 #include <span>
 
@@ -49,6 +48,8 @@ constexpr auto toString(const Mode& mode) -> std::string_view {
     case Mode::CLIENT:
       return "Client";
   }
+
+  __builtin_unreachable();  // TODO(C++23): replace with std::unreachable.
 }
 
 constexpr auto toMode(const zenohc::WhatAmI& me) -> Mode {
@@ -60,6 +61,8 @@ constexpr auto toMode(const zenohc::WhatAmI& me) -> Mode {
     case zenohc::WhatAmI::Z_WHATAMI_CLIENT:
       return Mode::CLIENT;
   }
+
+  __builtin_unreachable();  // TODO(C++23): replace with std::unreachable.
 }
 
 inline auto toStringVector(const zenohc::StrArrayView& arr) -> std::vector<std::string> {

--- a/modules/ipc/src/zenoh/liveliness.cpp
+++ b/modules/ipc/src/zenoh/liveliness.cpp
@@ -20,6 +20,8 @@ namespace {
     case Z_SAMPLE_KIND_DELETE:
       return PublisherStatus::DROPPED;
   }
+
+  __builtin_unreachable();  // TODO(C++23): replace with std::unreachable() in C++23
 }
 }  // namespace
 

--- a/modules/ipc/src/zenoh/query.cpp
+++ b/modules/ipc/src/zenoh/query.cpp
@@ -23,11 +23,11 @@ auto query(zenohc::Session& session, const std::string& topic,
     }
 
     const auto sample = std::get<zenohc::Sample>(r);
-    auto topic = std::string{ sample.get_keyexpr().as_string_view() };
+    auto reply_topic = std::string{ sample.get_keyexpr().as_string_view() };
     auto result = std::string{ sample.get_payload().as_string_view() };
 
     std::unique_lock<std::mutex> lock(mutex);
-    results.emplace_back(std::move(topic), std::move(result));
+    results.emplace_back(std::move(reply_topic), std::move(result));
   };
 
   auto on_done = [&sync_point] { sync_point.arrive_and_drop(); };

--- a/modules/ipc/src/zenoh/service.cpp
+++ b/modules/ipc/src/zenoh/service.cpp
@@ -8,7 +8,7 @@ namespace heph::ipc::zenoh {
 
 Service::Service(SessionPtr session, std::string topic, Callback&& callback)
   : session_(std::move(session)), topic_(std::move(topic)), callback_(std::move(callback)) {
-  auto query = [this](const zenohc::Query& query) mutable {
+  auto query_cb = [this](const zenohc::Query& query) mutable {
     QueryRequest request{ .topic = std::string{ query.get_keyexpr().as_string_view() },
                           .parameters = std::string{ query.get_parameters().as_string_view() },
                           .value = std::string{ query.get_value().as_string_view() } };
@@ -20,6 +20,6 @@ Service::Service(SessionPtr session, std::string topic, Callback&& callback)
   };
 
   queryable_ =
-      expectAsUniquePtr(session_->zenoh_session.declare_queryable(topic_, { std::move(query), []() {} }));
+      expectAsUniquePtr(session_->zenoh_session.declare_queryable(topic_, { std::move(query_cb), []() {} }));
 }
 }  // namespace heph::ipc::zenoh

--- a/modules/serdes/include/hephaestus/serdes/serdes.h
+++ b/modules/serdes/include/hephaestus/serdes/serdes.h
@@ -24,7 +24,7 @@ auto serialize(const T& data) -> std::vector<std::byte> {
   if constexpr (ProtobufSerializable<T>) {
     return protobuf::serialize(data);
   } else {
-    static_assert(false, "no serialization supported");
+    static_assert(ProtobufSerializable<T>, "no serialization supported");
   }
 }
 
@@ -40,7 +40,7 @@ auto getSerializedTypeInfo() -> TypeInfo {
   if constexpr (ProtobufSerializable<T>) {
     return protobuf::getTypeInfo<T>();
   } else {
-    static_assert(false, "no serialization supported");
+    static_assert(ProtobufSerializable<T>, "no serialization supported");
   }
 }
 

--- a/modules/serdes/src/dynamic_deserializer.cpp
+++ b/modules/serdes/src/dynamic_deserializer.cpp
@@ -1,3 +1,4 @@
+
 //=================================================================================================
 // Copyright (C) 2023-2024 HEPHAESTUS Contributors
 //=================================================================================================
@@ -30,5 +31,7 @@ auto DynamicDeserializer::toJson(const std::string& type, std::span<const std::b
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
       return std::string{ reinterpret_cast<const char*>(data.data()), data.size() };
   }
+
+  __builtin_unreachable();  // TODO(C++23): replace with std::unreachable() in C++23
 }
 }  // namespace heph::serdes

--- a/modules/utils/src/version_impl.h
+++ b/modules/utils/src/version_impl.h
@@ -17,8 +17,8 @@ static constexpr std::uint8_t VERSION_MAJOR = 0;
 static constexpr std::uint8_t VERSION_MINOR = 0;
 static constexpr std::uint16_t VERSION_PATCH = 1;
 
-static constexpr std::string_view REPO_BRANCH = "fix/proto_concept";
-static constexpr std::string_view BUILD_PROFILE = "Release";
-static constexpr std::string_view REPO_HASH = "900c283";
+static constexpr std::string_view REPO_BRANCH = "gcc_fix";
+static constexpr std::string_view BUILD_PROFILE = "RelWithDebInfo";
+static constexpr std::string_view REPO_HASH = "77f82e1";
 
 } // namespace heph::utils


### PR DESCRIPTION
# Description
Some fixes to make hephaestus compile with GCC

* GCC doesn't support `constexpr` strings
* GCC doesn't care if we cover all switch cases for an enum
* GCC think some variable are shadowed

## Type of change
- Bug fix (non-breaking change which fixes an issue)

