### PR TITLE
Fix: Service make it work with GCC

### DIFF
--- a/modules/ipc/include/hephaestus/ipc/zenoh/service.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/service.h
@@ -48,7 +48,7 @@ auto callService(Session& session, const TopicConfig& topic_config, const Reques
 
 namespace internal {
 // TODO: Remove these functions once zenoh resolves the issue of changing buffers based on encoding.
-auto addChangingBytes(std::vector<std::byte>& buffer);
+void addChangingBytes(std::vector<std::byte>& buffer);
 auto removeChangingBytes(std::span<const std::byte> buffer) -> std::span<const std::byte>;
 
 template <typename RequestT, typename ReplyT>

--- a/modules/ipc/include/hephaestus/ipc/zenoh/service.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/service.h
@@ -48,7 +48,7 @@ auto callService(Session& session, const TopicConfig& topic_config, const Reques
 
 namespace internal {
 // TODO: Remove these functions once zenoh resolves the issue of changing buffers based on encoding.
-auto addChangingBytes(std::vector<std::byte> buffer) -> std::vector<std::byte>;
+auto addChangingBytes(std::vector<std::byte>& buffer);
 auto removeChangingBytes(std::span<const std::byte> buffer) -> std::span<const std::byte>;
 
 template <typename RequestT, typename ReplyT>
@@ -176,7 +176,7 @@ auto callService(Session& session, const TopicConfig& topic_config, const Reques
 
     DLOG(INFO) << fmt::format("Request: payload size: {}, content: {}", buffer.size(),
                               fmt::join(buffer, ","));
-    buffer = internal::addChangingBytes(buffer);
+    internal::addChangingBytes(buffer);
     auto value = zenohc::Value(std::move(buffer), Z_ENCODING_PREFIX_EMPTY);
     options.set_value(value);
   }

--- a/modules/ipc/src/zenoh/service.cpp
+++ b/modules/ipc/src/zenoh/service.cpp
@@ -11,10 +11,11 @@ namespace heph::ipc::zenoh::internal {
 // TODO: Remove these functions once zenoh resolves the issue of changing buffers based on encoding.
 static constexpr int CHANGING_BYTES = 19;
 
-auto addChangingBytes(std::vector<std::byte> buffer) -> std::vector<std::byte> {
+auto addChangingBytes(std::vector<std::byte>& buffer) {
   auto send_buffer = std::vector<std::byte>(internal::CHANGING_BYTES, std::byte{});
-  send_buffer.insert(send_buffer.end(), buffer.begin(), buffer.end());
-  return send_buffer;
+  // send_buffer.insert(send_buffer.end(), buffer.begin(), buffer.end());
+  buffer.insert(buffer.begin(), internal::CHANGING_BYTES, std::byte{});
+  // return send_buffer;
 }
 
 auto removeChangingBytes(std::span<const std::byte> buffer) -> std::span<const std::byte> {

--- a/modules/ipc/src/zenoh/service.cpp
+++ b/modules/ipc/src/zenoh/service.cpp
@@ -11,7 +11,7 @@ namespace heph::ipc::zenoh::internal {
 // TODO: Remove these functions once zenoh resolves the issue of changing buffers based on encoding.
 static constexpr int CHANGING_BYTES = 19;
 
-auto addChangingBytes(std::vector<std::byte>& buffer) {
+void addChangingBytes(std::vector<std::byte>& buffer) {
   auto send_buffer = std::vector<std::byte>(internal::CHANGING_BYTES, std::byte{});
   // send_buffer.insert(send_buffer.end(), buffer.begin(), buffer.end());
   buffer.insert(buffer.begin(), internal::CHANGING_BYTES, std::byte{});

--- a/modules/ipc/src/zenoh/service.cpp
+++ b/modules/ipc/src/zenoh/service.cpp
@@ -13,9 +13,7 @@ static constexpr int CHANGING_BYTES = 19;
 
 void addChangingBytes(std::vector<std::byte>& buffer) {
   auto send_buffer = std::vector<std::byte>(internal::CHANGING_BYTES, std::byte{});
-  // send_buffer.insert(send_buffer.end(), buffer.begin(), buffer.end());
   buffer.insert(buffer.begin(), internal::CHANGING_BYTES, std::byte{});
-  // return send_buffer;
 }
 
 auto removeChangingBytes(std::span<const std::byte> buffer) -> std::span<const std::byte> {


### PR DESCRIPTION
# Description
GCC was complaining with error:
```
error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ reading 1 or more bytes from a region of size 0 [-Werror=stringop-overread] 431 | __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
```

also this solution I think is cleaner.

## Type of change
- Bug fix (non-breaking change which fixes an issue)
