### PR TITLE
Reduce code redundancy through additional template in blocking_queue

### DIFF
--- a/modules/containers/examples/blocking_queue_example.cpp
+++ b/modules/containers/examples/blocking_queue_example.cpp
@@ -57,8 +57,9 @@ void pushVsEmplace() {
   // push methods require extra moving (or copying if move semantics is not supported).
   {
     fmt::print("=== Use push to add new element into the queue\n");
-    heph::containers::BlockingQueue<std::pair<String, String>> queue{ {} };
-    if (!queue.tryPush({ String{ "1" }, String{ "2" } })) {
+    using StringPair = std::pair<String, String>;
+    heph::containers::BlockingQueue<StringPair> queue{ {} };
+    if (!queue.tryPush(StringPair{ String{ "1" }, String{ "2" } })) {
       return;
     }
   }

--- a/modules/containers/include/hephaestus/containers/blocking_queue.h
+++ b/modules/containers/include/hephaestus/containers/blocking_queue.h
@@ -30,28 +30,16 @@ public:
   /// Attempt to enqueue the data if there is space in the queue.
   /// \note This is safe to call from multiple threads.
   /// \return true if the new data is added to the queue, false otherwise.
-  [[nodiscard]] auto tryPush(const T& obj) -> bool {
+  template <typename U>
+  [[nodiscard]] auto tryPush(U&& obj) -> bool {
+    static_assert(std::is_same<typename std::decay_t<U>, T>::value,
+                  "Type used for tryPush must be T but is for Queue<T>");
     {
       std::unique_lock<std::mutex> lock(mutex_);
       if (max_size_.has_value() && queue_.size() == *max_size_) {
         return false;
       }
-      queue_.push_back(obj);
-    }
-    reader_signal_.notify_one();
-    return true;
-  }
-
-  /// Attempt to enqueue the data if there is space in the queue.
-  /// \note This is safe to call from multiple threads.
-  /// \return true if the new data is added to the queue, false otherwise.
-  [[nodiscard]] auto tryPush(T&& obj) -> bool {
-    {
-      std::unique_lock<std::mutex> lock(mutex_);
-      if (max_size_.has_value() && queue_.size() == *max_size_) {
-        return false;
-      }
-      queue_.emplace_back(std::move(obj));
+      queue_.emplace_back(std::forward<U>(obj));
     }
     reader_signal_.notify_one();
     return true;
@@ -61,25 +49,11 @@ public:
   /// \note This is safe to call from multiple threads.
   /// \param obj The value to push into the queue.
   /// \return If the queue was full, the element dropped to make space for the new one.
-  auto forcePush(const T& obj) -> std::optional<T> {
-    std::optional<T> element_dropped;
-    {
-      std::unique_lock<std::mutex> lock(mutex_);
-      if (max_size_.has_value() && queue_.size() == *max_size_) {
-        element_dropped.emplace(std::move(queue_.front()));
-        queue_.pop_front();
-      }
-      queue_.push_back(obj);
-    }
-    reader_signal_.notify_one();
-    return element_dropped;
-  }
+  template <typename U>
+  auto forcePush(U&& obj) -> std::optional<T> {
+    static_assert(std::is_same<typename std::decay_t<U>, T>::value,
+                  "Type used for forcePush must be T but is for Queue<T>");
 
-  /// Write the data to the queue. If no space is left in the queue, the oldest element is dropped.
-  /// \note This is safe to call from multiple threads.
-  /// \param obj The value to push into the queue.
-  /// \return If the queue was full, the element dropped to make space for the new one.
-  auto forcePush(T&& obj) -> std::optional<T> {
     std::optional<T> element_dropped;
     {
       std::unique_lock<std::mutex> lock(mutex_);
@@ -87,7 +61,7 @@ public:
         element_dropped.emplace(std::move(queue_.front()));
         queue_.pop_front();
       }
-      queue_.push_back(std::move(obj));
+      queue_.emplace_back(std::forward(obj));
     }
     reader_signal_.notify_one();
     return element_dropped;
@@ -96,7 +70,10 @@ public:
   /// Write the data to the queue. If no space is left in the queue,
   /// the function blocks until either space is freed or stop is called.
   /// \note This is safe to call from multiple threads.
-  void waitAndPush(const T& obj) {
+  template <typename U>
+  void waitAndPush(U&& obj) {
+    static_assert(std::is_same<typename std::decay_t<U>, T>::value,
+                  "Type used for waitAndPush must be T but is for Queue<T>");
     {
       std::unique_lock<std::mutex> lock(mutex_);
       writer_signal_.wait(lock,
@@ -104,23 +81,7 @@ public:
       if (stop_) {
         return;
       }
-      queue_.push_back(obj);
-    }
-    reader_signal_.notify_one();
-  }
-
-  /// Write the data to the queue. If no space is left in the queue,
-  /// the function blocks until either space is freed or stop is called.
-  /// \note This is safe to call from multiple threads.
-  void waitAndPush(T&& obj) {
-    {
-      std::unique_lock<std::mutex> lock(mutex_);
-      writer_signal_.wait(lock,
-                          [this]() { return !max_size_.has_value() || queue_.size() < *max_size_ || stop_; });
-      if (stop_) {
-        return;
-      }
-      queue_.push_back(std::move(obj));
+      queue_.emplace_back(std::forward(obj));
     }
     reader_signal_.notify_one();
   }

--- a/modules/containers/include/hephaestus/containers/blocking_queue.h
+++ b/modules/containers/include/hephaestus/containers/blocking_queue.h
@@ -60,7 +60,7 @@ public:
         element_dropped.emplace(std::move(queue_.front()));
         queue_.pop_front();
       }
-      queue_.emplace_back(std::forward<U>(obj));
+      queue_.push_back(std::forward<U>(obj));
     }
     reader_signal_.notify_one();
     return element_dropped;

--- a/modules/containers/include/hephaestus/containers/blocking_queue.h
+++ b/modules/containers/include/hephaestus/containers/blocking_queue.h
@@ -41,7 +41,7 @@ public:
       if (max_size_.has_value() && queue_.size() == *max_size_) {
         return false;
       }
-      queue_.emplace_back(std::forward<U>(obj));
+      queue_.push_back(std::forward<U>(obj));
     }
     reader_signal_.notify_one();
     return true;

--- a/modules/containers/include/hephaestus/containers/blocking_queue.h
+++ b/modules/containers/include/hephaestus/containers/blocking_queue.h
@@ -61,7 +61,7 @@ public:
         element_dropped.emplace(std::move(queue_.front()));
         queue_.pop_front();
       }
-      queue_.emplace_back(std::forward(obj));
+      queue_.emplace_back(std::forward<U>(obj));
     }
     reader_signal_.notify_one();
     return element_dropped;
@@ -81,7 +81,7 @@ public:
       if (stop_) {
         return;
       }
-      queue_.emplace_back(std::forward(obj));
+      queue_.emplace_back(std::forward<U>(obj));
     }
     reader_signal_.notify_one();
   }

--- a/modules/containers/include/hephaestus/containers/blocking_queue.h
+++ b/modules/containers/include/hephaestus/containers/blocking_queue.h
@@ -78,7 +78,7 @@ public:
       if (stop_) {
         return;
       }
-      queue_.emplace_back(std::forward<U>(obj));
+      queue_.push_back(std::forward<U>(obj));
     }
     reader_signal_.notify_one();
   }


### PR DESCRIPTION
# Description
Thanks for your great work on this project,  solving one of the main painpoints for most robotics applications today with modern c++!
By skimming through it, I noticed that some code redundancy could be removed. However this comes at the cost of having to write the type of constructed object for the functions explicitly, as can be seen in the examples.
What do you think?

I am not sure how to mark this PR, since [Feat] is not really applicable in my opinion. Do you have conventions for refactorings?

## Type of change
- New feature (non-breaking change which adds functionality). Actually its a proposal for reducing redundancy, but this was the best fit of the options...

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests. -> tested it with the examples and tests supplied
- [ ] If this is a new component I have added examples. -> not applicable
- [ ] I updated the README and related documentation. -> not needed since functionality is the same
