### PR TITLE
fix all versions and update to 0.11.0-rc3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,8 +35,10 @@ RUN  update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$CLANG_VE
 
 RUN ln -s /usr/bin/clangd-${CLANG_VERSION} /usr/bin/clangd
 
-RUN echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | tee -a /etc/apt/sources.list.d/zenoh.list > /dev/null && \
-    apt-get update && apt-get install -y systemctl zenoh && \
+RUN export ZENOH_VERSION="0.11.0-rc.3" && \
+    echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | tee /etc/apt/sources.list.d/zenoh.list >/dev/null && \
+    (apt-get update && apt-get install --no-install-recommends -y --allow-downgrades zenohd=${ZENOH_VERSION} zenoh-plugin-rest=${ZENOH_VERSION} || true) && \
+    sed -i 's/systemctl /# remove if fixed by zenoh: systemctl /' /var/lib/dpkg/info/zenohd.postinst && \
     rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION=1.76.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN export ZENOH_VERSION="0.11.0-rc.3" && \
     sed -i 's/systemctl /# remove if fixed by zenoh: systemctl /' /var/lib/dpkg/info/zenohd.postinst && \
     rm -rf /var/lib/apt/lists/*
 
-ENV RUST_VERSION=1.76.0
+RUN wget -q -O rust_installer.sh https://sh.rustup.rs && chmod +x rust_installer.sh && ./rust_installer.sh -y
 RUN wget -q -O rust_installer.sh https://sh.rustup.rs && chmod +x rust_installer.sh && ./rust_installer.sh -y && \
     . "$HOME/.cargo/env" && rustup install "$RUST_VERSION" && rustup default "$RUST_VERSION"
 RUN . "$HOME/.cargo/env" && cargo install sccache --locked

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,8 +42,6 @@ RUN export ZENOH_VERSION="0.11.0-rc.3" && \
     rm -rf /var/lib/apt/lists/*
 
 RUN wget -q -O rust_installer.sh https://sh.rustup.rs && chmod +x rust_installer.sh && ./rust_installer.sh -y
-RUN wget -q -O rust_installer.sh https://sh.rustup.rs && chmod +x rust_installer.sh && ./rust_installer.sh -y && \
-    . "$HOME/.cargo/env" && rustup install "$RUST_VERSION" && rustup default "$RUST_VERSION"
 RUN . "$HOME/.cargo/env" && cargo install sccache --locked
 RUN echo "export RUSTC_WRAPPER=sccache" >> $HOME/.bashrc
 

--- a/docker/version.sh
+++ b/docker/version.sh
@@ -3,4 +3,4 @@ VERSION=1.0.7
 IMAGE=hephaestus-dev
 
 # This is the version of the dep image. Increase this number everytime you change `external/CMakeLists.txt`
-DEPS_VERSION=1.0.10
+DEPS_VERSION=1.0.11

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -31,16 +31,16 @@ endif()
 
 set(ZENOH_VERSION "0.11.0.3")
 add_cmake_dependency(
-  NAME zenohc 
-  GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-c"  
-  GIT_TAG ${ZENOH_VERSION}  
+  NAME zenohc
+  GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-c"
+  GIT_TAG ${ZENOH_VERSION}
   CMAKE_ARGS -DZENOHC_CARGO_CHANNEL=+stable
 )
 
 add_cmake_dependency(
   NAME zenohcxx
-  GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-cpp"  
-  GIT_TAG ${ZENOH_VERSION}  
+  GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-cpp"
+  GIT_TAG ${ZENOH_VERSION}
   SOURCE_SUBDIR install
 )
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -31,13 +31,16 @@ endif()
 
 set(ZENOH_VERSION "0.11.0.3")
 add_cmake_dependency(
-  NAME zenohc URL "https://github.com/eclipse-zenoh/zenoh-c/archive/refs/tags/${ZENOH_VERSION}.zip"
+  NAME zenohc 
+  GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-c"  
+  GIT_TAG ${ZENOH_VERSION}  
   CMAKE_ARGS -DZENOHC_CARGO_CHANNEL=+stable
 )
 
 add_cmake_dependency(
   NAME zenohcxx
-  DEPENDS zenohc URL "https://github.com/eclipse-zenoh/zenoh-cpp/archive/refs/tags/${ZENOH_VERSION}.zip"
+  GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-cpp"  
+  GIT_TAG ${ZENOH_VERSION}  
   SOURCE_SUBDIR install
 )
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -29,16 +29,15 @@ endif()
 # --------------------------------------------------------------------------------------------------
 # zenoh
 
-set(GIT_TAG "0d0a6d8d1488a71224c3bf6929714036945e7947")
+set(ZENOH_VERSION "0.11.0.3")
 add_cmake_dependency(
-  NAME zenohc URL "https://github.com/eclipse-zenoh/zenoh-c/archive/${GIT_TAG}.zip"
-  CMAKE_ARGS -DZENOHC_CARGO_CHANNEL=1.76.0
+  NAME zenohc URL "https://github.com/eclipse-zenoh/zenoh-c/archive/refs/tags/${ZENOH_VERSION}.zip"
+  CMAKE_ARGS -DZENOHC_CARGO_CHANNEL=+stable
 )
 
-set(GIT_TAG "2013df93ee771ed691e0bf85f55c61d9cb85119d")
 add_cmake_dependency(
   NAME zenohcxx
-  DEPENDS zenohc URL "https://github.com/eclipse-zenoh/zenoh-cpp/archive/${GIT_TAG}.zip"
+  DEPENDS zenohc URL "https://github.com/eclipse-zenoh/zenoh-cpp/archive/refs/tags/${ZENOH_VERSION}.zip"
   SOURCE_SUBDIR install
 )
 


### PR DESCRIPTION
# Description
Fixing the zenoh version in the docker install and updating all zenoh dependencies to 0.11.0-rc3. Seems to work fine so far :-)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
