### PR TITLE
clang-tidy: warning as error

### DIFF
--- a/cmake/03_compiler_config.cmake
+++ b/cmake/03_compiler_config.cmake
@@ -149,14 +149,13 @@ if(ENABLE_LINTER)
   find_program(LINTER_BIN NAMES clang-tidy QUIET)
   if(LINTER_BIN)
     option(ENABLE_LINTER_CACHE "Enable static analysis cache" ON)
+    set(LINTER_ARGS -warnings-as-errors=* -extra-arg=-Wno-ignored-optimization-argument -extra-arg=-Wno-unknown-warning-option)
     if(ENABLE_LINTER_CACHE)
       # NOTE: To speed up linting, clang-tidy is invoked via clang-tidy-cache.
       # (https://github.com/matus-chochlik/ctcache) Cache location is set by environment variable CTCACHE_DIR
-      set(LINTER_INVOKE_COMMAND ${CMAKE_TEMPLATES_DIR}/clang-tidy-cache.py ${LINTER_BIN} -p ${CMAKE_BINARY_DIR}
-                                -extra-arg=-Wno-ignored-optimization-argument -extra-arg=-Wno-unknown-warning-option
-      )
+      set(LINTER_INVOKE_COMMAND ${CMAKE_TEMPLATES_DIR}/clang-tidy-cache.py ${LINTER_BIN} -p ${CMAKE_BINARY_DIR} ${LINTER_ARGS})
     else()
-      set(LINTER_INVOKE_COMMAND ${LINTER_BIN})
+      set(LINTER_INVOKE_COMMAND ${LINTER_BIN} ${LINTER_ARGS})
     endif()
     set(CMAKE_C_CLANG_TIDY ${LINTER_INVOKE_COMMAND})
     set(CMAKE_CXX_CLANG_TIDY ${LINTER_INVOKE_COMMAND})

--- a/cmake/03_compiler_config.cmake
+++ b/cmake/03_compiler_config.cmake
@@ -149,11 +149,15 @@ if(ENABLE_LINTER)
   find_program(LINTER_BIN NAMES clang-tidy QUIET)
   if(LINTER_BIN)
     option(ENABLE_LINTER_CACHE "Enable static analysis cache" ON)
-    set(LINTER_ARGS -warnings-as-errors=* -extra-arg=-Wno-ignored-optimization-argument -extra-arg=-Wno-unknown-warning-option)
+    set(LINTER_ARGS -warnings-as-errors=* -extra-arg=-Wno-ignored-optimization-argument
+                    -extra-arg=-Wno-unknown-warning-option
+    )
     if(ENABLE_LINTER_CACHE)
       # NOTE: To speed up linting, clang-tidy is invoked via clang-tidy-cache.
       # (https://github.com/matus-chochlik/ctcache) Cache location is set by environment variable CTCACHE_DIR
-      set(LINTER_INVOKE_COMMAND ${CMAKE_TEMPLATES_DIR}/clang-tidy-cache.py ${LINTER_BIN} -p ${CMAKE_BINARY_DIR} ${LINTER_ARGS})
+      set(LINTER_INVOKE_COMMAND ${CMAKE_TEMPLATES_DIR}/clang-tidy-cache.py ${LINTER_BIN} -p ${CMAKE_BINARY_DIR}
+                                ${LINTER_ARGS}
+      )
     else()
       set(LINTER_INVOKE_COMMAND ${LINTER_BIN} ${LINTER_ARGS})
     endif()

--- a/modules/containers/tests/blocking_queue_tests.cpp
+++ b/modules/containers/tests/blocking_queue_tests.cpp
@@ -122,7 +122,7 @@ TEST(BlockingQueue, WaitEmplace) {
   BlockingQueue<std::tuple<int, std::string, double>> block_queue(QUEUE_SIZE);
 
   block_queue.waitAndEmplace(1, "hello", 1.0);
-  auto future = std::async([&block_queue]() { return block_queue.waitAndEmplace(2, "hello", 1.0); });
+  auto future = std::async([&block_queue]() { block_queue.waitAndEmplace(2, "hello", 1.0); });
   auto data = block_queue.tryPop();
   EXPECT_TRUE(data);
   if (data.has_value()) {

--- a/modules/examples/examples/mcap_reader.cpp
+++ b/modules/examples/examples/mcap_reader.cpp
@@ -13,17 +13,22 @@
 #include <mcap/reader.hpp>
 
 auto main(int argc, const char* argv[]) -> int {
-  if (argc != 2) {
-    fmt::println(stderr, "Usage: {} <input.mcap>",
-                 argv[0]);  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    std::exit(1);
-  }
-  std::filesystem::path input{ argv[1] };  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  try {
+    if (argc != 2) {
+      fmt::println(stderr, "Usage: {} <input.mcap>",
+                   argv[0]);  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      std::exit(1);
+    }
+    std::filesystem::path input{ argv[1] };  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 
-  mcap::McapReader reader;
-  const auto res = reader.open(input.string());
-  if (!res.ok()) {
-    fmt::println(stderr, "Failed to open: {} for writing", input.c_str());
-    std::exit(1);
+    mcap::McapReader reader;
+    const auto res = reader.open(input.string());
+    if (!res.ok()) {
+      fmt::println(stderr, "Failed to open: {} for writing", input.c_str());
+      std::exit(1);
+    }
+  } catch (const std::exception& e) {
+    fmt::print("Error: {}\n", e.what());
+    return 1;
   }
 }

--- a/modules/examples/examples/serdes_examples.cpp
+++ b/modules/examples/examples/serdes_examples.cpp
@@ -10,15 +10,19 @@
 auto main(int argc, const char* argv[]) -> int {
   (void)argc;
   (void)argv;
+  try {
+    heph::examples::types::Pose pose;
+    pose.position = Eigen::Vector3d{ 1, 2, 3 };
+    pose.orientation =
+        Eigen::Quaterniond{ 1., 0.1, 0.2, 0.3 };  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
 
-  heph::examples::types::Pose pose;
-  pose.position = Eigen::Vector3d{ 1, 2, 3 };
-  pose.orientation =
-      Eigen::Quaterniond{ 1., 0.1, 0.2, 0.3 };  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+    const auto json_string = heph::serdes::serializeToJSON(pose);
+    fmt::print("Pose serialized to JSON:\n{}\n", json_string);
 
-  const auto json_string = heph::serdes::serializeToJSON(pose);
-  fmt::print("Pose serialized to JSON:\n{}\n", json_string);
-
-  const auto txt_string = heph::serdes::serializeToText(pose);
-  fmt::print("Pose serialized to text:\n{}\n", txt_string);
+    const auto txt_string = heph::serdes::serializeToText(pose);
+    fmt::print("Pose serialized to text:\n{}\n", txt_string);
+  } catch (const std::exception& e) {
+    fmt::print("Error: {}\n", e.what());
+    return 1;
+  }
 }

--- a/modules/ipc/apps/zenoh_topic_echo.cpp
+++ b/modules/ipc/apps/zenoh_topic_echo.cpp
@@ -79,7 +79,8 @@ private:
   void subscribeCallback(const MessageMetadata& metadata, std::span<const std::byte> data,
                          const std::optional<serdes::TypeInfo>& type_info) {
     throwExceptionIf<InvalidParameterException>(!type_info, "Topic echo requires the type info to run");
-    auto msg_json = dynamic_deserializer_.toJson(type_info->name, data);
+    auto msg_json =
+        dynamic_deserializer_.toJson(type_info->name, data);  // NOLINT(bugprone-unchecked-optional-access)
     truncateLongItems(msg_json, noarr_, max_array_length_);
     fmt::println("From: {}. Topic: {} - {}", metadata.sender_id, metadata.topic, msg_json);
   }

--- a/modules/ipc/src/zenoh/dynamic_subscriber.cpp
+++ b/modules/ipc/src/zenoh/dynamic_subscriber.cpp
@@ -7,6 +7,7 @@
 #include <absl/log/log.h>
 
 namespace heph::ipc::zenoh {
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved,-warnings-as-errors)
 DynamicSubscriber::DynamicSubscriber(DynamicSubscriberParams&& params)
   : session_(std::move(params.session))
   , topic_filter_(ipc::TopicFilter::create(params.topics_filter_params))

--- a/modules/utils/include/hephaestus/utils/string/string_literal.h
+++ b/modules/utils/include/hephaestus/utils/string/string_literal.h
@@ -32,7 +32,7 @@ struct StringLiteral {
 template <size_t Size>
 constexpr StringLiteral<Size>::StringLiteral(
     const char (&str)[Size]) {  // NOLINT(cppcoreguidelines-avoid-c-arrays)
-  std::copy_n(str, Size, value.begin());
+  std::copy_n(static_cast<const char*>(str), Size, value.begin());
 }
 
 template <size_t Size>


### PR DESCRIPTION
# Description
We were not running clang-tidy with warning as error, changing this, and fixing the warning