### PR TITLE
mcap: use url to download dependency

### DIFF
--- a/docker/version.sh
+++ b/docker/version.sh
@@ -3,4 +3,4 @@ VERSION=1.0.7
 IMAGE=hephaestus-dev
 
 # This is the version of the dep image. Increase this number everytime you change `external/CMakeLists.txt`
-DEPS_VERSION=1.0.12
+DEPS_VERSION=1.0.13

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -146,8 +146,7 @@ set(MCAP_VERSION 1.4.0)
 set(MCAP_TAG be4188d7f77838372ec609a733c65dc6b167f517)
 add_cmake_dependency(
   NAME mcap
-  VERSION ${MCAP_VERSION}
-  URL https://github.com/filippobrizzi/mcap/archive/${MCAP_TAG}.zip
+  VERSION ${MCAP_VERSION} URL https://github.com/filippobrizzi/mcap/archive/${MCAP_TAG}.zip
   SOURCE_SUBDIR cpp
   CMAKE_ARGS -DBUILD_TESTING=OFF
 )

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -147,8 +147,7 @@ set(MCAP_TAG be4188d7f77838372ec609a733c65dc6b167f517)
 add_cmake_dependency(
   NAME mcap
   VERSION ${MCAP_VERSION}
-  GIT_REPOSITORY "https://github.com/filippobrizzi/mcap.git"
-  GIT_TAG ${MCAP_TAG}
+  URL https://github.com/filippobrizzi/mcap/archive/${MCAP_TAG}.zip
   SOURCE_SUBDIR cpp
   CMAKE_ARGS -DBUILD_TESTING=OFF
 )


### PR DESCRIPTION
# Description
mcap now uses git lfs, so to speed up download and make sure that we do not miss the commit by accidentally squashing we use the URL directly

