### PR TITLE
Zenoh bag player

### DIFF
--- a/docker/version.sh
+++ b/docker/version.sh
@@ -3,4 +3,4 @@ VERSION=1.0.7
 IMAGE=hephaestus-dev
 
 # This is the version of the dep image. Increase this number everytime you change `external/CMakeLists.txt`
-DEPS_VERSION=1.0.13
+DEPS_VERSION=1.0.14

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -143,7 +143,7 @@ add_cmake_dependency(
 # --------------------------------------------------------------------------------------------------
 # mcap
 set(MCAP_VERSION 1.4.0)
-set(MCAP_TAG be4188d7f77838372ec609a733c65dc6b167f517)
+set(MCAP_TAG cfd117ea989e7e6c415ef2a485b751775c70c5a7)
 add_cmake_dependency(
   NAME mcap
   VERSION ${MCAP_VERSION} URL https://github.com/filippobrizzi/mcap/archive/${MCAP_TAG}.zip

--- a/modules/bag/CMakeLists.txt
+++ b/modules/bag/CMakeLists.txt
@@ -14,10 +14,10 @@ find_package(mcap REQUIRED)
 # library sources
 set(SOURCES
     src/zenoh_player.cpp
-    include/hephaestus/bag/zenoh_player.h
     src/zenoh_recorder.cpp
     src/writer.cpp
     README.md
+    include/hephaestus/bag/zenoh_player.h
     include/hephaestus/bag/zenoh_recorder.h
     include/hephaestus/bag/writer.h
 )

--- a/modules/bag/CMakeLists.txt
+++ b/modules/bag/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 declare_module(
   NAME bag
-  DEPENDS_ON_MODULES containers ipc
+  DEPENDS_ON_MODULES containers ipc random
   DEPENDS_ON_EXTERNAL_PROJECTS absl mcap
 )
 
@@ -12,8 +12,14 @@ find_package(absl REQUIRED)
 find_package(mcap REQUIRED)
 
 # library sources
-set(SOURCES src/zenoh_recorder.cpp src/writer.cpp README.md include/hephaestus/bag/zenoh_recorder.h
-            include/hephaestus/bag/writer.h
+set(SOURCES
+    src/zenoh_player.cpp
+    include/hephaestus/bag/zenoh_player.h
+    src/zenoh_recorder.cpp
+    src/writer.cpp
+    README.md
+    include/hephaestus/bag/zenoh_recorder.h
+    include/hephaestus/bag/writer.h
 )
 
 # library target

--- a/modules/bag/apps/CMakeLists.txt
+++ b/modules/bag/apps/CMakeLists.txt
@@ -8,3 +8,10 @@ define_module_executable(
         PUBLIC_INCLUDE_PATHS
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
         PUBLIC_LINK_LIBS "")
+
+define_module_executable(
+          NAME bag_player
+          SOURCES bag_player.cpp
+          PUBLIC_INCLUDE_PATHS
+          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+          PUBLIC_LINK_LIBS "")

--- a/modules/bag/apps/bag_player.cpp
+++ b/modules/bag/apps/bag_player.cpp
@@ -1,0 +1,59 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#include <csignal>
+#include <exception>
+#include <filesystem>
+#include <future>
+
+#include <absl/log/log.h>
+#include <fmt/core.h>
+#include <mcap/reader.hpp>
+
+#include "hephaestus/bag/zenoh_player.h"
+#include "hephaestus/cli/program_options.h"
+#include "hephaestus/ipc/program_options.h"
+#include "hephaestus/utils/exception.h"
+#include "hephaestus/utils/signal_handler.h"
+#include "hephaestus/utils/stack_trace.h"
+
+auto main(int argc, const char* argv[]) -> int {
+  heph::utils::StackTrace stack_trace;
+
+  try {
+    auto desc = heph::cli::ProgramDescription("Playback a bag to zenoh topics");
+    heph::ipc::appendIPCProgramOption(desc);
+    desc.defineOption<std::filesystem::path>("input_bag", 'i', "output file where to write the bag")
+        .defineFlag("wait_for_readers_to_connect", 'w',
+                    "Wait for readers to connect before starting playback");
+    const auto args = std::move(desc).parse(argc, argv);
+    auto input_file = args.getOption<std::filesystem::path>("input_bag");
+    auto wait_for_readers_to_connect = args.getOption<bool>("wait_for_readers_to_connect");
+    auto [config, _] = heph::ipc::parseIPCProgramOptions(args);
+
+    LOG(INFO) << fmt::format("Reading bag file: {}", input_file.string());
+
+    heph::throwExceptionIf<heph::InvalidDataException>(
+        !std::filesystem::exists(input_file),
+        fmt::format("input bag file {} doesn't exist", input_file.string()));
+    auto bag_reader = std::make_unique<mcap::McapReader>();
+    const auto status = bag_reader->open(input_file.string());
+    if (status.code != mcap::StatusCode::Success) {
+      fmt::print(stderr, "Failed to open bag file: {}", status.message);
+      std::exit(1);
+    }
+
+    heph::bag::ZenohPlayerParams params{ .session = heph::ipc::zenoh::createSession(std::move(config)),
+                                         .bag_reader = std::move(bag_reader),
+                                         .wait_for_readers_to_connect = wait_for_readers_to_connect };
+    auto zenoh_player = heph::bag::ZenohPlayer::create(std::move(params));
+    zenoh_player.start().get();
+
+    heph::utils::SignalHandlerStopOrAppComplete::wait(zenoh_player);
+
+  } catch (std::exception& e) {
+    fmt::println("Failed with exception: {}", e.what());
+    std::exit(1);
+  }
+}

--- a/modules/bag/apps/bag_player.cpp
+++ b/modules/bag/apps/bag_player.cpp
@@ -50,7 +50,7 @@ auto main(int argc, const char* argv[]) -> int {
     auto zenoh_player = heph::bag::ZenohPlayer::create(std::move(params));
     zenoh_player.start().get();
 
-    heph::utils::SignalHandlerStopOrAppComplete::wait(zenoh_player);
+    heph::utils::InterruptHandlerOrAppComplete::wait(zenoh_player);
 
   } catch (std::exception& e) {
     fmt::println("Failed with exception: {}", e.what());

--- a/modules/bag/apps/bag_player.cpp
+++ b/modules/bag/apps/bag_player.cpp
@@ -50,7 +50,7 @@ auto main(int argc, const char* argv[]) -> int {
     auto zenoh_player = heph::bag::ZenohPlayer::create(std::move(params));
     zenoh_player.start().get();
 
-    heph::utils::InterruptHandlerOrAppComplete::wait(zenoh_player);
+    heph::utils::TerminationBlocker::waitForInterruptOrAppCompletion(zenoh_player);
 
   } catch (std::exception& e) {
     fmt::println("Failed with exception: {}", e.what());

--- a/modules/bag/apps/bag_recorder.cpp
+++ b/modules/bag/apps/bag_recorder.cpp
@@ -33,7 +33,7 @@ auto main(int argc, const char* argv[]) -> int {
     auto zeno_recorder = heph::bag::ZenohRecorder::create(std::move(params));
     zeno_recorder.start().wait();
 
-    heph::utils::InterruptHandler::wait();
+    heph::utils::TerminationBlocker::waitForInterrupt();
 
     zeno_recorder.stop().get();
 

--- a/modules/bag/include/hephaestus/bag/zenoh_player.h
+++ b/modules/bag/include/hephaestus/bag/zenoh_player.h
@@ -1,0 +1,44 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#pragma once
+
+#include <future>
+
+#include "hephaestus/ipc/zenoh/session.h"
+
+#define MCAP_IMPLEMENTATION
+#define MCAP_COMPRESSION_NO_ZSTD
+#define MCAP_COMPRESSION_NO_LZ4
+#include <mcap/reader.hpp>
+
+namespace heph::bag {
+
+struct ZenohPlayerParams {
+  ipc::zenoh::SessionPtr session;
+  std::unique_ptr<mcap::McapReader> bag_reader;
+  bool wait_for_readers_to_connect{ false };
+};
+
+class ZenohPlayer {
+public:
+  ~ZenohPlayer();
+
+  [[nodiscard]] static auto create(ZenohPlayerParams params) -> ZenohPlayer;
+
+  [[nodiscard]] auto start() -> std::future<void>;
+
+  [[nodiscard]] auto stop() -> std::future<void>;
+
+  void wait() const;
+
+private:
+  explicit ZenohPlayer(ZenohPlayerParams params);
+
+private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace heph::bag

--- a/modules/bag/src/zenoh_player.cpp
+++ b/modules/bag/src/zenoh_player.cpp
@@ -1,0 +1,192 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#include "hephaestus/bag/zenoh_player.h"
+
+#include <chrono>
+
+#include <fmt/chrono.h>
+
+#include "hephaestus/ipc/zenoh/publisher.h"
+#include "hephaestus/utils/exception.h"
+
+namespace heph::bag {
+
+class ZenohPlayer::Impl {
+public:
+  explicit Impl(ZenohPlayerParams params);
+
+  [[nodiscard]] auto start() -> std::future<void>;
+
+  [[nodiscard]] auto stop() -> std::future<void>;
+
+  void wait() const;
+
+private:
+  void createPublisher(const mcap::Channel& channel);
+
+  void run();
+
+private:
+  ipc::zenoh::SessionPtr session_;
+  std::unique_ptr<mcap::McapReader> bag_reader_;
+
+  bool wait_for_readers_to_connect_;
+
+  std::size_t channel_count_{};
+  std::unordered_map<std::string, std::unique_ptr<ipc::zenoh::Publisher>> publishers_;
+  std::unordered_set<std::string> publishers_with_subscriber_;
+  std::atomic_flag all_publisher_connected_ = ATOMIC_FLAG_INIT;
+
+  std::future<void> run_job_;
+
+  std::atomic_bool terminate_ = false;
+  std::condition_variable play_cv_;
+  std::mutex play_mutex_;
+};
+
+ZenohPlayer::Impl::Impl(ZenohPlayerParams params)
+  : session_(std::move(params.session))
+  , bag_reader_(std::move(params.bag_reader))
+  , wait_for_readers_to_connect_(params.wait_for_readers_to_connect) {
+}
+
+auto ZenohPlayer::Impl::start() -> std::future<void> {
+  const auto status = bag_reader_->readSummary(mcap::ReadSummaryMethod::AllowFallbackScan);
+  throwExceptionIf<InvalidDataException>(!status.ok(),
+                                         fmt::format("Failed to read bag summary: {}", status.message));
+
+  const auto channels = bag_reader_->channels();
+  channel_count_ = channels.size();
+  LOG(INFO) << fmt::format("found {} channels in the bag", channels.size());
+  for (const auto& [id, channel] : channels) {
+    createPublisher(*channel);
+  }
+
+  run_job_ = std::async(std::launch::async, [this]() { run(); });
+
+  std::promise<void> promise;
+  promise.set_value();
+  return promise.get_future();
+}
+
+auto ZenohPlayer::Impl::stop() -> std::future<void> {
+  throwExceptionIf<InvalidOperationException>(terminate_, "player is already stopped, cannot stop again");
+  terminate_ = true;
+  play_cv_.notify_all();
+
+  return std::async(std::launch::async, [this]() { run_job_.get(); });
+}
+
+void ZenohPlayer::Impl::wait() const {
+  run_job_.wait();
+}
+
+void ZenohPlayer::Impl::createPublisher(const mcap::Channel& channel) {
+  throwExceptionIf<InvalidDataException>(
+      publishers_.contains(channel.topic),
+      fmt::format("failed to create publisher for topic: {}; topic already exist", channel.topic));
+
+  const auto& schema = bag_reader_->schema(channel.schemaId);
+  auto type_info = serdes::TypeInfo{
+    .name = schema->name,
+    .schema = schema->data,
+    .serialization = serdes::TypeInfo::Serialization::PROTOBUF,  // TODO: get this from schema
+    .original_type =
+        "",  // TODO: figure out if there is a way to get this. We can use the channel metadata!!!
+  };
+
+  publishers_[channel.topic] = std::make_unique<ipc::zenoh::Publisher>(
+      session_, ipc::TopicConfig{ .name = channel.topic }, std::move(type_info),
+      [this, &channel](ipc::zenoh::MatchingStatus status) {
+        if (!status.matching) {
+          return;
+        }
+
+        publishers_with_subscriber_.insert(channel.topic);
+        if (publishers_with_subscriber_.size() == channel_count_) {
+          all_publisher_connected_.test_and_set();
+          all_publisher_connected_.notify_all();
+        }
+      });
+
+  LOG(INFO) << fmt::format("Created publisher for topic: {}", channel.topic);
+}
+
+void ZenohPlayer::Impl::run() {
+  auto read_options = mcap::ReadMessageOptions{};
+  read_options.readOrder = mcap::ReadMessageOptions::ReadOrder::LogTimeOrder;
+  auto messages = bag_reader_->readMessages([](const auto&) {}, read_options);
+
+  auto first_msg_timestamp = std::chrono::steady_clock::time_point{ std::chrono::nanoseconds{
+      messages.begin()->message.publishTime } };
+
+  std::size_t msgs_played_count = 0;
+  std::size_t deadline_missed_count = 0;
+
+  // TODO: wait for all subscriber to be available before publishing
+  LOG_IF(WARNING, wait_for_readers_to_connect_) << "Waiting for subscribers to connect is NOT supported yet!";
+  if (wait_for_readers_to_connect_) {
+    all_publisher_connected_.wait(false);
+  }
+
+  const auto first_playback_timestamp = std::chrono::steady_clock::now();
+  for (const auto& message : messages) {
+    if (terminate_) {
+      break;
+    }
+
+    const auto& topic = message.channel->topic;
+    const auto& publisher = publishers_[topic];
+
+    const auto current_msg_timestamp =
+        std::chrono::steady_clock::time_point{ std::chrono::nanoseconds{ message.message.publishTime } };
+
+    const auto write_timestamp = current_msg_timestamp - first_msg_timestamp + first_playback_timestamp;
+
+    if (auto now = std::chrono::steady_clock::now(); now > write_timestamp && msgs_played_count > 0) {
+      ++deadline_missed_count;
+      LOG(WARNING) << fmt::format("failed to publish message {} in time for topic {}, delay {}",
+                                  message.message.sequence, topic, now - write_timestamp);
+    } else {
+      std::unique_lock<std::mutex> guard(play_mutex_);
+      if (play_cv_.wait_until(guard, write_timestamp, [this] { return terminate_.load(); })) {
+        break;
+      }
+    }
+
+    auto success = publisher->publish({ message.message.data, message.message.dataSize });
+    LOG_IF(WARNING, !success) << fmt::format("Failed to publish message {} for topic {}",
+                                             message.message.sequence, topic);
+
+    ++msgs_played_count;
+  }
+
+  LOG(INFO) << fmt::format("Played {} messages, missed {} deadlines", msgs_played_count,
+                           deadline_missed_count);
+}
+
+// ----------------------------------------------------------------------------------------------------------
+
+ZenohPlayer::ZenohPlayer(ZenohPlayerParams params) : impl_(std::make_unique<Impl>(std::move(params))) {
+}
+
+ZenohPlayer::~ZenohPlayer() = default;
+
+auto ZenohPlayer::start() -> std::future<void> {
+  return impl_->start();
+}
+
+auto ZenohPlayer::stop() -> std::future<void> {
+  return impl_->stop();
+}
+
+void ZenohPlayer::wait() const {
+  impl_->wait();
+}
+
+auto ZenohPlayer::create(ZenohPlayerParams params) -> ZenohPlayer {
+  return ZenohPlayer{ std::move(params) };
+}
+}  // namespace heph::bag

--- a/modules/bag/src/zenoh_player.cpp
+++ b/modules/bag/src/zenoh_player.cpp
@@ -125,7 +125,6 @@ void ZenohPlayer::Impl::run() {
   std::size_t msgs_played_count = 0;
   std::size_t deadline_missed_count = 0;
 
-  // TODO: wait for all subscriber to be available before publishing
   LOG_IF(WARNING, wait_for_readers_to_connect_) << "Waiting for subscribers to connect is NOT supported yet!";
   if (wait_for_readers_to_connect_) {
     all_publisher_connected_.wait(false);

--- a/modules/bag/src/zenoh_player.cpp
+++ b/modules/bag/src/zenoh_player.cpp
@@ -130,7 +130,7 @@ void ZenohPlayer::Impl::run() {
     all_publisher_connected_.wait(false);
   }
 
-  const auto first_playback_timestamp = std::chrono::steady_clock::now();
+  const auto first_playback_timestamp = std::chrono::system_clock::now();
   for (const auto& message : messages) {
     if (terminate_) {
       break;
@@ -144,9 +144,9 @@ void ZenohPlayer::Impl::run() {
 
     const auto write_timestamp = current_msg_timestamp - first_msg_timestamp + first_playback_timestamp;
 
-    if (auto now = std::chrono::steady_clock::now(); now > write_timestamp && msgs_played_count > 0) {
+    if (const auto now = std::chrono::system_clock::now(); now > write_timestamp && msgs_played_count > 0) {
       ++deadline_missed_count;
-      LOG(WARNING) << fmt::format("failed to publish message {} in time for topic {}, delay {}",
+      LOG(WARNING) << fmt::format("deadline misseed on message {} for topic {}, delay {}",
                                   message.message.sequence, topic, now - write_timestamp);
     } else {
       std::unique_lock<std::mutex> guard(play_mutex_);

--- a/modules/bag/tests/CMakeLists.txt
+++ b/modules/bag/tests/CMakeLists.txt
@@ -1,3 +1,12 @@
 #=================================================================================================
 # Copyright (C) 2023-2024 HEPHAESTUS Contributors
 #=================================================================================================
+
+define_module_proto_library(NAME bag_tests_proto SOURCES test.proto)
+
+define_module_test(
+        NAME tests
+        SOURCES tests.cpp test_proto_conversion.h
+        PUBLIC_INCLUDE_PATHS
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+        PUBLIC_LINK_LIBS hephaestus::bag_tests_proto hephaestus::random)

--- a/modules/bag/tests/buf.yaml
+++ b/modules/bag/tests/buf.yaml
@@ -1,0 +1,13 @@
+version: v1
+breaking:
+  use:
+    - FILE
+  except:
+    # https://docs.buf.build/breaking/rules#file_no_delete
+    # hephaestus is monorepo, build system will fail the build if this file is used.
+    - FILE_NO_DELETE
+lint:
+  use:
+    - DEFAULT
+  except:
+    - PACKAGE_VERSION_SUFFIX

--- a/modules/bag/tests/test.proto
+++ b/modules/bag/tests/test.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package heph.bag.tests.proto;
+
+message User {
+    string name = 1;
+    int32 age = 2;
+    repeated float scores = 3;
+}
+
+message Company {
+  string name = 1;
+  int32 employer_count = 2;
+}

--- a/modules/bag/tests/test.proto
+++ b/modules/bag/tests/test.proto
@@ -2,13 +2,13 @@ syntax = "proto3";
 
 package heph.bag.tests.proto;
 
-message User {
+message Robot {
     string name = 1;
-    int32 age = 2;
+    int32 version = 2;
     repeated float scores = 3;
 }
 
-message Company {
+message Fleet {
   string name = 1;
-  int32 employer_count = 2;
+  int32 robot_count = 2;
 }

--- a/modules/bag/tests/test_proto_conversion.h
+++ b/modules/bag/tests/test_proto_conversion.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <random>
+
+#include "hephaestus/random/random_container.h"
+#include "hephaestus/serdes/protobuf/concepts.h"
+#include "test.pb.h"
+
+namespace heph::bag::tests {
+struct User {
+  auto operator==(const User& other) const -> bool = default;
+  [[nodiscard]] static auto random(std::mt19937_64& mt) -> User;
+
+  std::string name;
+  int age{};
+  std::vector<float> scores;
+};
+
+auto User::random(std::mt19937_64& mt) -> User {
+  return { .name = random::randomT<std::string>(mt),
+           .age = random::randomT<int>(mt),
+           .scores = random::randomT<std::vector<float>>(mt) };
+}
+
+struct Company {
+  auto operator==(const Company& other) const -> bool = default;
+  [[nodiscard]] static auto random(std::mt19937_64& mt) -> Company;
+
+  std::string name;
+  int employer_count{};
+};
+
+auto Company::random(std::mt19937_64& mt) -> Company {
+  return { .name = random::randomT<std::string>(mt), .employer_count = random::randomT<int>(mt) };
+}
+}  // namespace heph::bag::tests
+
+namespace heph::serdes::protobuf {
+template <>
+struct ProtoAssociation<heph::bag::tests::User> {
+  using Type = heph::bag::tests::proto::User;
+};
+
+template <>
+struct ProtoAssociation<heph::bag::tests::Company> {
+  using Type = heph::bag::tests::proto::Company;
+};
+}  // namespace heph::serdes::protobuf
+
+namespace heph::bag::tests {
+void toProto(proto::User& proto_user, const User& user) {
+  proto_user.set_name(user.name);
+  proto_user.set_age(user.age);
+  proto_user.mutable_scores()->Add(user.scores.begin(), user.scores.end());
+}
+
+void fromProto(const proto::User& proto_user, User& user) {
+  user.name = proto_user.name();
+  user.age = proto_user.age();
+  user.scores = { proto_user.scores().begin(), proto_user.scores().end() };
+}
+
+void toProto(proto::Company& proto_company, const Company& company) {
+  proto_company.set_name(company.name);
+  proto_company.set_employer_count(company.employer_count);
+}
+
+void fromProto(const proto::Company& proto_company, Company& company) {
+  company.name = proto_company.name();
+  company.employer_count = proto_company.employer_count();
+}
+
+}  // namespace heph::bag::tests

--- a/modules/bag/tests/test_proto_conversion.h
+++ b/modules/bag/tests/test_proto_conversion.h
@@ -7,67 +7,67 @@
 #include "test.pb.h"
 
 namespace heph::bag::tests {
-struct User {
-  auto operator==(const User& other) const -> bool = default;
-  [[nodiscard]] static auto random(std::mt19937_64& mt) -> User;
+struct Robot {
+  auto operator==(const Robot& other) const -> bool = default;
+  [[nodiscard]] static auto random(std::mt19937_64& mt) -> Robot;
 
   std::string name;
-  int age{};
+  int version{};
   std::vector<float> scores;
 };
 
-auto User::random(std::mt19937_64& mt) -> User {
+auto Robot::random(std::mt19937_64& mt) -> Robot {
   return { .name = random::randomT<std::string>(mt),
-           .age = random::randomT<int>(mt),
+           .version = random::randomT<int>(mt),
            .scores = random::randomT<std::vector<float>>(mt) };
 }
 
-struct Company {
-  auto operator==(const Company& other) const -> bool = default;
-  [[nodiscard]] static auto random(std::mt19937_64& mt) -> Company;
+struct Fleet {
+  auto operator==(const Fleet& other) const -> bool = default;
+  [[nodiscard]] static auto random(std::mt19937_64& mt) -> Fleet;
 
   std::string name;
-  int employer_count{};
+  int robot_count{};
 };
 
-auto Company::random(std::mt19937_64& mt) -> Company {
-  return { .name = random::randomT<std::string>(mt), .employer_count = random::randomT<int>(mt) };
+auto Fleet::random(std::mt19937_64& mt) -> Fleet {
+  return { .name = random::randomT<std::string>(mt), .robot_count = random::randomT<int>(mt) };
 }
 }  // namespace heph::bag::tests
 
 namespace heph::serdes::protobuf {
 template <>
-struct ProtoAssociation<heph::bag::tests::User> {
-  using Type = heph::bag::tests::proto::User;
+struct ProtoAssociation<heph::bag::tests::Robot> {
+  using Type = heph::bag::tests::proto::Robot;
 };
 
 template <>
-struct ProtoAssociation<heph::bag::tests::Company> {
-  using Type = heph::bag::tests::proto::Company;
+struct ProtoAssociation<heph::bag::tests::Fleet> {
+  using Type = heph::bag::tests::proto::Fleet;
 };
 }  // namespace heph::serdes::protobuf
 
 namespace heph::bag::tests {
-void toProto(proto::User& proto_user, const User& user) {
+void toProto(proto::Robot& proto_user, const Robot& user) {
   proto_user.set_name(user.name);
-  proto_user.set_age(user.age);
+  proto_user.set_version(user.version);
   proto_user.mutable_scores()->Add(user.scores.begin(), user.scores.end());
 }
 
-void fromProto(const proto::User& proto_user, User& user) {
+void fromProto(const proto::Robot& proto_user, Robot& user) {
   user.name = proto_user.name();
-  user.age = proto_user.age();
+  user.version = proto_user.version();
   user.scores = { proto_user.scores().begin(), proto_user.scores().end() };
 }
 
-void toProto(proto::Company& proto_company, const Company& company) {
+void toProto(proto::Fleet& proto_company, const Fleet& company) {
   proto_company.set_name(company.name);
-  proto_company.set_employer_count(company.employer_count);
+  proto_company.set_robot_count(company.robot_count);
 }
 
-void fromProto(const proto::Company& proto_company, Company& company) {
+void fromProto(const proto::Fleet& proto_company, Fleet& company) {
   company.name = proto_company.name();
-  company.employer_count = proto_company.employer_count();
+  company.robot_count = proto_company.robot_count();
 }
 
 }  // namespace heph::bag::tests

--- a/modules/bag/tests/tests.cpp
+++ b/modules/bag/tests/tests.cpp
@@ -1,0 +1,139 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "hephaestus/bag/writer.h"
+#include "hephaestus/bag/zenoh_player.h"
+#include "hephaestus/bag/zenoh_recorder.h"
+#include "hephaestus/random/random_generator.h"
+#include "hephaestus/serdes/serdes.h"
+#include "hephaestus/utils/filesystem/scoped_path.h"
+#include "test.pb.h"
+#include "test_proto_conversion.h"
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace ::testing;
+
+namespace heph::bag::tests {
+namespace {
+constexpr std::size_t USER_MSG_COUNT = 10;
+constexpr auto USER_MSG_PERIOD = std::chrono::milliseconds{ 1 };
+constexpr std::size_t COMPANY_MSG_COUNT = 5;
+constexpr auto COMPANY_MSG_PERIOD = std::chrono::milliseconds{ 2 };
+constexpr auto SENDER_ID = "bag_tester";
+constexpr auto USER_TOPIC = "user";
+constexpr auto COMPANY_TOPIC = "company";
+
+[[nodiscard]] auto
+createBag() -> std::tuple<utils::filesystem::ScopedPath, std::vector<User>, std::vector<Company>> {
+  auto scoped_path = utils::filesystem::ScopedPath::createFile();
+  auto mcap_writer = createMcapWriter({ scoped_path });
+
+  auto user_type_info = serdes::getSerializedTypeInfo<User>();
+  mcap_writer->registerSchema(user_type_info);
+  mcap_writer->registerChannel(USER_TOPIC, user_type_info);
+
+  auto company_type_info = serdes::getSerializedTypeInfo<Company>();
+  mcap_writer->registerSchema(company_type_info);
+  mcap_writer->registerChannel(COMPANY_TOPIC, company_type_info);
+
+  auto mt = random::createRNG();
+
+  const auto start_time = std::chrono::nanoseconds{ 0 };
+  std::vector<User> users(USER_MSG_COUNT);
+  for (std::size_t i = 0; i < USER_MSG_COUNT; ++i) {
+    users[i] = User::random(mt);
+    mcap_writer->writeRecord({ .sender_id = SENDER_ID,
+                               .topic = USER_TOPIC,
+                               .timestamp = start_time + i * USER_MSG_PERIOD,
+                               .sequence_id = i },
+                             serdes::serialize(users[i]));
+  }
+
+  std::vector<Company> company(COMPANY_MSG_COUNT);
+  for (std::size_t i = 0; i < COMPANY_MSG_COUNT; ++i) {
+    company[i] = Company::random(mt);
+    mcap_writer->writeRecord({ .sender_id = SENDER_ID,
+                               .topic = COMPANY_TOPIC,
+                               .timestamp = start_time + i * COMPANY_MSG_PERIOD,
+                               .sequence_id = i },
+                             serdes::serialize(company[i]));
+  }
+
+  return { std::move(scoped_path), std::move(users), std::move(company) };
+}
+
+TEST(Bag, PlayAndRecord) {
+  auto output_bag = utils::filesystem::ScopedPath::createFile();
+  auto [bag_path, users, companies] = createBag();
+  {
+    auto reader = std::make_unique<mcap::McapReader>();
+    const auto status = reader->open(bag_path);
+    EXPECT_TRUE(status.ok());
+
+    auto session = ipc::zenoh::createSession({});
+    auto player = ZenohPlayer::create(
+        { .session = session, .bag_reader = std::move(reader), .wait_for_readers_to_connect = true });
+
+    auto bag_writer = createMcapWriter({ output_bag });
+    auto recorder = ZenohRecorder::create(
+        { .session = session, .bag_writer = std::move(bag_writer), .topics_filter_params = {} });
+
+    recorder.start().get();
+    player.start().get();
+    player.wait();
+
+    player.stop().get();
+    recorder.stop().get();
+  }
+
+  auto reader = std::make_unique<mcap::McapReader>();
+  const auto status = reader->open(output_bag);
+  EXPECT_TRUE(status.ok());
+
+  const auto summary_status = reader->readSummary(mcap::ReadSummaryMethod::AllowFallbackScan);
+  EXPECT_TRUE(summary_status.ok());
+
+  auto statistics = reader->statistics();
+  ASSERT_TRUE(statistics.has_value());
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+  EXPECT_EQ(statistics->messageCount, USER_MSG_COUNT + COMPANY_MSG_COUNT);
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+  EXPECT_EQ(statistics->channelCount, 2);
+  const auto channels = reader->channels();
+  EXPECT_THAT(channels, SizeIs(2));
+  std::unordered_map<std::string, mcap::ChannelId> reverse_channels;
+  for (const auto& [id, channel] : channels) {
+    reverse_channels[channel->topic] = id;
+  }
+
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+  EXPECT_EQ(statistics->channelMessageCounts[reverse_channels[USER_TOPIC]], USER_MSG_COUNT);
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+  EXPECT_EQ(statistics->channelMessageCounts[reverse_channels[COMPANY_TOPIC]], COMPANY_MSG_COUNT);
+
+  auto read_options = mcap::ReadMessageOptions{};
+  read_options.readOrder = mcap::ReadMessageOptions::ReadOrder::LogTimeOrder;
+  auto messages = reader->readMessages([](const auto&) {}, read_options);
+
+  for (const auto& message : messages) {
+    if (message.channel->topic == USER_TOPIC) {
+      User user;
+      serdes::deserialize<User>({ message.message.data, message.message.dataSize }, user);
+      EXPECT_EQ(user, users[message.message.sequence]);
+    } else if (message.channel->topic == COMPANY_TOPIC) {
+      Company company;
+      serdes::deserialize<Company>({ message.message.data, message.message.dataSize }, company);
+      EXPECT_EQ(company, companies[message.message.sequence]);
+    } else {
+      FAIL() << "unexpected channel id: " << message.channel->topic;
+    }
+  }
+}
+
+}  // namespace
+
+}  // namespace heph::bag::tests

--- a/modules/concurrency/examples/spinner_example.cpp
+++ b/modules/concurrency/examples/spinner_example.cpp
@@ -28,7 +28,7 @@ auto main() -> int {
     spinner.start();
 
     // Wait until signal is set
-    heph::utils::InterruptHandler::wait();
+    heph::utils::TerminationBlocker::waitForInterrupt();
 
     spinner.stop().get();
 

--- a/modules/examples/examples/mcap_reader.cpp
+++ b/modules/examples/examples/mcap_reader.cpp
@@ -27,6 +27,9 @@ auto main(int argc, const char* argv[]) -> int {
       fmt::println(stderr, "Failed to open: {} for writing", input.c_str());
       std::exit(1);
     }
+
+    reader.readMessages();
+
   } catch (const std::exception& e) {
     fmt::print("Error: {}\n", e.what());
     return 1;

--- a/modules/examples/examples/zenoh_pub.cpp
+++ b/modules/examples/examples/zenoh_pub.cpp
@@ -44,7 +44,7 @@ auto main(int argc, const char* argv[]) -> int {
 
     static constexpr auto LOOP_WAIT = std::chrono::seconds(1);
     double count = 0;
-    while (!heph::utils::InterruptHandler::stopRequested()) {
+    while (!heph::utils::TerminationBlocker::stopRequested()) {
       heph::examples::types::Pose pose;
       pose.position = Eigen::Vector3d{ 1, 2, count++ };
       pose.orientation =

--- a/modules/examples/examples/zenoh_service_server.cpp
+++ b/modules/examples/examples/zenoh_service_server.cpp
@@ -42,7 +42,7 @@ auto main(int argc, const char* argv[]) -> int {
 
     LOG(INFO) << fmt::format("Server started. Wating for queries on '{}' topic", topic_config.name);
 
-    heph::utils::InterruptHandler::wait();
+    heph::utils::TerminationBlocker::waitForInterrupt();
 
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/modules/examples/examples/zenoh_string_service_server.cpp
+++ b/modules/examples/examples/zenoh_string_service_server.cpp
@@ -38,7 +38,7 @@ auto main(int argc, const char* argv[]) -> int {
 
     LOG(INFO) << fmt::format("String server started. Wating for queries on '{}' topic", topic_config.name);
 
-    heph::utils::InterruptHandler::wait();
+    heph::utils::TerminationBlocker::waitForInterrupt();
 
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/modules/examples/examples/zenoh_sub.cpp
+++ b/modules/examples/examples/zenoh_sub.cpp
@@ -48,7 +48,7 @@ auto main(int argc, const char* argv[]) -> int {
         session, std::move(topic_config), std::move(cb));
     (void)subscriber;
 
-    heph::utils::InterruptHandler::wait();
+    heph::utils::TerminationBlocker::waitForInterrupt();
 
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/modules/ipc/apps/zenoh_topic_echo.cpp
+++ b/modules/ipc/apps/zenoh_topic_echo.cpp
@@ -122,7 +122,7 @@ auto main(int argc, const char* argv[]) -> int {
     heph::ipc::apps::TopicEcho topic_echo{ std::move(session), topic_config, noarr, max_array_length };
     topic_echo.start().wait();
 
-    heph::utils::InterruptHandler::wait();
+    heph::utils::TerminationBlocker::waitForInterrupt();
 
     topic_echo.stop().wait();
 

--- a/modules/ipc/apps/zenoh_topic_list.cpp
+++ b/modules/ipc/apps/zenoh_topic_list.cpp
@@ -27,7 +27,7 @@ void getLiveListOfPublisher(heph::ipc::zenoh::SessionPtr session, heph::ipc::Top
   heph::ipc::zenoh::PublisherDiscovery discover{ std::move(session), std::move(topic_config),
                                                  std::move(callback) };
 
-  heph::utils::InterruptHandler::wait();
+  heph::utils::TerminationBlocker::waitForInterrupt();
 }
 
 auto main(int argc, const char* argv[]) -> int {

--- a/modules/ipc/src/zenoh/liveliness.cpp
+++ b/modules/ipc/src/zenoh/liveliness.cpp
@@ -82,6 +82,7 @@ PublisherDiscovery::PublisherDiscovery(SessionPtr session, TopicConfig topic_con
 
 PublisherDiscovery::~PublisherDiscovery() {
   z_undeclare_subscriber(&liveliness_subscriber_);
+  z_drop(z_move(liveliness_subscriber_));
 }
 
 void PublisherDiscovery::createLivelinessSubscriber() {

--- a/modules/utils/include/hephaestus/utils/concepts.h
+++ b/modules/utils/include/hephaestus/utils/concepts.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <future>
 #include <sstream>
 #include <type_traits>
 
@@ -17,6 +18,16 @@ template <typename T>
 concept StringStreamable = requires(std::string str, T value) {
   std::istringstream{ str } >> value;
   std::ostringstream{ str } << value;
+};
+
+template <typename T>
+concept Stoppable = requires(T value) {
+  { value.stop() } -> std::same_as<std::future<void>>;
+};
+
+template <typename T>
+concept Waitable = requires(T value) {
+  { value.wait() };
 };
 
 }  // namespace heph

--- a/modules/utils/include/hephaestus/utils/signal_handler.h
+++ b/modules/utils/include/hephaestus/utils/signal_handler.h
@@ -7,6 +7,8 @@
 #include <atomic>
 #include <csignal>
 
+#include "hephaestus/utils/concepts.h"
+
 namespace heph::utils {
 
 /// \brief Use this class to block until a signal is received.
@@ -38,5 +40,59 @@ private:
 private:
   std::atomic_flag stop_flag_ = ATOMIC_FLAG_INIT;
 };  // namespace heph::utils
+
+template <typename T>
+concept StoppableAndWaitable = requires { Stoppable<T>&& Waitable<T>; };
+
+/// \brief Use this class to block until a signal is received or the application completes.
+/// Usage:
+/// ```
+/// int main() {
+///   auto app = MyApp{};
+///   app.start().get();
+///   InterruptHandlerOrAppComplete::wait(app);
+/// }
+/// ```
+/// > NOTE: `MayApp` needs to satify the stoppable compoenent interface.
+class InterruptHandlerOrAppComplete {
+public:
+  template <StoppableAndWaitable T>
+  void wait(T& app);
+
+private:
+  InterruptHandlerOrAppComplete() = default;
+  [[nodiscard]] static auto instance() -> InterruptHandlerOrAppComplete&;
+
+  static auto signalHandler(int /*unused*/) -> void;
+
+private:
+  std::future<void> stop_future_;
+  std::function<std::future<void>()> app_stop_cb_;
+};
+
+template <StoppableAndWaitable T>
+void InterruptHandlerOrAppComplete::wait(T& app) {
+  instance().app_stop_cb_ = [&app]() { return app.stop(); };
+
+  (void)signal(SIGINT, InterruptHandlerOrAppComplete::signalHandler);
+  (void)signal(SIGTERM, InterruptHandlerOrAppComplete::signalHandler);
+
+  app.wait();
+
+  if (instance().stop_future_.valid()) {
+    instance().stop_future_.get();
+  } else {
+    app.stop().get();
+  }
+}
+
+auto InterruptHandlerOrAppComplete::instance() -> InterruptHandlerOrAppComplete& {
+  static InterruptHandlerOrAppComplete instance;
+  return instance;
+}
+
+auto InterruptHandlerOrAppComplete::signalHandler(int /*unused*/) -> void {
+  instance().stop_future_ = instance().app_stop_cb_();
+}
 
 }  // namespace heph::utils

--- a/modules/utils/include/hephaestus/utils/signal_handler.h
+++ b/modules/utils/include/hephaestus/utils/signal_handler.h
@@ -54,7 +54,7 @@ concept StoppableAndWaitable = requires { Stoppable<T>&& Waitable<T>; };
 ///   InterruptHandlerOrAppComplete::wait(app);
 /// }
 /// ```
-/// > NOTE: `MayApp` needs to satify the stoppable compoenent interface.
+/// > NOTE: `MyApp` needs to satify the stoppable compoenent interface.
 class InterruptHandlerOrAppComplete {
 public:
   /// Wait returns when a signal is received or the app completes.

--- a/modules/utils/include/hephaestus/utils/signal_handler.h
+++ b/modules/utils/include/hephaestus/utils/signal_handler.h
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <csignal>
+#include <future>
 
 #include "hephaestus/utils/concepts.h"
 

--- a/modules/utils/include/hephaestus/utils/signal_handler.h
+++ b/modules/utils/include/hephaestus/utils/signal_handler.h
@@ -12,72 +12,52 @@
 
 namespace heph::utils {
 
+template <typename T>
+concept StoppableAndWaitable = requires { Stoppable<T>&& Waitable<T>; };
+
 /// \brief Use this class to block until a signal is received.
 /// > NOTE: can be extended to call a generic callback when a signal is received.
 /// Usage:
 /// ```
 /// int main() {
 ///  // Do something
-///  InterruptHandler::wait();
+///  TerminationBlocker::waitForInterrupt();
 /// }
 /// // Or
-/// while (InterruptHandler::stopRequested()) {
+/// while (TerminationBlocker::stopRequested()) {
 /// // Do something
 /// }
 /// ```
-class InterruptHandler {
+class TerminationBlocker {
 public:
   /// Return false if a signal has been received, true otherwise.
   [[nodiscard]] static auto stopRequested() -> bool;
+
   /// Blocks until a signal has been received.
-  static void wait();
+  static void waitForInterrupt();
+
+  /// Wait returns when a signal is received or the app completes.
+  template <StoppableAndWaitable T>
+  static void waitForInterruptOrAppCompletion(T& app);
 
 private:
-  InterruptHandler() = default;
-  [[nodiscard]] static auto instance() -> InterruptHandler&;
+  TerminationBlocker() = default;
+  [[nodiscard]] static auto instance() -> TerminationBlocker&;
 
   static auto signalHandler(int /*unused*/) -> void;
 
 private:
   std::atomic_flag stop_flag_ = ATOMIC_FLAG_INIT;
+  std::future<void> stop_future_;
+  std::function<std::future<void>()> app_stop_callback_ = []() { return std::future<void>{}; };
 };  // namespace heph::utils
 
-template <typename T>
-concept StoppableAndWaitable = requires { Stoppable<T>&& Waitable<T>; };
-
-/// \brief Use this class to block until a signal is received or the application completes.
-/// Usage:
-/// ```
-/// int main() {
-///   auto app = MyApp{};
-///   app.start().get();
-///   InterruptHandlerOrAppComplete::wait(app);
-/// }
-/// ```
-/// > NOTE: `MyApp` needs to satify the stoppable compoenent interface.
-class InterruptHandlerOrAppComplete {
-public:
-  /// Wait returns when a signal is received or the app completes.
-  template <StoppableAndWaitable T>
-  static void wait(T& app);
-
-private:
-  InterruptHandlerOrAppComplete() = default;
-  [[nodiscard]] static auto instance() -> InterruptHandlerOrAppComplete&;
-
-  static auto signalHandler(int /*unused*/) -> void;
-
-private:
-  std::future<void> stop_future_;
-  std::function<std::future<void>()> app_stop_cb_;
-};
-
 template <StoppableAndWaitable T>
-void InterruptHandlerOrAppComplete::wait(T& app) {
-  instance().app_stop_cb_ = [&app]() { return app.stop(); };
+void TerminationBlocker::waitForInterruptOrAppCompletion(T& app) {
+  instance().app_stop_callback_ = [&app]() { return app.stop(); };
 
-  (void)signal(SIGINT, InterruptHandlerOrAppComplete::signalHandler);
-  (void)signal(SIGTERM, InterruptHandlerOrAppComplete::signalHandler);
+  (void)signal(SIGINT, TerminationBlocker::signalHandler);
+  (void)signal(SIGTERM, TerminationBlocker::signalHandler);
 
   app.wait();
 
@@ -86,15 +66,6 @@ void InterruptHandlerOrAppComplete::wait(T& app) {
   } else {
     app.stop().get();
   }
-}
-
-auto InterruptHandlerOrAppComplete::instance() -> InterruptHandlerOrAppComplete& {
-  static InterruptHandlerOrAppComplete instance;
-  return instance;
-}
-
-auto InterruptHandlerOrAppComplete::signalHandler(int /*unused*/) -> void {
-  instance().stop_future_ = instance().app_stop_cb_();
 }
 
 }  // namespace heph::utils

--- a/modules/utils/include/hephaestus/utils/signal_handler.h
+++ b/modules/utils/include/hephaestus/utils/signal_handler.h
@@ -57,8 +57,9 @@ concept StoppableAndWaitable = requires { Stoppable<T>&& Waitable<T>; };
 /// > NOTE: `MayApp` needs to satify the stoppable compoenent interface.
 class InterruptHandlerOrAppComplete {
 public:
+  /// Wait returns when a signal is received or the app completes.
   template <StoppableAndWaitable T>
-  void wait(T& app);
+  static void wait(T& app);
 
 private:
   InterruptHandlerOrAppComplete() = default;

--- a/modules/utils/src/signal_handler.cpp
+++ b/modules/utils/src/signal_handler.cpp
@@ -6,23 +6,25 @@
 
 namespace heph::utils {
 
-auto InterruptHandler::stopRequested() -> bool {
+auto TerminationBlocker::stopRequested() -> bool {
   return instance().stop_flag_.test();
 }
 
-void InterruptHandler::wait() {
-  (void)signal(SIGINT, InterruptHandler::signalHandler);
-  (void)signal(SIGTERM, InterruptHandler::signalHandler);
+void TerminationBlocker::waitForInterrupt() {
+  (void)signal(SIGINT, TerminationBlocker::signalHandler);
+  (void)signal(SIGTERM, TerminationBlocker::signalHandler);
 
   instance().stop_flag_.wait(false);
 }
 
-auto InterruptHandler::instance() -> InterruptHandler& {
-  static InterruptHandler instance;
+auto TerminationBlocker::instance() -> TerminationBlocker& {
+  static TerminationBlocker instance;
   return instance;
 }
 
-auto InterruptHandler::signalHandler(int /*unused*/) -> void {
+auto TerminationBlocker::signalHandler(int /*unused*/) -> void {
+  instance().stop_future_ = instance().app_stop_callback_();
+
   instance().stop_flag_.test_and_set();
   instance().stop_flag_.notify_all();
 }


### PR DESCRIPTION
# Description
Add bag player library and app:
*  Right now the bag player is basic and all topic share the same thread. This I already know is a problem but I wanted to have something running end-to-end
* Add test that: create an mcap bag -> play the bag -> record the bag -> check that the two bags are the same
  * To do this I create test protofile in the bag test folder. These are very similar to the one that already exists in the `serdes` module. I will unify them later as I need to find a satisfying way of doing it.
* Extendend signal handler utilis to support   the case of bag playback where we want to terminate either because the app complete or via signal, please provide better naming! 