### PR TITLE
IPC: zenoh config command line options & utils to register signal handler

### DIFF
--- a/modules/bag/apps/bag_recorder.cpp
+++ b/modules/bag/apps/bag_recorder.cpp
@@ -33,7 +33,7 @@ auto main(int argc, const char* argv[]) -> int {
     auto zeno_recorder = heph::bag::ZenohRecorder::create(std::move(params));
     zeno_recorder.start().wait();
 
-    heph::utils::SignalHandlerStop::wait();
+    heph::utils::InterruptHandler::wait();
 
     zeno_recorder.stop().get();
 

--- a/modules/bag/apps/bag_recorder.cpp
+++ b/modules/bag/apps/bag_recorder.cpp
@@ -7,40 +7,35 @@
 
 #include "hephaestus/bag/zenoh_recorder.h"
 #include "hephaestus/cli/program_options.h"
+#include "hephaestus/ipc/program_options.h"
+#include "hephaestus/utils/signal_handler.h"
 #include "hephaestus/utils/stack_trace.h"
 
-std::atomic_flag stop_flag = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-auto signalHandler(int /*unused*/) -> void {
-  stop_flag.test_and_set();
-  stop_flag.notify_all();
-}
-
 auto main(int argc, const char* argv[]) -> int {
-  (void)signal(SIGINT, signalHandler);
-  (void)signal(SIGTERM, signalHandler);
-
   heph::utils::StackTrace stack_trace;
 
   try {
     auto desc = heph::cli::ProgramDescription("Record a bag from zenoh topics");
-    desc.defineOption<std::string>("topic", 't', "Topics to record", "**")
-        .defineOption<std::string>("output_bag", 'o', "output file where to write the bag");
+    heph::ipc::appendIPCProgramOption(desc);
+    desc.defineOption<std::string>("output_bag", 'o', "output file where to write the bag");
     const auto args = std::move(desc).parse(argc, argv);
-    auto topic = args.getOption<std::string>("topic");
+    auto [config, topic] = heph::ipc::parseIPCProgramOptions(args);
     auto output_file = args.getOption<std::string>("output_bag");
 
     heph::bag::ZenohRecorderParams params{
-      .session = heph::ipc::zenoh::createSession({}),
+      .session = heph::ipc::zenoh::createSession(std::move(config)),
       .bag_writer = heph::bag::createMcapWriter({ .output_file = std::move(output_file) }),
-      .topics_filter_params =
-          heph::ipc::TopicFilterParams{ .include_topics_only = {}, .prefix = topic, .exclude_topics = {} }
+      .topics_filter_params = heph::ipc::TopicFilterParams{ .include_topics_only = {},
+                                                            .prefix = topic.name,
+                                                            .exclude_topics = {} }
     };
 
     auto zeno_recorder = heph::bag::ZenohRecorder::create(std::move(params));
     zeno_recorder.start().wait();
 
-    stop_flag.wait(false);
-    zeno_recorder.stop().wait();
+    heph::utils::SignalHandlerStop::wait();
+
+    zeno_recorder.stop().get();
 
   } catch (std::exception& e) {
     fmt::println("Failed with exception: {}", e.what());

--- a/modules/concurrency/examples/spinner_example.cpp
+++ b/modules/concurrency/examples/spinner_example.cpp
@@ -28,7 +28,7 @@ auto main() -> int {
     spinner.start();
 
     // Wait until signal is set
-    heph::utils::SignalHandlerStop::wait();
+    heph::utils::InterruptHandler::wait();
 
     spinner.stop().get();
 

--- a/modules/examples/examples/zenoh_pub.cpp
+++ b/modules/examples/examples/zenoh_pub.cpp
@@ -17,18 +17,11 @@
 #include "hephaestus/ipc/zenoh/session.h"
 #include "hephaestus/serdes/serdes.h"
 #include "hephaestus/utils/exception.h"
+#include "hephaestus/utils/signal_handler.h"
 #include "hephaestus/utils/stack_trace.h"
 #include "zenoh_program_options.h"
 
-std::atomic_flag stop_flag = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-auto signalHandler(int /*unused*/) -> void {
-  stop_flag.test_and_set();
-  stop_flag.notify_all();
-}
-
 auto main(int argc, const char* argv[]) -> int {
-  (void)signal(SIGINT, signalHandler);
-  (void)signal(SIGTERM, signalHandler);
   heph::utils::StackTrace stack_trace;
 
   try {
@@ -51,7 +44,7 @@ auto main(int argc, const char* argv[]) -> int {
 
     static constexpr auto LOOP_WAIT = std::chrono::seconds(1);
     double count = 0;
-    while (!stop_flag.test()) {
+    while (heph::utils::SignalHandlerStop::ok()) {
       heph::examples::types::Pose pose;
       pose.position = Eigen::Vector3d{ 1, 2, count++ };
       pose.orientation =
@@ -63,7 +56,9 @@ auto main(int argc, const char* argv[]) -> int {
 
       std::this_thread::sleep_for(LOOP_WAIT);
     }
+
     return EXIT_SUCCESS;
+
   } catch (const std::exception& ex) {
     std::ignore =
         std::fputs(fmt::format("main terminated with an exception: {}\n", ex.what()).c_str(), stderr);

--- a/modules/examples/examples/zenoh_pub.cpp
+++ b/modules/examples/examples/zenoh_pub.cpp
@@ -44,7 +44,7 @@ auto main(int argc, const char* argv[]) -> int {
 
     static constexpr auto LOOP_WAIT = std::chrono::seconds(1);
     double count = 0;
-    while (heph::utils::SignalHandlerStop::ok()) {
+    while (!heph::utils::InterruptHandler::stopRequested()) {
       heph::examples::types::Pose pose;
       pose.position = Eigen::Vector3d{ 1, 2, count++ };
       pose.orientation =

--- a/modules/examples/examples/zenoh_service_server.cpp
+++ b/modules/examples/examples/zenoh_service_server.cpp
@@ -42,7 +42,7 @@ auto main(int argc, const char* argv[]) -> int {
 
     LOG(INFO) << fmt::format("Server started. Wating for queries on '{}' topic", topic_config.name);
 
-    heph::utils::SignalHandlerStop::wait();
+    heph::utils::InterruptHandler::wait();
 
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/modules/examples/examples/zenoh_service_server.cpp
+++ b/modules/examples/examples/zenoh_service_server.cpp
@@ -4,7 +4,6 @@
 
 #include <csignal>
 #include <cstdlib>
-#include <thread>
 
 #include <fmt/chrono.h>
 #include <fmt/core.h>
@@ -15,19 +14,11 @@
 #include "hephaestus/examples/types_protobuf/pose.h"
 #include "hephaestus/ipc/zenoh/service.h"
 #include "hephaestus/ipc/zenoh/session.h"
+#include "hephaestus/utils/signal_handler.h"
 #include "hephaestus/utils/stack_trace.h"
 #include "zenoh_program_options.h"
 
-std::atomic_flag stop_flag = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-auto signalHandler(int /*unused*/) -> void {
-  stop_flag.test_and_set();
-  stop_flag.notify_all();
-}
-
 auto main(int argc, const char* argv[]) -> int {
-  (void)signal(SIGINT, signalHandler);
-  (void)signal(SIGTERM, signalHandler);
-
   heph::utils::StackTrace stack_trace;
 
   try {
@@ -51,7 +42,7 @@ auto main(int argc, const char* argv[]) -> int {
 
     LOG(INFO) << fmt::format("Server started. Wating for queries on '{}' topic", topic_config.name);
 
-    stop_flag.wait(false);
+    heph::utils::SignalHandlerStop::wait();
 
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/modules/examples/examples/zenoh_string_service_server.cpp
+++ b/modules/examples/examples/zenoh_string_service_server.cpp
@@ -38,7 +38,7 @@ auto main(int argc, const char* argv[]) -> int {
 
     LOG(INFO) << fmt::format("String server started. Wating for queries on '{}' topic", topic_config.name);
 
-    heph::utils::SignalHandlerStop::wait();
+    heph::utils::InterruptHandler::wait();
 
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/modules/examples/examples/zenoh_string_service_server.cpp
+++ b/modules/examples/examples/zenoh_string_service_server.cpp
@@ -4,7 +4,6 @@
 
 #include <csignal>
 #include <cstdlib>
-#include <thread>
 
 #include <fmt/chrono.h>
 #include <fmt/core.h>
@@ -15,19 +14,11 @@
 #include "hephaestus/examples/types_protobuf/pose.h"
 #include "hephaestus/ipc/zenoh/service.h"
 #include "hephaestus/ipc/zenoh/session.h"
+#include "hephaestus/utils/signal_handler.h"
 #include "hephaestus/utils/stack_trace.h"
 #include "zenoh_program_options.h"
 
-std::atomic_flag stop_flag = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-auto signalHandler(int /*unused*/) -> void {
-  stop_flag.test_and_set();
-  stop_flag.notify_all();
-}
-
 auto main(int argc, const char* argv[]) -> int {
-  (void)signal(SIGINT, signalHandler);
-  (void)signal(SIGTERM, signalHandler);
-
   heph::utils::StackTrace stack_trace;
 
   try {
@@ -47,7 +38,7 @@ auto main(int argc, const char* argv[]) -> int {
 
     LOG(INFO) << fmt::format("String server started. Wating for queries on '{}' topic", topic_config.name);
 
-    stop_flag.wait(false);
+    heph::utils::SignalHandlerStop::wait();
 
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/modules/examples/examples/zenoh_sub.cpp
+++ b/modules/examples/examples/zenoh_sub.cpp
@@ -19,19 +19,11 @@
 #include "hephaestus/ipc/subscriber.h"
 #include "hephaestus/ipc/zenoh/session.h"
 #include "hephaestus/ipc/zenoh/subscriber.h"
+#include "hephaestus/utils/signal_handler.h"
 #include "hephaestus/utils/stack_trace.h"
 #include "zenoh_program_options.h"
 
-std::atomic_flag stop_flag = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-auto signalHandler(int /*unused*/) -> void {
-  stop_flag.test_and_set();
-  stop_flag.notify_all();
-}
-
 auto main(int argc, const char* argv[]) -> int {
-  (void)signal(SIGINT, signalHandler);
-  (void)signal(SIGTERM, signalHandler);
-
   heph::utils::StackTrace stack_trace;
 
   try {
@@ -56,7 +48,7 @@ auto main(int argc, const char* argv[]) -> int {
         session, std::move(topic_config), std::move(cb));
     (void)subscriber;
 
-    stop_flag.wait(false);
+    heph::utils::SignalHandlerStop::wait();
 
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/modules/examples/examples/zenoh_sub.cpp
+++ b/modules/examples/examples/zenoh_sub.cpp
@@ -48,7 +48,7 @@ auto main(int argc, const char* argv[]) -> int {
         session, std::move(topic_config), std::move(cb));
     (void)subscriber;
 
-    heph::utils::SignalHandlerStop::wait();
+    heph::utils::InterruptHandler::wait();
 
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/modules/ipc/CMakeLists.txt
+++ b/modules/ipc/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(zenohcxx REQUIRED)
 # library sources
 set(SOURCES
     src/common.cpp
+    src/program_options.cpp
     src/topic_database.cpp
     src/topic_filter.cpp
     src/zenoh/dynamic_subscriber.cpp
@@ -29,6 +30,7 @@ set(SOURCES
     src/zenoh/utils.cpp
     README.md
     include/hephaestus/ipc/common.h
+    include/hephaestus/ipc/program_options.h
     include/hephaestus/ipc/topic_database.h
     include/hephaestus/ipc/topic_filter.h
     include/hephaestus/ipc/zenoh/dynamic_subscriber.h

--- a/modules/ipc/apps/CMakeLists.txt
+++ b/modules/ipc/apps/CMakeLists.txt
@@ -4,28 +4,28 @@
 
 define_module_executable(
         NAME zenoh_topic_list
-        SOURCES zenoh_topic_list.cpp zenoh_program_options.h
+        SOURCES zenoh_topic_list.cpp
         PUBLIC_INCLUDE_PATHS
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
         PUBLIC_LINK_LIBS "")
 
 define_module_executable(
         NAME zenoh_node_list
-        SOURCES zenoh_node_list.cpp zenoh_program_options.h
+        SOURCES zenoh_node_list.cpp
         PUBLIC_INCLUDE_PATHS
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
         PUBLIC_LINK_LIBS "")
 
 define_module_executable(
         NAME zenoh_string_service
-        SOURCES zenoh_string_service.cpp zenoh_program_options.h
+        SOURCES zenoh_string_service.cpp
         PUBLIC_INCLUDE_PATHS
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
         PUBLIC_LINK_LIBS "")
 
 define_module_executable(
         NAME zenoh_topic_echo
-        SOURCES zenoh_topic_echo.cpp zenoh_program_options.h
+        SOURCES zenoh_topic_echo.cpp
         PUBLIC_INCLUDE_PATHS
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
         PUBLIC_LINK_LIBS "")

--- a/modules/ipc/apps/zenoh_string_service.cpp
+++ b/modules/ipc/apps/zenoh_string_service.cpp
@@ -4,23 +4,25 @@
 
 #include <fmt/core.h>
 
+#include "hephaestus/ipc/program_options.h"
 #include "hephaestus/ipc/zenoh/service.h"
 #include "hephaestus/ipc/zenoh/session.h"
 #include "hephaestus/ipc/zenoh/utils.h"
 #include "hephaestus/utils/stack_trace.h"
-#include "zenoh_program_options.h"
 
 auto main(int argc, const char* argv[]) -> int {
   heph::utils::StackTrace stack_trace;
 
   try {
-    auto desc = getProgramDescription("Simple service for std::string types for both Request and Reply. "
+    auto desc =
+        heph::cli::ProgramDescription("Simple service for std::string types for both Request and Reply. "
                                       "Don't use for services with different types.");
+    heph::ipc::appendIPCProgramOption(desc);
     desc.defineOption<std::string>("value", 'v', "the value to pass the query", "");
     const auto args = std::move(desc).parse(argc, argv);
     const auto value = args.getOption<std::string>("value");
 
-    auto [config, topic_config] = parseArgs(args);
+    auto [config, topic_config] = heph::ipc::parseIPCProgramOptions(args);
     auto session = heph::ipc::zenoh::createSession(std::move(config));
     LOG(INFO) << fmt::format("Opening session: {}",
                              heph::ipc::zenoh::toString(session->zenoh_session.info_zid()));

--- a/modules/ipc/apps/zenoh_topic_echo.cpp
+++ b/modules/ipc/apps/zenoh_topic_echo.cpp
@@ -122,7 +122,7 @@ auto main(int argc, const char* argv[]) -> int {
     heph::ipc::apps::TopicEcho topic_echo{ std::move(session), topic_config, noarr, max_array_length };
     topic_echo.start().wait();
 
-    heph::utils::SignalHandlerStop::wait();
+    heph::utils::InterruptHandler::wait();
 
     topic_echo.stop().wait();
 

--- a/modules/ipc/apps/zenoh_topic_list.cpp
+++ b/modules/ipc/apps/zenoh_topic_list.cpp
@@ -27,7 +27,7 @@ void getLiveListOfPublisher(heph::ipc::zenoh::SessionPtr session, heph::ipc::Top
   heph::ipc::zenoh::PublisherDiscovery discover{ std::move(session), std::move(topic_config),
                                                  std::move(callback) };
 
-  heph::utils::SignalHandlerStop::wait();
+  heph::utils::InterruptHandler::wait();
 }
 
 auto main(int argc, const char* argv[]) -> int {

--- a/modules/ipc/apps/zenoh_topic_list.cpp
+++ b/modules/ipc/apps/zenoh_topic_list.cpp
@@ -9,16 +9,11 @@
 #include <zenoh.h>
 #include <zenohc.hxx>
 
+#include "hephaestus/ipc/program_options.h"
 #include "hephaestus/ipc/zenoh/liveliness.h"
 #include "hephaestus/ipc/zenoh/session.h"
+#include "hephaestus/utils/signal_handler.h"
 #include "hephaestus/utils/stack_trace.h"
-#include "zenoh_program_options.h"
-
-std::atomic_flag stop_flag = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-auto signalHandler(int /*unused*/) -> void {
-  stop_flag.test_and_set();
-  stop_flag.notify_all();
-}
 
 void getListOfPublisher(const heph::ipc::zenoh::Session& session, std::string_view topic) {
   const auto publishers_info = heph::ipc::zenoh::getListOfPublishers(session, topic);
@@ -32,21 +27,19 @@ void getLiveListOfPublisher(heph::ipc::zenoh::SessionPtr session, heph::ipc::Top
   heph::ipc::zenoh::PublisherDiscovery discover{ std::move(session), std::move(topic_config),
                                                  std::move(callback) };
 
-  stop_flag.wait(false);
+  heph::utils::SignalHandlerStop::wait();
 }
 
 auto main(int argc, const char* argv[]) -> int {
-  (void)signal(SIGINT, signalHandler);
-  (void)signal(SIGTERM, signalHandler);
-
   heph::utils::StackTrace stack_trace;
 
   try {
-    auto desc = getProgramDescription("Periodic publisher example");
+    auto desc = heph::cli::ProgramDescription("List all the publishers of a topic.");
+    heph::ipc::appendIPCProgramOption(desc);
     desc.defineFlag("live", 'l', "if set the app will keep running waiting for new publisher to advertise");
     const auto args = std::move(desc).parse(argc, argv);
 
-    auto [session_config, topic_config] = parseArgs(args);
+    auto [session_config, topic_config] = heph::ipc::parseIPCProgramOptions(args);
 
     fmt::println("Opening session...");
     auto session = heph::ipc::zenoh::createSession(std::move(session_config));

--- a/modules/ipc/include/hephaestus/ipc/program_options.h
+++ b/modules/ipc/include/hephaestus/ipc/program_options.h
@@ -1,0 +1,16 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+#pragma once
+
+#include "hephaestus/cli/program_options.h"
+#include "hephaestus/ipc/common.h"
+
+namespace heph::ipc {
+
+void appendIPCProgramOption(cli::ProgramDescription& program_description);
+
+[[nodiscard]] auto
+parseIPCProgramOptions(const heph::cli::ProgramOptions& args) -> std::pair<Config, TopicConfig>;
+
+}  // namespace heph::ipc

--- a/modules/ipc/src/zenoh/utils.cpp
+++ b/modules/ipc/src/zenoh/utils.cpp
@@ -47,12 +47,10 @@ auto createZenohConfig(const Config& config) -> zenohc::Config {
     auto res = zconfig.insert_json(Z_CONFIG_CONNECT_KEY, router_endpoint.c_str());
     throwExceptionIf<FailedZenohOperation>(!res, "failed to add router endpoint");
   }
-
-  if (config.qos) {
-    auto res = zconfig.insert_json("transport/unicast/qos/enabled", "true");
+  {
+    auto res = zconfig.insert_json("transport/unicast/qos/enabled", config.qos ? "true" : "false");
     throwExceptionIf<FailedZenohOperation>(!res, "failed to set QoS");
   }
-
   if (config.real_time) {
     auto res = zconfig.insert_json("transport/unicast/qos/enabled", "false");
     throwExceptionIf<FailedZenohOperation>(!res, "failed to set QoS");

--- a/modules/utils/CMakeLists.txt
+++ b/modules/utils/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SOURCES
     src/concepts.cpp
     src/exception.cpp
     src/utils.cpp
+    src/signal_handler.cpp
     src/stack_trace.cpp
     src/version.cpp
     src/filesystem/file.cpp
@@ -32,6 +33,7 @@ set(SOURCES
     include/hephaestus/utils/concepts.h
     include/hephaestus/utils/exception.h
     include/hephaestus/utils/utils.h
+    include/hephaestus/utils/signal_handler.h
     include/hephaestus/utils/stack_trace.h
     include/hephaestus/utils/version.h
     include/hephaestus/utils/filesystem/file.h

--- a/modules/utils/include/hephaestus/utils/signal_handler.h
+++ b/modules/utils/include/hephaestus/utils/signal_handler.h
@@ -12,15 +12,23 @@
 namespace heph::utils {
 
 /// \brief Use this class to block until a signal is received.
+/// > NOTE: can be extended to call a generic callback when a signal is received.
 /// Usage:
 /// ```
 /// int main() {
 ///  // Do something
 ///  SignalHandlerStop::wait();
 /// }
+/// // Or
+/// while (SignalHandlerStop::ok()) {
+/// // Do something
+/// }
 /// ```
 class SignalHandlerStop {
 public:
+  /// Return false if a signal has been received, true otherwise.
+  [[nodiscard]] static auto ok() -> bool;
+  /// Blocks until a signal has been received.
   static void wait();
 
 private:

--- a/modules/utils/include/hephaestus/utils/signal_handler.h
+++ b/modules/utils/include/hephaestus/utils/signal_handler.h
@@ -17,14 +17,14 @@ namespace heph::utils {
 /// ```
 /// int main() {
 ///  // Do something
-///  SignalHandlerStop::wait();
+///  InterruptHandler::wait();
 /// }
 /// // Or
-/// while (SignalHandlerStop::ok()) {
+/// while (InterruptHandler::stopRequested()) {
 /// // Do something
 /// }
 /// ```
-class SignalHandlerStop {
+class InterruptHandler {
 public:
   /// Return false if a signal has been received, true otherwise.
   [[nodiscard]] static auto ok() -> bool;
@@ -32,8 +32,8 @@ public:
   static void wait();
 
 private:
-  SignalHandlerStop() = default;
-  [[nodiscard]] static auto instance() -> SignalHandlerStop&;
+  InterruptHandler() = default;
+  [[nodiscard]] static auto instance() -> InterruptHandler&;
 
   static auto signalHandler(int /*unused*/) -> void;
 

--- a/modules/utils/include/hephaestus/utils/signal_handler.h
+++ b/modules/utils/include/hephaestus/utils/signal_handler.h
@@ -7,8 +7,6 @@
 #include <atomic>
 #include <csignal>
 
-#include <range/v3/range/conversion.hpp>
-
 namespace heph::utils {
 
 /// \brief Use this class to block until a signal is received.

--- a/modules/utils/include/hephaestus/utils/signal_handler.h
+++ b/modules/utils/include/hephaestus/utils/signal_handler.h
@@ -1,0 +1,36 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#pragma once
+
+#include <atomic>
+#include <csignal>
+
+#include <range/v3/range/conversion.hpp>
+
+namespace heph::utils {
+
+/// \brief Use this class to block until a signal is received.
+/// Usage:
+/// ```
+/// int main() {
+///  // Do something
+///  SignalHandlerStop::wait();
+/// }
+/// ```
+class SignalHandlerStop {
+public:
+  static void wait();
+
+private:
+  SignalHandlerStop() = default;
+  [[nodiscard]] static auto instance() -> SignalHandlerStop&;
+
+  static auto signalHandler(int /*unused*/) -> void;
+
+private:
+  std::atomic_flag stop_flag_ = ATOMIC_FLAG_INIT;
+};  // namespace heph::utils
+
+}  // namespace heph::utils

--- a/modules/utils/include/hephaestus/utils/signal_handler.h
+++ b/modules/utils/include/hephaestus/utils/signal_handler.h
@@ -27,7 +27,7 @@ namespace heph::utils {
 class InterruptHandler {
 public:
   /// Return false if a signal has been received, true otherwise.
-  [[nodiscard]] static auto ok() -> bool;
+  [[nodiscard]] static auto stopRequested() -> bool;
   /// Blocks until a signal has been received.
   static void wait();
 

--- a/modules/utils/src/signal_handler.cpp
+++ b/modules/utils/src/signal_handler.cpp
@@ -6,6 +6,10 @@
 
 namespace heph::utils {
 
+auto SignalHandlerStop::ok() -> bool {
+  return instance().stop_flag_.test();
+}
+
 void SignalHandlerStop::wait() {
   (void)signal(SIGINT, SignalHandlerStop::signalHandler);
   (void)signal(SIGTERM, SignalHandlerStop::signalHandler);

--- a/modules/utils/src/signal_handler.cpp
+++ b/modules/utils/src/signal_handler.cpp
@@ -1,0 +1,25 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#include "hephaestus/utils/signal_handler.h"
+
+namespace heph::utils {
+
+void SignalHandlerStop::wait() {
+  (void)signal(SIGINT, SignalHandlerStop::signalHandler);
+  (void)signal(SIGTERM, SignalHandlerStop::signalHandler);
+
+  instance().stop_flag_.wait(false);
+}
+
+auto SignalHandlerStop::instance() -> SignalHandlerStop& {
+  static SignalHandlerStop instance;
+  return instance;
+}
+
+auto SignalHandlerStop::signalHandler(int /*unused*/) -> void {
+  instance().stop_flag_.test_and_set();
+  instance().stop_flag_.notify_all();
+}
+}  // namespace heph::utils

--- a/modules/utils/src/signal_handler.cpp
+++ b/modules/utils/src/signal_handler.cpp
@@ -6,23 +6,23 @@
 
 namespace heph::utils {
 
-auto SignalHandlerStop::ok() -> bool {
+auto InterruptHandler::stopRequested() -> bool {
   return instance().stop_flag_.test();
 }
 
-void SignalHandlerStop::wait() {
-  (void)signal(SIGINT, SignalHandlerStop::signalHandler);
-  (void)signal(SIGTERM, SignalHandlerStop::signalHandler);
+void InterruptHandler::wait() {
+  (void)signal(SIGINT, InterruptHandler::signalHandler);
+  (void)signal(SIGTERM, InterruptHandler::signalHandler);
 
   instance().stop_flag_.wait(false);
 }
 
-auto SignalHandlerStop::instance() -> SignalHandlerStop& {
-  static SignalHandlerStop instance;
+auto InterruptHandler::instance() -> InterruptHandler& {
+  static InterruptHandler instance;
   return instance;
 }
 
-auto SignalHandlerStop::signalHandler(int /*unused*/) -> void {
+auto InterruptHandler::signalHandler(int /*unused*/) -> void {
   instance().stop_flag_.test_and_set();
   instance().stop_flag_.notify_all();
 }


### PR DESCRIPTION
# Description
Two utils to make easier writing apps:
* Zenoh config command line options are now in a dedicated file in the ipc module and functions are provided to easily append the option to any program description.
  * This allows to use the options also in apps that are outside of the IPC module.
* Add `SignalHandlerStop` class utils that allows to block until `ctrl+c` is pressed. This clean up a lot of code.
  * Please advise for a better name as I don't really like it but couldn't find anything better. 
