### PR TITLE
Fix: various minor zenoh fixes

### DIFF
--- a/modules/ipc/include/hephaestus/ipc/zenoh/liveliness.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/liveliness.h
@@ -24,9 +24,15 @@ void printPublisherInfo(const PublisherInfo& info);
 class PublisherDiscovery {
 public:
   using Callback = std::function<void(const PublisherInfo& info)>;
-  /// The callback needs to be thread safe as they maybe called in parallel for different publishers
+  /// The callback needs to be thread safe as they may be called in parallel for different publishers
   /// discovered.
   explicit PublisherDiscovery(SessionPtr session, TopicConfig topic_config, Callback&& callback);
+  ~PublisherDiscovery();
+
+  PublisherDiscovery(const PublisherDiscovery&) = delete;
+  PublisherDiscovery(PublisherDiscovery&&) = delete;
+  auto operator=(const PublisherDiscovery&) -> PublisherDiscovery& = delete;
+  auto operator=(PublisherDiscovery&&) -> PublisherDiscovery& = delete;
 
 private:
   void createLivelinessSubscriber();

--- a/modules/ipc/include/hephaestus/ipc/zenoh/publisher.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/publisher.h
@@ -35,11 +35,11 @@ public:
             MatchCallback&& match_cb = nullptr);
   ~Publisher();
   Publisher(const Publisher&) = delete;
-  Publisher(Publisher&&) = default;
+  Publisher(Publisher&&) = delete;
   auto operator=(const Publisher&) -> Publisher& = delete;
-  auto operator=(Publisher&&) -> Publisher& = default;
+  auto operator=(Publisher&&) -> Publisher& = delete;
 
-  [[nodiscard]] auto publish(std::span<std::byte> data) -> bool;
+  [[nodiscard]] auto publish(std::span<const std::byte> data) -> bool;
 
   [[nodiscard]] auto id() const -> std::string {
     return toString(session_->zenoh_session.info_zid());

--- a/modules/ipc/src/topic_database.cpp
+++ b/modules/ipc/src/topic_database.cpp
@@ -40,7 +40,7 @@ auto ZenohTopicDatabase::getTypeInfo(const std::string& topic) -> const serdes::
 
   auto query_topic = getTypeInfoServiceTopic(topic);
 
-  static constexpr auto TIMEOUT = std::chrono::milliseconds{ 500 };
+  static constexpr auto TIMEOUT = std::chrono::milliseconds{ 1000 };
   const auto response = zenoh::callService<std::string, std::string>(
       *session_, TopicConfig{ .name = query_topic }, "", TIMEOUT);
   throwExceptionIf<heph::InvalidDataException>(

--- a/modules/ipc/src/zenoh/liveliness.cpp
+++ b/modules/ipc/src/zenoh/liveliness.cpp
@@ -80,6 +80,10 @@ PublisherDiscovery::PublisherDiscovery(SessionPtr session, TopicConfig topic_con
   }
 }
 
+PublisherDiscovery::~PublisherDiscovery() {
+  z_undeclare_subscriber(&liveliness_subscriber_);
+}
+
 void PublisherDiscovery::createLivelinessSubscriber() {
   zenohc::ClosureSample cb = [this](const zenohc::Sample& sample) {
     PublisherInfo info{ .topic = std::string{ sample.get_keyexpr().as_string_view() },

--- a/modules/ipc/src/zenoh/publisher.cpp
+++ b/modules/ipc/src/zenoh/publisher.cpp
@@ -50,7 +50,7 @@ Publisher::~Publisher() {
   z_drop(z_move(pub_cache_));
 }
 
-auto Publisher::publish(std::span<std::byte> data) -> bool {
+auto Publisher::publish(std::span<const std::byte> data) -> bool {
   attachment_[messageCounterKey()] = std::to_string(pub_msg_count_++);
 
   return publisher_->put({ data.data(), data.size() }, put_options_);


### PR DESCRIPTION
# Description
* `PublisherDiscovery` was not correctly shutting down zenoh data
* `Publisher` move constructor doesn't work (probably due to some internal zenoh limitation) so we are deleting it
* `publish` now accept const data to be more permissive
