### PR TITLE
Fix/Fix missing std::ranges::for_each() error in gcc11.

### DIFF
--- a/modules/ipc/apps/zenoh_node_list.cpp
+++ b/modules/ipc/apps/zenoh_node_list.cpp
@@ -19,8 +19,8 @@ auto main(int argc, const char* argv[]) -> int {
     fmt::println("Scouting..");
 
     auto nodes_info = heph::ipc::zenoh::getListOfNodes();
-    std::ranges::for_each(nodes_info,
-                          [](const auto& info) { fmt::println("{}", heph::ipc::zenoh::toString(info)); });
+    std::for_each(nodes_info.begin(), nodes_info.end(),
+                  [](const auto& info) { fmt::println("{}", heph::ipc::zenoh::toString(info)); });
 
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/modules/ipc/apps/zenoh_string_service.cpp
+++ b/modules/ipc/apps/zenoh_string_service.cpp
@@ -29,8 +29,8 @@ auto main(int argc, const char* argv[]) -> int {
 
     auto results = heph::ipc::zenoh::callService<std::string, std::string>(*session, topic_config, value);
 
-    std::ranges::for_each(
-        results, [](const auto& res) { fmt::println(">> Received ('{}': '{}')", res.topic, res.value); });
+    std::for_each(results.begin(), results.end(),
+                  [](const auto& res) { fmt::println(">> Received ('{}': '{}')", res.topic, res.value); });
 
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/modules/ipc/apps/zenoh_topic_list.cpp
+++ b/modules/ipc/apps/zenoh_topic_list.cpp
@@ -17,8 +17,8 @@
 
 void getListOfPublisher(const heph::ipc::zenoh::Session& session, std::string_view topic) {
   const auto publishers_info = heph::ipc::zenoh::getListOfPublishers(session, topic);
-  std::ranges::for_each(publishers_info,
-                        [](const auto& info) { heph::ipc::zenoh::printPublisherInfo(info); });
+  std::for_each(publishers_info.begin(), publishers_info.end(),
+                [](const auto& info) { heph::ipc::zenoh::printPublisherInfo(info); });
 }
 
 void getLiveListOfPublisher(heph::ipc::zenoh::SessionPtr session, heph::ipc::TopicConfig topic_config) {


### PR DESCRIPTION
# Description
For compatibility reasons, we transition from `std::ranges::for_each` to `std::for_each`.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
