### PR TITLE
Fix some IWYU issues; fix typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ninja all examples
 
 To compile and run the unit test
 ```bash
-ninja checks
+ninja check
 ```
 
 > TODO: add section on the different flags and options.

--- a/modules/utils/include/hephaestus/utils/timing/watchdog.h
+++ b/modules/utils/include/hephaestus/utils/timing/watchdog.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <chrono>
+#include <condition_variable>
+#include <cstdint>
 #include <functional>
 #include <thread>
 

--- a/modules/utils/src/timing/watchdog.cpp
+++ b/modules/utils/src/timing/watchdog.cpp
@@ -4,6 +4,9 @@
 
 #include "hephaestus/utils/timing/watchdog.h"
 
+#include <mutex>
+#include <utility>
+
 namespace heph::utils::timing {
 void WatchdogTimer::start(std::chrono::milliseconds period, Callback&& callback) {
   period_ = period;


### PR DESCRIPTION
# Description

  * Fix some missing includes to make things compile; it looks like there might be other instances where more diligence is needed w.r.t IWYU, but these I stumbled upon as it made the compile hick-up.
  * The `ninja checks` in the README should really be `check`
  * There is another typo in the README `cmake --preset preferred` ... the `preferred` preset does not actually exist. Maybe `default` was meant ? Anyway, not touching that, but you should probably change that to one of the existing options.
 