### PR TITLE
[Fix] TerminationBlocker stopRequested was not registering signal handler function

### DIFF
--- a/modules/utils/src/signal_handler.cpp
+++ b/modules/utils/src/signal_handler.cpp
@@ -7,8 +7,6 @@
 #include <csignal>
 #include <mutex>
 
-#include <fmt/core.h>
-
 namespace heph::utils {
 
 auto TerminationBlocker::stopRequested() -> bool {

--- a/modules/utils/src/signal_handler.cpp
+++ b/modules/utils/src/signal_handler.cpp
@@ -5,10 +5,19 @@
 #include "hephaestus/utils/signal_handler.h"
 
 #include <csignal>
+#include <mutex>
+
+#include <fmt/core.h>
 
 namespace heph::utils {
 
 auto TerminationBlocker::stopRequested() -> bool {
+  static std::once_flag flag;
+  std::call_once(flag, []() {
+    (void)signal(SIGINT, TerminationBlocker::signalHandler);
+    (void)signal(SIGTERM, TerminationBlocker::signalHandler);
+  });
+
   return instance().stop_flag_.test();
 }
 


### PR DESCRIPTION
# Description
`TerminationBlocker::stopRequested` was not registering signal handler function.

## Type of change
- Bug fix (non-breaking change which fixes an issue)