### PR TITLE
add structured logging proposal

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -150,3 +150,18 @@ add_cmake_dependency(
   SOURCE_SUBDIR cpp
   CMAKE_ARGS -DBUILD_TESTING=OFF
 )
+
+# --------------------------------------------------------------------------------------------------
+# spdlog
+set(SPDLOG_VERSION 1.14.1)
+set(SPDLOG_TAG v${SPDLOG_VERSION})
+set(SPDLOG_CMAKE_ARGS -DSPDLOG_BUILD_EXAMPLE=OFF -DSPDLOG_INSTALL=ON)
+add_cmake_dependency(
+  NAME spdlog
+  VERSION ${SPDLOG_VERSION}
+  GIT_REPOSITORY "https://github.com/gabime/spdlog.git"
+  GIT_TAG ${SPDLOG_TAG}
+  CMAKE_ARGS ${SPDLOG_CMAKE_ARGS}
+)
+
+

--- a/modules/utils/CMakeLists.txt
+++ b/modules/utils/CMakeLists.txt
@@ -5,12 +5,13 @@
 declare_module(
   NAME utils
   DEPENDS_ON_MODULES "" # **Note**: This module should not depend on any other module
-  DEPENDS_ON_EXTERNAL_PROJECTS fmt
+  DEPENDS_ON_EXTERNAL_PROJECTS fmt spdlog
   ALWAYS_BUILD
 )
 
 find_package(absl REQUIRED)
 find_package(fmt REQUIRED)
+find_package(spdlog REQUIRED)
 
 # generate version header
 configure_file(src/version.in ${CMAKE_CURRENT_SOURCE_DIR}/src/version_impl.h @ONLY)
@@ -24,6 +25,7 @@ set(SOURCES
     src/utils.cpp
     src/signal_handler.cpp
     src/stack_trace.cpp
+    src/struclog.cpp
     src/version.cpp
     src/filesystem/file.cpp
     src/filesystem/scoped_path.cpp
@@ -35,6 +37,7 @@ set(SOURCES
     include/hephaestus/utils/utils.h
     include/hephaestus/utils/signal_handler.h
     include/hephaestus/utils/stack_trace.h
+    include/hephaestus/utils/struclog.h
     include/hephaestus/utils/version.h
     include/hephaestus/utils/filesystem/file.h
     include/hephaestus/utils/filesystem/scoped_path.h

--- a/modules/utils/include/hephaestus/utils/struclog.h
+++ b/modules/utils/include/hephaestus/utils/struclog.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#pragma once
+
+#include <iomanip>
+#include <source_location>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace heph::utils::struclog {
+
+/**
+ * @brief A class that allows easy composition of logs for sturctured logging with spdlog.
+ *        Example(see also struclog.cpp):
+ *        namespace sl=struclog;
+ *        sl::error(sl::Log("adding super-frame")("id", 12345)("tag", "test"));
+ *
+ *        logs
+ *        'level=info file=struclog.h:123 time=2023-12-3T8:52:02+0 message="adding super-frame" id=12345
+ * tag="test"'
+ *
+ *        Remark: We would like to use libfmt with quoted formatting as proposed in
+ *                https://github.com/fmtlib/fmt/issues/825 once its included (instead of sstream).
+ *
+ */
+class Log {
+public:
+  explicit Log(const std::string& msg, std::source_location location = std::source_location::current());
+
+  /*
+   * @brief General loginfo consumer, should be used like Log("my message")("field", 1234)
+   *        Converted to string with stringstream.
+   * @todo  When we update to cpp23, we can use operator[] that makes a clearer interface.
+   *
+   * @tparam T any type that is consumeable by stringstream
+   * @param key identifier for the logging data
+   * @param val value of the logging data
+   * @return Log&&
+   */
+  template <typename T>
+  auto operator()(const std::string& key, const T& val) -> Log&& {
+    std::stringstream ss;
+    ss << key << FIELD_SEPERATOR << val;
+    logging_data_.emplace_back(ss.str());
+
+    return std::move(*this);
+  }
+
+  /*
+   * @brief Specialized loginfo consumer for string types so that they are quoted, should be used like Log("my
+   * message")("field", "mystring")
+   * @todo  When we update to cpp23, we can use operator[] that makes a clearer interface.
+   *
+   * @tparam T any type that is consumeable by stringstream
+   * @param key identifier for the logging data
+   * @param val value of the logging data
+   * @return Log&&
+   */
+  template <std::convertible_to<std::string> S>
+  auto operator()(const std::string& key, const S& val) -> Log&& {
+    std::stringstream ss;
+    // Pointer decay is wanted here to catch char[n] messages
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+    ss << key << FIELD_SEPERATOR << std::quoted(val);
+    logging_data_.emplace_back(ss.str());
+
+    return std::move(*this);
+  }
+
+  [[nodiscard]] auto format() const -> std::string;
+
+private:
+  static void setPattern();
+
+  std::vector<std::string> logging_data_;
+  static constexpr char FIELD_SEPERATOR{ '=' };
+  static constexpr char ELEMENT_SEPERATOR{ ' ' };
+};
+
+void init();
+
+void trace(const Log& s);
+void debug(const Log& s);
+void info(const Log& s);
+void warn(const Log& s);
+void error(const Log& s);
+void critical(const Log& s);
+}  // namespace heph::utils::struclog

--- a/modules/utils/src/struclog.cpp
+++ b/modules/utils/src/struclog.cpp
@@ -1,0 +1,70 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+// MIT License
+//=================================================================================================
+
+#include "hephaestus/utils/struclog.h"
+
+#include <filesystem>
+#include <numeric>
+#include <string>
+
+#include <fmt/format.h>
+#include <spdlog/spdlog.h>
+
+namespace heph::utils::struclog {
+
+Log::Log(const std::string& msg, std::source_location location) {
+  {
+    std::stringstream ss;
+    ss << "message" << FIELD_SEPERATOR << std::quoted(msg);
+    logging_data_.emplace_back(ss.str());
+  }
+  {
+    std::stringstream ss;
+    ss << "location" << FIELD_SEPERATOR
+       << std::quoted(std::format("{}:{}", std::filesystem::path{ location.file_name() }.filename().string(),
+                                  location.line()));
+    logging_data_.emplace_back(ss.str());
+  }
+}
+
+auto Log::format() const -> std::string {
+  setPattern();
+
+  return std::accumulate(std::next(logging_data_.cbegin()), logging_data_.cend(), logging_data_[0],
+                         [](const std::string& accumulated, const std::string& next) {
+                           return fmt::format("{}{}{}", accumulated, ELEMENT_SEPERATOR, next);
+                         });
+}
+
+void Log::setPattern() {
+  // We could add %@ to print the current file, voer then we would need to use the SPDLOG_INFO macros,
+  // which is less nice and less encapsulated (and could result to clashing versions of fmt).
+  spdlog::set_pattern("level=%^%l%$ time=%Y-%m-%dT%H:%M:%S%z %v");
+}
+
+void init() {
+  spdlog::set_level(spdlog::level::trace);
+}
+
+void trace(const Log& s) {
+  spdlog::trace(s.format());
+}
+void debug(const Log& s) {
+  spdlog::debug(s.format());
+}
+void info(const Log& s) {
+  spdlog::info(s.format());
+}
+void warn(const Log& s) {
+  spdlog::warn(s.format());
+}
+void error(const Log& s) {
+  spdlog::error(s.format());
+}
+void critical(const Log& s) {
+  spdlog::critical(s.format());
+}
+
+}  // namespace heph::utils::struclog

--- a/modules/utils/tests/CMakeLists.txt
+++ b/modules/utils/tests/CMakeLists.txt
@@ -29,3 +29,10 @@ define_module_test(
   PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   PUBLIC_LINK_LIBS ""
 )
+
+define_module_test(
+  NAME struclog_tests
+  SOURCES struclog_tests.cpp
+  PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  PUBLIC_LINK_LIBS ""
+)

--- a/modules/utils/tests/struclog_tests.cpp
+++ b/modules/utils/tests/struclog_tests.cpp
@@ -1,0 +1,57 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#include <random>
+
+#include <gtest/gtest.h>
+
+#include "hephaestus/utils/struclog.h"
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace ::testing;
+
+namespace sl = heph::utils::struclog;
+
+auto printout(const sl::Log& s) -> std::string {
+  return s.format();
+}
+
+TEST(struclog, Log) {
+  std::string a = "test a great message";
+  std::string b = "test \"great\" name";
+  // clang-format off
+  int current_line = __LINE__; auto s = printout(sl::Log(std::string(a))("b", std::string(b)));
+  // clang-format on
+
+  std::stringstream ss;
+  ss << "message=" << std::quoted(a);
+
+  std::stringstream ss2;
+  ss2 << " b=" << std::quoted(b);
+
+  ASSERT_TRUE(s.find(ss.str()) != std::string::npos);
+  ASSERT_TRUE(s.find(std::format("location=\"struclog_tests.cpp:{}\"", current_line)) != std::string::npos);
+  ASSERT_TRUE(s.find(ss2.str()) != std::string::npos);
+}
+
+TEST(struclog, Escapes) {
+  const std::string a = "test a great message";
+  const std::string b = "test \"great\" name";
+  const std::string c = "test 'great' name";
+  const int num = 123;
+  // clang-format off
+  int current_line = __LINE__; auto s = printout(sl::Log{ std::string(a) }("b", std::string(b))("c", std::string(c))("num", num));
+  // clang-format on
+
+  std::stringstream ss;
+  ss << "message=" << std::quoted(a) << " ";
+  ss << std::format("location=\"struclog_tests.cpp:{}\"", current_line) << " ";
+  ss << "b=" << std::quoted(b) << " ";
+  ss << "c=" << std::quoted(c) << " ";
+  ss << "num=" << num;
+
+  std::cout << ss.str() << "\n";
+
+  ASSERT_EQ(s, ss.str());
+}


### PR DESCRIPTION
# Description
As discussed in https://github.com/olympus-robotics/hephaestus/issues/86 we want to make the logging more scalable.
This is a proposal for adding structured logging.
Done:
* Logging on different levels with spdlog
* Draft of interface for structured logging

To be done:
* Add additional sink for InfluxDB

To be discussed:
I am not quite satisfied with the interface yet:
Log{"msg"}("key",val)("key2",val2)
is not super nice.
I like []  better but this is only avaliable in c++23.
Also map interface has too many brackets in my opinion:
Log{"msg"}({{"key",val},{"key2",val2}})
Best solution would be designated initilializers like:
Log{"msg"}(.key=val, .key2=val2)
But for this I would need reflections to turn the struct fields into json, perhaps possible with c++26...

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
