### PR TITLE
Bump protobuf and absl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Hephaestus provides functionalities that cover the following domains:
 ### Env
 The best way to build hephaestus is to do it inside the docker container provided in the `docker` folder. You can build the container with `build.sh` and start it using `run.sh`.
 
+If you add or update a dependency, bump `DEPS_VERSION`.
+
 ### Compilation
 
 Hephaestus uses CMake to build, the build infrastructure is copied and adapted from [grape](https://github.com/cvilas/grape).

--- a/docker/version.sh
+++ b/docker/version.sh
@@ -3,4 +3,4 @@ VERSION=1.0.7
 IMAGE=hephaestus-dev
 
 # This is the version of the dep image. Increase this number everytime you change `external/CMakeLists.txt`
-DEPS_VERSION=1.0.16
+DEPS_VERSION=1.0.17

--- a/docker/version.sh
+++ b/docker/version.sh
@@ -3,4 +3,4 @@ VERSION=1.0.7
 IMAGE=hephaestus-dev
 
 # This is the version of the dep image. Increase this number everytime you change `external/CMakeLists.txt`
-DEPS_VERSION=1.0.15
+DEPS_VERSION=1.0.16

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -62,7 +62,7 @@ add_cmake_dependency(
 # --------------------------------------------------------------------------------------------------
 # protobuf
 set(PROTOBUF_TAG v27.2)
-set(PROTOBUF_VERSION 4.27.2)
+set(PROTOBUF_VERSION 5.27.2)
 set(PROTOBUF_CMAKE_ARGS -Dprotobuf_BUILD_EXAMPLES=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_ABSL_PROVIDER=package
                         -Dprotobuf_BUILD_CONFORMANCE=OFF
 )

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -47,7 +47,7 @@ add_cmake_dependency(
 # --------------------------------------------------------------------------------------------------
 # Abseil C++
 set(ABSEIL_VERSION 20240116)
-set(ABSEIL_TAG ${ABSEIL_VERSION}.0)
+set(ABSEIL_TAG ${ABSEIL_VERSION}.2)
 set(ABSEIL_CMAKE_ARGS -DABSL_BUILD_TESTING=OFF -DABSL_ENABLE_INSTALL=ON -DABSL_PROPAGATE_CXX_STD=ON
                       -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
 )

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -46,8 +46,8 @@ add_cmake_dependency(
 
 # --------------------------------------------------------------------------------------------------
 # Abseil C++
-set(ABSEIL_VERSION 20230802)
-set(ABSEIL_TAG ${ABSEIL_VERSION}.1)
+set(ABSEIL_VERSION 20240116)
+set(ABSEIL_TAG ${ABSEIL_VERSION}.0)
 set(ABSEIL_CMAKE_ARGS -DABSL_BUILD_TESTING=OFF -DABSL_ENABLE_INSTALL=ON -DABSL_PROPAGATE_CXX_STD=ON
                       -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
 )
@@ -61,8 +61,8 @@ add_cmake_dependency(
 
 # --------------------------------------------------------------------------------------------------
 # protobuf
-set(PROTOBUF_TAG v25.2)
-set(PROTOBUF_VERSION 4.25.2)
+set(PROTOBUF_TAG v27.2)
+set(PROTOBUF_VERSION 4.27.2)
 set(PROTOBUF_CMAKE_ARGS -Dprotobuf_BUILD_EXAMPLES=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_ABSL_PROVIDER=package
                         -Dprotobuf_BUILD_CONFORMANCE=OFF
 )

--- a/modules/serdes/include/hephaestus/serdes/protobuf/protobuf.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/protobuf.h
@@ -58,7 +58,7 @@ template <class T>
   std::string json_string;
   google::protobuf::util::JsonPrintOptions options;
   options.add_whitespace = true;
-  options.always_print_primitive_fields = true;
+  options.always_print_fields_with_no_presence = true;
   auto status = google::protobuf::util::MessageToJsonString(proto, &json_string, options);
   throwExceptionIf<FailedSerdesOperation>(
       !status.ok(), fmt::format("failed to convert proto message to JSON with error: {}", status.message()));

--- a/modules/serdes/src/protobuf/dynamic_deserializer.cpp
+++ b/modules/serdes/src/protobuf/dynamic_deserializer.cpp
@@ -53,7 +53,7 @@ auto DynamicDeserializer::toJson(const std::string& type, std::span<const std::b
 
   std::string msg_json;
   google::protobuf::util::JsonPrintOptions options;
-  options.always_print_primitive_fields = true;
+  options.always_print_fields_with_no_presence = true;
   options.add_whitespace = true;
   options.unquote_int64_if_possible = true;
   const auto status = google::protobuf::util::MessageToJsonString(*message, &msg_json, options);

--- a/modules/utils/src/filesystem/scoped_path.cpp
+++ b/modules/utils/src/filesystem/scoped_path.cpp
@@ -1,5 +1,6 @@
 #include "hephaestus/utils/filesystem/scoped_path.h"
 
+#include <cstdio>
 #include <filesystem>
 #include <string>
 #include <string_view>

--- a/modules/utils/src/filesystem/scoped_path.cpp
+++ b/modules/utils/src/filesystem/scoped_path.cpp
@@ -1,6 +1,5 @@
 #include "hephaestus/utils/filesystem/scoped_path.h"
 
-#include <cstdio>
 #include <filesystem>
 #include <string>
 #include <string_view>

--- a/modules/utils/src/timing/watchdog.cpp
+++ b/modules/utils/src/timing/watchdog.cpp
@@ -6,6 +6,7 @@
 
 #include <chrono>
 #include <mutex>
+#include <thread>
 #include <utility>
 
 namespace heph::utils::timing {


### PR DESCRIPTION
# Description
Bump protobuf to v27.2 and absl to the matching 20240116.2. See absl release notes for breaking changes. 

Bump `DEPS_VERSION=1.0.17` accordingly.

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
