### PR TITLE
Update zenohcxx and link it correctly.

### DIFF
--- a/docker/version.sh
+++ b/docker/version.sh
@@ -3,4 +3,4 @@ VERSION=1.0.7
 IMAGE=hephaestus-dev
 
 # This is the version of the dep image. Increase this number everytime you change `external/CMakeLists.txt`
-DEPS_VERSION=1.0.20
+DEPS_VERSION=1.0.21

--- a/docker/version.sh
+++ b/docker/version.sh
@@ -3,4 +3,4 @@ VERSION=1.0.7
 IMAGE=hephaestus-dev
 
 # This is the version of the dep image. Increase this number everytime you change `external/CMakeLists.txt`
-DEPS_VERSION=1.0.17
+DEPS_VERSION=1.0.20

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -29,7 +29,9 @@ endif()
 # --------------------------------------------------------------------------------------------------
 # zenoh
 
-set(ZENOH_VERSION "1.0.0.4")
+# As soon as zenohcxx commit makes to a release, move back to the release.
+# set(ZENOH_VERSION "1.0.0.4")
+set(ZENOH_VERSION "c75ce16e855e8b1f0562523cdf6be6c37f4ebb56")
 add_cmake_dependency(
   NAME zenohc
   GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-c"

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -41,6 +41,7 @@ add_cmake_dependency(
 set(ZENOHCXX_VERSION "535b3629db7fc1e52aecba90238a8caec2f6c947")
 add_cmake_dependency(
   NAME zenohcxx
+  DEPENDS ${ZENOHCXX_DEPENDS}
   GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-cpp"
   GIT_TAG ${ZENOHCXX_VERSION}
   SOURCE_SUBDIR install

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -29,8 +29,7 @@ endif()
 # --------------------------------------------------------------------------------------------------
 # zenoh
 
-# As soon as zenohcxx commit makes to a release, move back to the release.
-# set(ZENOH_VERSION "1.0.0.4")
+# As soon as zenohcxx commit makes to a release, move back to the release. set(ZENOH_VERSION "1.0.0.4")
 set(ZENOH_VERSION "c75ce16e855e8b1f0562523cdf6be6c37f4ebb56")
 add_cmake_dependency(
   NAME zenohc

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 # --------------------------------------------------------------------------------------------------
 # zenoh
 
-set(ZENOH_VERSION "0.11.0.3")
+set(ZENOH_VERSION "1.0.0.4")
 add_cmake_dependency(
   NAME zenohc
   GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-c"
@@ -37,10 +37,12 @@ add_cmake_dependency(
   CMAKE_ARGS -DZENOHC_CARGO_CHANNEL=+stable
 )
 
+# This should be equal to ${ZENOH_VERSION}, but we need to the fix coming from this commit.
+set(ZENOHCXX_VERSION "535b3629db7fc1e52aecba90238a8caec2f6c947")
 add_cmake_dependency(
   NAME zenohcxx
   GIT_REPOSITORY "https://github.com/eclipse-zenoh/zenoh-cpp"
-  GIT_TAG ${ZENOH_VERSION}
+  GIT_TAG ${ZENOHCXX_VERSION}
   SOURCE_SUBDIR install
 )
 

--- a/modules/ipc/CMakeLists.txt
+++ b/modules/ipc/CMakeLists.txt
@@ -57,7 +57,7 @@ define_module_library(
     nlohmann_json::nlohmann_json
     range-v3::range-v3
     zenohc::lib
-    zenohcxx::lib
+    zenohcxx::zenohc::lib
   PRIVATE_LINK_LIBS ""
   SOURCES ${SOURCES}
   PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>

--- a/modules/ipc/CMakeLists.txt
+++ b/modules/ipc/CMakeLists.txt
@@ -5,7 +5,7 @@
 declare_module(
   NAME ipc
   DEPENDS_ON_MODULES cli concurrency containers utils serdes
-  DEPENDS_ON_EXTERNAL_PROJECTS absl fmt nlohmann_json range-v3 zenohcxx
+  DEPENDS_ON_EXTERNAL_PROJECTS absl fmt nlohmann_json range-v3 zenohc zenohcxx
 )
 
 find_package(absl REQUIRED)
@@ -57,6 +57,7 @@ define_module_library(
     nlohmann_json::nlohmann_json
     range-v3::range-v3
     zenohc::lib
+    zenohcxx::lib
   PRIVATE_LINK_LIBS ""
   SOURCES ${SOURCES}
   PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>


### PR DESCRIPTION
# Description
Update `zenohcxx` to the latest commit where we fixed the cmake install script.
Now we can properly link it.

