### PR TITLE
Enhance JSON serialization

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -146,3 +146,15 @@ set(MCAP_TAG cb34e058cfd529f694a4ff1747517478339fc866)
 add_cmake_dependency(
   NAME mcap VERSION ${MCAP_VERSION} URL https://github.com/olympus-robotics/mcap_builder/archive/${MCAP_TAG}.zip
 )
+
+# --------------------------------------------------------------------------------------------------
+# reflect-cpp
+set(REFLECT_CPP_VERSION 0.13.0)
+set(REFLECT_CPP_TAG v${REFLECT_CPP_VERSION})
+add_cmake_dependency(
+  NAME reflect-cpp
+  VERSION ${REFLECT_CPP_VERSION}
+  GIT_REPOSITORY https://github.com/getml/reflect-cpp.git
+  GIT_TAG ${REFLECT_CPP_TAG}
+  CMAKE_ARGS -DREFLECTCPP_YAML=OFF
+)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -146,15 +146,3 @@ set(MCAP_TAG cb34e058cfd529f694a4ff1747517478339fc866)
 add_cmake_dependency(
   NAME mcap VERSION ${MCAP_VERSION} URL https://github.com/olympus-robotics/mcap_builder/archive/${MCAP_TAG}.zip
 )
-
-# --------------------------------------------------------------------------------------------------
-# reflect-cpp
-set(REFLECT_CPP_VERSION 0.13.0)
-set(REFLECT_CPP_TAG v${REFLECT_CPP_VERSION})
-add_cmake_dependency(
-  NAME reflect-cpp
-  VERSION ${REFLECT_CPP_VERSION}
-  GIT_REPOSITORY https://github.com/getml/reflect-cpp.git
-  GIT_TAG ${REFLECT_CPP_TAG}
-  CMAKE_ARGS -DREFLECTCPP_YAML=OFF
-)

--- a/modules/examples/examples/serdes_examples.cpp
+++ b/modules/examples/examples/serdes_examples.cpp
@@ -8,6 +8,7 @@
 
 #include "hephaestus/examples/types/pose.h"
 #include "hephaestus/examples/types_protobuf/pose.h"  // NOLINT(misc-include-cleaner)
+#include "hephaestus/serdes/json.h"
 #include "hephaestus/serdes/serdes.h"
 
 //=================================================================================================

--- a/modules/ipc/include/hephaestus/ipc/zenoh/service.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/service.h
@@ -53,9 +53,9 @@ auto removeChangingBytes(std::span<const std::byte> buffer) -> std::span<const s
 
 template <typename RequestT, typename ReplyT>
 constexpr void checkTemplatedTypes() {
-  static_assert(serdes::ProtobufSerializable<RequestT> || std::is_same_v<RequestT, std::string>,
+  static_assert(serdes::protobuf::ProtobufSerializable<RequestT> || std::is_same_v<RequestT, std::string>,
                 "Request needs to be serializable or std::string.");
-  static_assert(serdes::ProtobufSerializable<ReplyT> || std::is_same_v<ReplyT, std::string>,
+  static_assert(serdes::protobuf::ProtobufSerializable<ReplyT> || std::is_same_v<ReplyT, std::string>,
                 "Reply needs to be serializable or std::string.");
 }
 

--- a/modules/serdes/include/hephaestus/serdes/json.h
+++ b/modules/serdes/include/hephaestus/serdes/json.h
@@ -8,8 +8,6 @@
 #include <string_view>
 
 #include <nlohmann/json.hpp>
-#include <rfl.hpp>
-#include <rfl/json.hpp>
 
 #include "hephaestus/serdes/protobuf/concepts.h"
 #include "hephaestus/serdes/protobuf/protobuf.h"

--- a/modules/serdes/include/hephaestus/serdes/json.h
+++ b/modules/serdes/include/hephaestus/serdes/json.h
@@ -1,0 +1,83 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include <nlohmann/json.hpp>
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+
+#include "hephaestus/serdes/protobuf/concepts.h"
+#include "hephaestus/serdes/protobuf/protobuf.h"
+
+namespace heph::serdes {
+
+template <typename T>
+concept JSONSerializable = requires(const T& data) {
+  { toJSON(data) } -> std::convertible_to<std::string>;
+};
+
+template <typename T>
+concept JSONDeserializable = requires(T& mutable_data, std::string_view json) {
+  { fromJSON(json, mutable_data) };
+};
+
+template <typename T>
+concept NlohmannJSONSerializable = requires(const T& data) {
+  { nlohmann::json(data) } -> std::convertible_to<nlohmann::json>;
+};
+
+/// Serialize data to JSON.
+/// This is achieved by checking at compile time what serialization capabilities are provided for the input
+/// data. In order of priority, the following serialization methods are checked:
+// - Protobuf
+// - Custom `toJSON` / `fromJSON` functions
+// - Nlohmann JSON serialization
+template <class T>
+[[nodiscard]] auto serializeToJSON(const T& data) -> std::string;
+
+/// Deserialize data from JSON.
+/// See `serializeToJSON` for more details.
+template <class T>
+auto deserializeFromJSON(std::string_view json, T& data) -> void;
+
+// -----------------------------------------------------------------------------------------------
+// Specializations
+// -----------------------------------------------------------------------------------------------
+
+template <protobuf::ProtobufSerializable T>
+auto serializeToJSON(const T& data) -> std::string {
+  return protobuf::serializeToJSON(data);
+}
+
+template <JSONSerializable T>
+auto serializeToJSON(const T& data) -> std::string {
+  return toJSON(data);
+}
+
+template <NlohmannJSONSerializable T>
+auto serializeToJSON(const T& data) -> std::string {
+  const nlohmann::json j = data;
+  return j.dump();
+}
+
+template <protobuf::ProtobufSerializable T>
+auto deserializeFromJSON(std::string_view json, T& data) -> void {
+  protobuf::deserializeFromJSON(json, data);
+}
+
+template <JSONDeserializable T>
+auto deserializeFromJSON(std::string_view json, T& data) -> void {
+  fromJSON(json, data);
+}
+
+template <NlohmannJSONSerializable T>
+auto deserializeFromJSON(std::string_view json, T& data) -> void {
+  data = nlohmann::json::parse(json).get<T>();
+}
+
+}  // namespace heph::serdes

--- a/modules/serdes/include/hephaestus/serdes/protobuf/concepts.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/concepts.h
@@ -23,4 +23,7 @@ concept ProtobufConvertible = requires(T data, Proto proto) {
   { fromProto(proto, data) };
 };
 
+template <class T>
+concept ProtobufSerializable = protobuf::ProtobufMessage<typename protobuf::ProtoAssociation<T>::Type>;
+
 }  // namespace heph::serdes::protobuf

--- a/modules/serdes/include/hephaestus/serdes/serdes.h
+++ b/modules/serdes/include/hephaestus/serdes/serdes.h
@@ -3,22 +3,19 @@
 //=================================================================================================
 
 #pragma once
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
 
-#include <filesystem>
-#include <type_traits>
-
+#include "hephaestus/serdes/protobuf/concepts.h"
 #include "hephaestus/serdes/protobuf/protobuf.h"
+#include "hephaestus/serdes/type_info.h"
 
 namespace heph::serdes {
 
 template <class T>
-concept ProtobufSerializable = protobuf::ProtobufMessage<typename protobuf::ProtoAssociation<T>::Type>;
-
-template <class T>
 [[nodiscard]] auto serialize(const T& data) -> std::vector<std::byte>;
-
-template <class T>
-[[nodiscard]] auto serializeToJSON(const T& data) -> std::string;
 
 template <class T>
 [[nodiscard]] auto serializeToText(const T& data) -> std::string;
@@ -27,76 +24,38 @@ template <class T>
 auto deserialize(std::span<const std::byte> buffer, T& data) -> void;
 
 template <class T>
-auto deserializeFromJSON(std::string_view buffer, T& data) -> void;
-
-template <class T>
 auto deserializeFromText(std::string_view buffer, T& data) -> void;
 
+template <class T>
+auto getSerializedTypeInfo() -> TypeInfo;
+
 // -----------------------------------------------------------------------------------------------
-// Implementation
+// Specialization
 // -----------------------------------------------------------------------------------------------
 
-template <class T>
+template <protobuf::ProtobufSerializable T>
 auto serialize(const T& data) -> std::vector<std::byte> {
-  if constexpr (ProtobufSerializable<T>) {
-    return protobuf::serialize(data);
-  } else {
-    static_assert(ProtobufSerializable<T>, "No serialization supported");
-  }
+  return protobuf::serialize(data);
 }
 
-template <class T>
-auto serializeToJSON(const T& data) -> std::string {
-  if constexpr (ProtobufSerializable<T>) {
-    return protobuf::serializeToJSON(data);
-  } else {
-    static_assert(ProtobufSerializable<T>, "No serialization to JSON supported");
-  }
-}
-
-template <class T>
+template <protobuf::ProtobufSerializable T>
 [[nodiscard]] auto serializeToText(const T& data) -> std::string {
-  if constexpr (ProtobufSerializable<T>) {
-    return protobuf::serializeToText(data);
-  } else {
-    static_assert(ProtobufSerializable<T>, "No serialization to text supported");
-  }
+  return protobuf::serializeToText(data);
 }
 
-template <class T>
+template <protobuf::ProtobufSerializable T>
 auto deserialize(std::span<const std::byte> buffer, T& data) -> void {
-  if constexpr (ProtobufSerializable<T>) {
-    protobuf::deserialize(buffer, data);
-  } else {
-    static_assert(ProtobufSerializable<T>, "No deserialization supported");
-  }
+  protobuf::deserialize(buffer, data);
 }
 
-template <class T>
-auto deserializeFromJSON(std::string_view buffer, T& data) -> void {
-  if constexpr (ProtobufSerializable<T>) {
-    protobuf::deserializeFromJSON(buffer, data);
-  } else {
-    static_assert(ProtobufSerializable<T>, "No deserialization from JSON supported");
-  }
-}
-
-template <class T>
+template <protobuf::ProtobufSerializable T>
 auto deserializeFromText(std::string_view buffer, T& data) -> void {
-  if constexpr (ProtobufSerializable<T>) {
-    protobuf::deserializeFromText(buffer, data);
-  } else {
-    static_assert(ProtobufSerializable<T>, "No deserialization from text supported");
-  }
+  protobuf::deserializeFromText(buffer, data);
 }
 
-template <class T>
+template <protobuf::ProtobufSerializable T>
 auto getSerializedTypeInfo() -> TypeInfo {
-  if constexpr (ProtobufSerializable<T>) {
-    return protobuf::getTypeInfo<T>();
-  } else {
-    static_assert(ProtobufSerializable<T>, "No serialization supported");
-  }
+  return protobuf::getTypeInfo<T>();
 }
 
 }  // namespace heph::serdes

--- a/modules/serdes/src/json.cpp
+++ b/modules/serdes/src/json.cpp
@@ -1,0 +1,7 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#include "hephaestus/serdes/json.h"  // NOLINT(misc-include-cleaner)
+
+namespace heph::serdes {}  // namespace heph::serdes

--- a/modules/serdes/tests/tests.cpp
+++ b/modules/serdes/tests/tests.cpp
@@ -42,7 +42,7 @@ struct Data {
 };
 
 struct DummyJSONSerializable {
-  auto operator==(const DummyJSONSerializable& other) const -> bool = default;
+  auto operator==(const DummyJSONSerializable&) const -> bool = default;
   int dummy = 0;
 };
 
@@ -55,7 +55,7 @@ void fromJSON(std::string_view json, DummyJSONSerializable& data) {
 }
 
 struct DummyNlohmannJSONSerializable {
-  auto operator==(const DummyNlohmannJSONSerializable& other) const -> bool = default;
+  auto operator==(const DummyNlohmannJSONSerializable&) const -> bool = default;
   int dummy = 0;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(DummyNlohmannJSONSerializable, dummy)

--- a/modules/serdes/tests/tests.cpp
+++ b/modules/serdes/tests/tests.cpp
@@ -10,6 +10,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <nlohmann/detail/macro_scope.hpp>
 
 #include "hephaestus/serdes/json.h"
 #include "hephaestus/serdes/protobuf/buffers.h"


### PR DESCRIPTION
# Description
* Refactor serialization:
  *  Move JSON serialization to a dedicated header
  * Move to template specialization instead of  `if constexpr`
    * This makes the code cleaner
    * Has one important change: a struct cannot support multiple serialization methods -> this ensures no confusion happens when serialization/deserializing.
      * If a struct supports multiple serialization methods the compiler will complain with: `call of overloaded 'serialize(...)' is ambiguous` 
* Add JSON support:
  * with `fromJSON` / `toJSON` user-defined function
  * with `Nlohmann`   
