### PR TITLE
Feat/Expose spin counter

### DIFF
--- a/modules/concurrency/include/hephaestus/concurrency/spinner.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner.h
@@ -27,8 +27,11 @@ public:
 
   void start();
   auto stop() -> std::future<void>;
-  virtual void spinOnce() = 0;  // Pure virtual function
   void addStopCallback(std::function<void()>&& callback);
+
+  virtual void spinOnce() = 0;  //!< Override this function to define the spinner's behavior.
+
+  [[nodiscard]] auto spinCount() const -> uint64_t;
 
 private:
   void spin();

--- a/modules/concurrency/src/spinner.cpp
+++ b/modules/concurrency/src/spinner.cpp
@@ -89,4 +89,8 @@ void Spinner::addStopCallback(std::function<void()>&& callback) {
   stop_callback_ = std::move(callback);
 }
 
+auto Spinner::spinCount() const -> uint64_t {
+  return spin_count_;
+}
+
 }  // namespace heph::concurrency


### PR DESCRIPTION
# Description
Expose spin counter in `Spinner` class. This e.g. allows to use the counter to assign monotonous ids to data processed during `spinOnce`. A typical example is a `frame_id` or `frame_index`. 

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
