### PR TITLE
Spinner: refactor to move from inheritance to composition

### DIFF
--- a/modules/bag/tests/tests.cpp
+++ b/modules/bag/tests/tests.cpp
@@ -96,7 +96,7 @@ TEST(Bag, PlayAndRecord) {
 
       player.stop().get();
     }
-    // std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
+
     recorder.stop().get();
   }
 

--- a/modules/concurrency/include/hephaestus/concurrency/message_queue_consumer.h
+++ b/modules/concurrency/include/hephaestus/concurrency/message_queue_consumer.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <functional>
-#include <thread>
 
+#include "hephaestus/concurrency/spinner.h"
 #include "hephaestus/containers/blocking_queue.h"
 
 namespace heph::concurrency {
@@ -18,34 +18,44 @@ class MessageQueueConsumer {
 public:
   using Callback = std::function<void(const T&)>;
   [[nodiscard]] MessageQueueConsumer(Callback&& callback, std::optional<std::size_t> max_queue_size);
-  ~MessageQueueConsumer();
+  ~MessageQueueConsumer() = default;
   MessageQueueConsumer(const MessageQueueConsumer&) = delete;
   MessageQueueConsumer(MessageQueueConsumer&&) = delete;
   auto operator=(const MessageQueueConsumer&) -> MessageQueueConsumer& = delete;
   auto operator=(MessageQueueConsumer&&) -> MessageQueueConsumer& = delete;
 
+  void start();
+  void stop();
+
   /// Return the queue to allow to push messages to process.
   /// This is simpler than having to mask all the different type of push methods of the queue.
+  /// The downside is that it is possible to consume messages from the outside without calling the callback.
   [[nodiscard]] auto queue() -> containers::BlockingQueue<T>&;
 
 private:
-  void spin();
+  void consume();
 
 private:
   Callback callback_;
   containers::BlockingQueue<T> message_queue_;
 
-  std::thread callback_thread_;
+  Spinner spinner_;
 };
 
 template <typename T>
 MessageQueueConsumer<T>::MessageQueueConsumer(Callback&& callback, std::optional<std::size_t> max_queue_size)
-  : callback_(std::move(callback)), message_queue_(max_queue_size), callback_thread_([this] { spin(); }){};
+  : callback_(std::move(callback)), message_queue_(max_queue_size), spinner_([this] { consume(); }) {
+}
 
 template <typename T>
-MessageQueueConsumer<T>::~MessageQueueConsumer() {
+void MessageQueueConsumer<T>::start() {
+  spinner_.start();
+}
+
+template <typename T>
+void MessageQueueConsumer<T>::stop() {
   message_queue_.stop();
-  callback_thread_.join();
+  spinner_.stop();
 }
 
 template <typename T>
@@ -54,16 +64,13 @@ auto MessageQueueConsumer<T>::queue() -> containers::BlockingQueue<T>& {
 }
 
 template <typename T>
-void MessageQueueConsumer<T>::spin() {
-  // TODO: set thread name
-  while (true) {
-    auto message = message_queue_.waitAndPop();
-    if (!message.has_value()) {
-      break;
-    }
-
-    callback_(message.value());
+void MessageQueueConsumer<T>::consume() {
+  auto message = message_queue_.waitAndPop();
+  if (!message.has_value()) {
+    return;
   }
+
+  callback_(message.value());
 }
 
 }  // namespace heph::concurrency

--- a/modules/concurrency/include/hephaestus/concurrency/spinner.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner.h
@@ -18,8 +18,10 @@ namespace heph::concurrency {
 /// the given fixed rate.
 class Spinner {
 public:
-  explicit Spinner(double rate_hz = 0);
-  virtual ~Spinner();
+  using Callback = std::function<void()>;
+
+  explicit Spinner(Callback&& callback, double rate_hz = 0);
+  ~Spinner();
   Spinner(const Spinner&) = delete;
   auto operator=(const Spinner&) -> Spinner& = delete;
   Spinner(Spinner&&) = delete;
@@ -27,9 +29,6 @@ public:
 
   void start();
   auto stop() -> std::future<void>;
-  void addStopCallback(std::function<void()>&& callback);
-
-  virtual void spinOnce() = 0;  //!< Override this function to define the spinner's behavior.
 
   [[nodiscard]] auto spinCount() const -> uint64_t;
 
@@ -38,9 +37,10 @@ private:
   void stopImpl();
 
 private:
+  Callback callback_;
+
   std::atomic_bool is_started_ = false;
   std::atomic_bool stop_requested_ = false;
-  std::function<void()> stop_callback_;
   std::thread spinner_thread_;
 
   std::chrono::microseconds spin_period_;

--- a/modules/concurrency/src/spinner.cpp
+++ b/modules/concurrency/src/spinner.cpp
@@ -31,8 +31,11 @@ namespace {
 }
 }  // namespace
 
-Spinner::Spinner(double rate_hz /*= 0*/)
-  : is_started_(false), stop_requested_(false), spin_period_(rateHzToMicroseconds(rate_hz)) {
+Spinner::Spinner(Callback&& callback, double rate_hz /*= 0*/)
+  : callback_(std::move(callback))
+  , is_started_(false)
+  , stop_requested_(false)
+  , spin_period_(rateHzToMicroseconds(rate_hz)) {
 }
 
 Spinner::~Spinner() {
@@ -55,13 +58,15 @@ void Spinner::spin() {
   start_timestamp_ = std::chrono::system_clock::now();
 
   while (!stop_requested_.load()) {
-    spinOnce();
+    callback_();
+
+    ++spin_count_;
 
     if (spin_period_.count() == 0) {
       continue;
     }
 
-    const auto target_timestamp = start_timestamp_ + (++spin_count_) * spin_period_;
+    const auto target_timestamp = start_timestamp_ + spin_count_ * spin_period_;
     std::unique_lock<std::mutex> lock(mutex_);
     condition_.wait_until(lock, target_timestamp);
   }
@@ -78,15 +83,7 @@ auto Spinner::stop() -> std::future<void> {
 void Spinner::stopImpl() {
   spinner_thread_.join();
 
-  if (stop_callback_) {
-    stop_callback_();
-  }
-
   is_started_.store(false);
-}
-
-void Spinner::addStopCallback(std::function<void()>&& callback) {
-  stop_callback_ = std::move(callback);
 }
 
 auto Spinner::spinCount() const -> uint64_t {

--- a/modules/concurrency/src/spinner.cpp
+++ b/modules/concurrency/src/spinner.cpp
@@ -55,6 +55,8 @@ void Spinner::start() {
 }
 
 void Spinner::spin() {
+  // TODO: set thread name
+
   start_timestamp_ = std::chrono::system_clock::now();
 
   while (!stop_requested_.load()) {

--- a/modules/concurrency/src/spinner.cpp
+++ b/modules/concurrency/src/spinner.cpp
@@ -19,7 +19,7 @@
 
 namespace heph::concurrency {
 namespace {
-[[nodiscard]] auto rateHzToMicroseconds(double rate_hz) -> std::chrono::microseconds {
+[[nodiscard]] auto rateToPeriod(double rate_hz) -> std::chrono::microseconds {
   if (rate_hz == 0) {
     return std::chrono::microseconds{ 0 };
   }
@@ -35,7 +35,7 @@ Spinner::Spinner(Callback&& callback, double rate_hz /*= 0*/)
   : callback_(std::move(callback))
   , is_started_(false)
   , stop_requested_(false)
-  , spin_period_(rateHzToMicroseconds(rate_hz)) {
+  , spin_period_(rateToPeriod(rate_hz)) {
 }
 
 Spinner::~Spinner() {

--- a/modules/concurrency/tests/queue_consumer_tests.cpp
+++ b/modules/concurrency/tests/queue_consumer_tests.cpp
@@ -45,7 +45,7 @@ TEST(MessageQueueConsumer, ProcessMessages) {
                                           }
                                         },
                                          MESSAGE_COUNT };
-
+  spinner.start();
   auto mt = random::createRNG();
   std::vector<Message> messages(MESSAGE_COUNT);
   std::for_each(messages.begin(), messages.end(),
@@ -57,6 +57,8 @@ TEST(MessageQueueConsumer, ProcessMessages) {
   flag.wait(false);
 
   EXPECT_EQ(messages, processed_messages);
+
+  spinner.stop();
 }
 
 }  // namespace heph::concurrency::tests

--- a/modules/concurrency/tests/spinner_tests.cpp
+++ b/modules/concurrency/tests/spinner_tests.cpp
@@ -44,7 +44,7 @@ TEST(SpinnerTest, StopCallback) {
   static constexpr auto WAIT_FOR = std::chrono::milliseconds{ 10 };
 
   std::size_t callback_called_counter = 0;
-  Spinner spinner([&callback_called_counter] { ++callback_called_counter; });
+  Spinner spinner([&callback_called_counter]() { ++callback_called_counter; });
 
   spinner.start();
   std::this_thread::sleep_for(WAIT_FOR);

--- a/modules/ipc/src/zenoh/subscriber.cpp
+++ b/modules/ipc/src/zenoh/subscriber.cpp
@@ -48,10 +48,15 @@ Subscriber::Subscriber(SessionPtr session, TopicConfig topic_config, DataCallbac
           callback_(metadata, std::span<const std::byte>(buffer.begin(), buffer.end()));
         },
         DEFAULT_CACHE_RESERVES);
+    callback_messages_consumer_->start();
   }
 }
 
 Subscriber::~Subscriber() {
+  if (callback_messages_consumer_ != nullptr) {
+    callback_messages_consumer_->stop();
+  }
+
   z_drop(z_move(cache_subscriber_));
 }
 


### PR DESCRIPTION
# Description
Spinner class now follows the composition pattern. 

Update MessageQueueConsumer to use the Spinner class instead of re-implementing the logic.