### PR TITLE
Fix: bug in Telemetry; update cmake build tests target name; update CI test step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,9 @@ jobs:
       run: cmake --build ${{github.workspace}}/build -- all examples
 
     - name: Test
-      # working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: cd ${{github.workspace}}/build && ninja check
+      run: |
+        cd ${{github.workspace}}/build
+        ninja tests_build
+        ninja test

--- a/cmake/05_modules.cmake
+++ b/cmake/05_modules.cmake
@@ -573,11 +573,11 @@ set_target_properties(gmock_main PROPERTIES CXX_CLANG_TIDY "")
 
 # ==================================================================================================
 # Adds a custom target to group all test programs built on call to `make tests`
-set(TESTS_TARGET tests)
+set(TESTS_BUILD_TARGET tests_build)
 if(BUILD_AS_SUBPROJECT)
-  set(TESTS_TARGET "${PROJECT_NAME}_${TESTS_TARGET}")
+  set(TESTS_BUILD_TARGET "${PROJECT_NAME}_${TESTS_BUILD_TARGET}")
 endif()
-add_custom_target(${TESTS_TARGET} COMMENT "Building tests")
+add_custom_target(${TESTS_BUILD_TARGET} COMMENT "Building tests")
 
 # ==================================================================================================
 # Adds a custom convenience target to run all tests and generate report on 'make check'
@@ -591,7 +591,7 @@ add_custom_target(
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   COMMENT "Building and running tests"
 )
-add_dependencies(${CHECK_TARGET} ${TESTS_TARGET}) # `check` depends on `tests` target
+add_dependencies(${CHECK_TARGET} ${TESTS_BUILD_TARGET}) # `check` depends on `tests` target
 
 # ==================================================================================================
 # macro: define_module_test
@@ -643,7 +643,7 @@ macro(define_module_test)
             ${TARGET_ARG_PRIVATE_LINK_LIBS} GTest::gtest GTest::gmock GTest::gtest_main GTest::gmock_main
   )
 
-  add_dependencies(${TESTS_TARGET} ${TARGET_NAME}) # Set this to be built on `make tests`
+  add_dependencies(${TESTS_BUILD_TARGET} ${TARGET_NAME}) # Set this to be built on `make tests`
 
   if(NOT BUILD_AS_SUBPROJECT)
     # Add to cmake tests (call using ctest)

--- a/modules/telemetry/telemetry/src/metric_record.cpp
+++ b/modules/telemetry/telemetry/src/metric_record.cpp
@@ -88,6 +88,12 @@ auto jsonToValuesMap(std::string_view json) -> std::unordered_map<std::string, M
 class MetricRecorder {
 public:
   explicit MetricRecorder();
+  ~MetricRecorder();
+  MetricRecorder(const MetricRecorder&) = delete;
+  MetricRecorder(MetricRecorder&&) = delete;
+  auto operator=(const MetricRecorder&) -> MetricRecorder& = delete;
+  auto operator=(MetricRecorder&&) -> MetricRecorder& = delete;
+
   static void registerSink(std::unique_ptr<IMetricSink> sink);
 
   static void record(const Metric& metric);
@@ -112,6 +118,11 @@ void record(const Metric& metric) {
 
 MetricRecorder::MetricRecorder()
   : entries_consumer_([this](const Metric& entry) { processEntries(entry); }, std::nullopt) {
+  entries_consumer_.start();
+}
+
+MetricRecorder::~MetricRecorder() {
+  entries_consumer_.stop();
 }
 
 auto MetricRecorder::instance() -> MetricRecorder& {

--- a/modules/telemetry/telemetry/tests/metric_record_tests.cpp
+++ b/modules/telemetry/telemetry/tests/metric_record_tests.cpp
@@ -33,10 +33,8 @@ class MockMetricSink final : public IMetricSink {
 public:
   void send(const Metric& metric) override {
     measure_entries_.push_back(metric);
-    fmt::println("Received metric");
     flag_.test_and_set();
     flag_.notify_all();
-    fmt::println("Received metric: notified");
   }
 
   [[nodiscard]] auto getMeasureEntries() const -> const std::vector<Metric>& {
@@ -44,9 +42,7 @@ public:
   }
 
   void wait() const {
-    fmt::println("Waiting for metric");
     flag_.wait(false);
-    fmt::println("Waiting completed");
   }
 
 private:

--- a/modules/telemetry/telemetry/tests/metric_record_tests.cpp
+++ b/modules/telemetry/telemetry/tests/metric_record_tests.cpp
@@ -33,8 +33,10 @@ class MockMetricSink final : public IMetricSink {
 public:
   void send(const Metric& metric) override {
     measure_entries_.push_back(metric);
+    fmt::println("Received metric");
     flag_.test_and_set();
     flag_.notify_all();
+    fmt::println("Received metric: notified");
   }
 
   [[nodiscard]] auto getMeasureEntries() const -> const std::vector<Metric>& {
@@ -42,7 +44,9 @@ public:
   }
 
   void wait() const {
+    fmt::println("Waiting for metric");
     flag_.wait(false);
+    fmt::println("Waiting completed");
   }
 
 private:


### PR DESCRIPTION
# Description
* Fix bug in telemetry due to the missed update after the spinner change
* update cmake build tests target name from `tests` to `tests_build`
* update CI from running `check` -> `tests_build` && `test`
 * provide better logging, as it displays progress

