### PR TITLE
Fix: Cmake module update add project prefix

### DIFF
--- a/cmake/05_modules.cmake
+++ b/cmake/05_modules.cmake
@@ -68,7 +68,7 @@ function(enumerate_modules)
       ON
       CACHE INTERNAL "Enumeration of modules in progress"
   )
-  message(STATUS "Enumerating ${PROJID} modules")
+  message(STATUS "Enumerating ${PROJECT_NAME} modules")
   foreach(_module IN LISTS _module_paths)
     if(NOT ${_module} STREQUAL ${CMAKE_CURRENT_LIST_FILE}) # avoid recursion
       message(VERBOSE "  Parsing ${_module}")
@@ -120,6 +120,7 @@ macro(configure_modules)
   get_property(_enabled_modules_list GLOBAL PROPERTY ENABLED_MODULES)
 
   # Add each marked module into the build
+  message("\n\n${_enabled_modules_list}\n\n")
   foreach(_module IN LISTS _enabled_modules_list)
     message(VERBOSE "Adding subdirectory ${MODULE_${_module}_PATH} for module ${_module}")
     add_subdirectory(${MODULE_${_module}_PATH})
@@ -168,6 +169,8 @@ macro(declare_module)
     message(FATAL_ERROR "NAME not specified")
   endif()
 
+  set(MODULE_ARG_NAME "${PROJECT_NAME}_${MODULE_ARG_NAME}")
+
   # Either have it always build, or allow user to choose at configuration-time
   if(("${MODULE_ARG_NAME}" IN_LIST BUILD_MODULES)
      OR (("all" IN_LIST BUILD_MODULES) AND NOT MODULE_ARG_EXCLUDE_FROM_ALL)
@@ -196,6 +199,13 @@ macro(declare_module)
         "${CMAKE_CURRENT_LIST_DIR}"
         CACHE INTERNAL "location of ${MODULE_ARG_NAME}"
     )
+
+    # Update the dependency list
+    set(NEW_LIST "")
+    foreach(module ${MODULE_ARG_DEPENDS_ON_MODULES})
+      list(APPEND NEW_LIST "${PROJECT_NAME}_${module}")
+    endforeach()
+    set(MODULE_ARG_DEPENDS_ON_MODULES ${NEW_LIST})
     set(MODULE_${MODULE_ARG_NAME}_DEPENDS_ON
         ${MODULE_ARG_DEPENDS_ON_MODULES}
         CACHE INTERNAL "Dependencies of ${MODULE_ARG_NAME}"

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -26,7 +26,7 @@ if(Protobuf IN_LIST EXTERNAL_PROJECTS_LIST)
   list(APPEND EXTERNAL_PROJECTS_LIST ${PROTOBUF_DEPENDS})
 endif()
 
-if(influxdb IN_LIST EXTERNAL_PROJECTS_LIST)
+if(InfluxDB IN_LIST EXTERNAL_PROJECTS_LIST)
   set(INFLUXDB_DEPENDS cpr curl)
   list(APPEND EXTERNAL_PROJECTS_LIST ${INFLUXDB_DEPENDS})
 endif()
@@ -181,7 +181,7 @@ add_cmake_dependency(
 # influxdb
 set(INFLUXDB_GIT_TAG 8d8ab3b5ddc40b767a3ebf5eb1df76aa170dbca9)
 add_cmake_dependency(
-  NAME influxdb
+  NAME InfluxDB
   DEPENDS ${INFLUXDB_DEPENDS} URL https://github.com/offa/influxdb-cxx/archive/${INFLUXDB_GIT_TAG}.zip
   CMAKE_ARGS -DINFLUXCXX_WITH_BOOST=OFF -DINFLUXCXX_TESTING=OFF -DINFLUXCXX_SYSTEMTEST=OFF
 )

--- a/modules/telemetry/telemetry_influxdb_sink/CMakeLists.txt
+++ b/modules/telemetry/telemetry_influxdb_sink/CMakeLists.txt
@@ -5,7 +5,7 @@
 declare_module(
   NAME telemetry_influxdb_sink
   DEPENDS_ON_MODULES concurrency random serdes telemetry
-  DEPENDS_ON_EXTERNAL_PROJECTS influxdb fmt
+  DEPENDS_ON_EXTERNAL_PROJECTS InfluxDB fmt
 )
 
 find_package(InfluxDB REQUIRED)


### PR DESCRIPTION
# Description
When using Hephaestus as a submodule, if you create a new module with the same name of a module in hephaestus you will get a clash.

This change add internally the project name as a suffix to the module so that we can distinguish.

Minor: fix influxdb name to make it match the module.