### PR TITLE
[Fix: Cmake] properly set module prefix

### DIFF
--- a/cmake/05_modules.cmake
+++ b/cmake/05_modules.cmake
@@ -169,10 +169,11 @@ macro(declare_module)
     message(FATAL_ERROR "NAME not specified")
   endif()
 
+  set(MODULE_ARG_NAME_NO_PREFIX ${MODULE_ARG_NAME})
   set(MODULE_ARG_NAME "${PROJECT_NAME}_${MODULE_ARG_NAME}")
 
   # Either have it always build, or allow user to choose at configuration-time
-  if(("${MODULE_ARG_NAME}" IN_LIST BUILD_MODULES)
+  if(("${MODULE_ARG_NAME_NO_PREFIX}" IN_LIST BUILD_MODULES)
      OR (("all" IN_LIST BUILD_MODULES) AND NOT MODULE_ARG_EXCLUDE_FROM_ALL)
      OR MODULE_ARG_ALWAYS_BUILD
   )
@@ -200,7 +201,12 @@ macro(declare_module)
         CACHE INTERNAL "location of ${MODULE_ARG_NAME}"
     )
 
-    # Update the dependency list
+    set(MODULE_${MODULE_ARG_NAME}_DEPENDS_ON_NO_PREFIX
+        ${MODULE_ARG_DEPENDS_ON_MODULES}
+        CACHE INTERNAL "Dependencies of ${MODULE_ARG_NAME} withot prefix"
+    )
+
+    # Add prefix
     set(NEW_LIST "")
     foreach(module ${MODULE_ARG_DEPENDS_ON_MODULES})
       list(APPEND NEW_LIST "${PROJECT_NAME}_${module}")
@@ -370,7 +376,7 @@ macro(define_module_example)
     message(FATAL_ERROR "Executable name not specified")
   endif()
 
-  set(TARGET_NAME ${PROJECT_NAME}_${MODULE_NAME}_${TARGET_ARG_NAME})
+  set(TARGET_NAME ${MODULE_NAME}_${TARGET_ARG_NAME})
 
   add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL ${TARGET_ARG_SOURCES})
   add_clang_format(${TARGET_NAME})
@@ -635,7 +641,7 @@ macro(define_module_test)
     message(FATAL_ERROR "Executable name not specified")
   endif()
 
-  set(TARGET_NAME ${PROJECT_NAME}_${MODULE_NAME}_${TARGET_ARG_NAME})
+  set(TARGET_NAME ${MODULE_NAME}_${TARGET_ARG_NAME})
 
   add_executable(${TARGET_NAME} EXCLUDE_FROM_ALL ${TARGET_ARG_SOURCES}) # Don't build on `make`
   add_clang_format(${TARGET_NAME})
@@ -683,9 +689,9 @@ function(install_modules)
   foreach(_module IN LISTS _enabled_modules_list)
 
     # These variables are copied into module-config.cmake.in to set up dependencies
-    set(INSTALL_MODULE_NAME ${PROJECT_NAME}_${_module})
+    set(INSTALL_MODULE_NAME ${_module})
     set(INSTALL_MODULE_LIB_TARGETS ${MODULE_${_module}_LIB_TARGETS})
-    set(INSTALL_MODULE_INTERNAL_DEPENDENCIES ${MODULE_${_module}_DEPENDS_ON})
+    set(INSTALL_MODULE_INTERNAL_DEPENDENCIES ${MODULE_${_module}_DEPENDS_ON_NO_PREFIX})
     set(INSTALL_MODULE_EXTERNAL_DEPENDENCIES ${MODULE_${_module}_EXTERNAL_PROJECT_DEPS})
 
     set(config_create_location ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cmake/${INSTALL_MODULE_NAME})

--- a/modules/examples/examples/zenoh_action_server.cpp
+++ b/modules/examples/examples/zenoh_action_server.cpp
@@ -24,15 +24,15 @@
 #include "hephaestus/utils/stack_trace.h"
 #include "zenoh_program_options.h"
 
-[[nodiscard]] auto
-request(const heph::examples::types::SampleRequest& sample) -> heph::ipc::zenoh::TriggerStatus {
+[[nodiscard]] auto request(const heph::examples::types::SampleRequest& sample)
+    -> heph::ipc::zenoh::action_server::TriggerStatus {
   LOG(INFO) << fmt::format("Request received: {}", sample);
   if (sample.iterations_count == 0) {
     LOG(ERROR) << "Invalid request, iterations must be greater than 0";
-    return heph::ipc::zenoh::TriggerStatus::REJECTED;
+    return heph::ipc::zenoh::action_server::TriggerStatus::REJECTED;
   }
 
-  return heph::ipc::zenoh::TriggerStatus::SUCCESSFUL;
+  return heph::ipc::zenoh::action_server::TriggerStatus::SUCCESSFUL;
 }
 
 [[nodiscard]] auto execute(const heph::examples::types::SampleRequest& request,
@@ -84,16 +84,17 @@ auto main(int argc, const char* argv[]) -> int {
       return execute(sample, publisher, stop_requested);
     };
 
-    const heph::ipc::zenoh::ActionServer<heph::examples::types::SampleRequest,
-                                         heph::examples::types::SampleReply,
-                                         heph::examples::types::SampleReply>
+    const heph::ipc::zenoh::action_server::ActionServer<heph::examples::types::SampleRequest,
+                                                        heph::examples::types::SampleReply,
+                                                        heph::examples::types::SampleReply>
         action_server(session, topic_config, request_callback, execute_callback);
 
     LOG(INFO) << fmt::format("Action Server started. Wating for queries on '{}' topic", topic_config.name);
 
     heph::utils::TerminationBlocker::registerInterruptCallback(
         [stop_session = std::ref(*stop_session), &topic_config] {
-          std::ignore = heph::ipc::zenoh::requestActionServerToStopExecution(stop_session, topic_config);
+          std::ignore =
+              heph::ipc::zenoh::action_server::requestActionServerToStopExecution(stop_session, topic_config);
         });
 
     heph::utils::TerminationBlocker::waitForInterrupt();

--- a/modules/examples/examples/zenoh_action_server_client.cpp
+++ b/modules/examples/examples/zenoh_action_server_client.cpp
@@ -32,7 +32,8 @@ auto main(int argc, const char* argv[]) -> int {
     auto session = heph::ipc::zenoh::createSession(std::move(session_config));
 
     heph::utils::TerminationBlocker::registerInterruptCallback([session = std::ref(*session), &topic_config] {
-      std::ignore = heph::ipc::zenoh::requestActionServerToStopExecution(session, topic_config);
+      std::ignore =
+          heph::ipc::zenoh::action_server::requestActionServerToStopExecution(session, topic_config);
     });
 
     auto status_update_cb = [](const heph::examples::types::SampleReply& sample) {
@@ -45,10 +46,11 @@ auto main(int argc, const char* argv[]) -> int {
       .initial_value = START,
       .iterations_count = ITERATIONS,
     };
-    auto result_future = heph::ipc::zenoh::callActionServer<heph::examples::types::SampleRequest,
-                                                            heph::examples::types::SampleReply,
-                                                            heph::examples::types::SampleReply>(
-        session, topic_config, target, status_update_cb);
+    auto result_future =
+        heph::ipc::zenoh::action_server::callActionServer<heph::examples::types::SampleRequest,
+                                                          heph::examples::types::SampleReply,
+                                                          heph::examples::types::SampleReply>(
+            session, topic_config, target, status_update_cb);
 
     LOG(INFO) << fmt::format("Call to Action Server (topic: '{}') started. Wating for result.",
                              topic_config.name);


### PR DESCRIPTION
# Description
In a previous PR (https://github.com/olympus-robotics/hephaestus/pull/145)  I fixed cmake to add the project as prefix to the module name, to make Hephaestus properly work when it is used as a submodule. 
The fix was incomplete, as it was not accounting for all the places where the module is used. Hopefully, now it works better.