### PR TITLE
String utils: add toLower; add string to double; fix interface

### DIFF
--- a/modules/bag/src/writer.cpp
+++ b/modules/bag/src/writer.cpp
@@ -4,7 +4,6 @@
 
 #include "hephaestus/bag/writer.h"
 
-#include <algorithm>
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
@@ -14,6 +13,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include <absl/strings/ascii.h>
 #include <fmt/core.h>
 #include <magic_enum.hpp>
 #include <mcap/types.hpp>
@@ -28,8 +28,7 @@ namespace {
 
 [[nodiscard]] auto serializationType(const serdes::TypeInfo::Serialization& serialization) -> std::string {
   auto schema_type = std::string{ magic_enum::enum_name(serialization) };
-  std::transform(schema_type.begin(), schema_type.end(), schema_type.begin(),
-                 [](char c) { return std::tolower(c); });
+  absl::AsciiStrToLower(&schema_type);
   return schema_type;
 }
 

--- a/modules/telemetry/telemetry/src/metric_record.cpp
+++ b/modules/telemetry/telemetry/src/metric_record.cpp
@@ -45,7 +45,7 @@ namespace {
     auto value_str = json_value.get<std::string>();
     // According to JSON specification integer bigger than 32bits are converted to string, so we need to check
     // if the string is actually a number.
-    if (const auto value_i = utils::string::stringToInt64(value_str); value_i.has_value()) {
+    if (const auto value_i = utils::string::stringTo<int64_t>(value_str); value_i.has_value()) {
       return value_i.value();
     }
 

--- a/modules/telemetry/telemetry/src/metric_record.cpp
+++ b/modules/telemetry/telemetry/src/metric_record.cpp
@@ -17,12 +17,12 @@
 
 #include <absl/base/thread_annotations.h>
 #include <absl/log/log.h>
+#include <absl/strings/numbers.h>
 #include <fmt/core.h>
 #include <nlohmann/json_fwd.hpp>
 
 #include "hephaestus/concurrency/message_queue_consumer.h"
 #include "hephaestus/telemetry/metric_sink.h"
-#include "hephaestus/utils/string/string_utils.h"
 
 namespace heph::telemetry {
 
@@ -45,8 +45,9 @@ namespace {
     auto value_str = json_value.get<std::string>();
     // According to JSON specification integer bigger than 32bits are converted to string, so we need to check
     // if the string is actually a number.
-    if (const auto value_i = utils::string::stringTo<int64_t>(value_str); value_i.has_value()) {
-      return value_i.value();
+    int64_t value{};
+    if (const auto success = absl::SimpleAtoi(value_str, &value); success) {
+      return value;
     }
 
     return value_str;

--- a/modules/utils/include/hephaestus/utils/string/string_utils.h
+++ b/modules/utils/include/hephaestus/utils/string/string_utils.h
@@ -37,11 +37,6 @@ namespace heph::utils::string {
 /// camelCase -> CAMEL_CASE
 [[nodiscard]] auto toScreamingSnakeCase(std::string_view camel_case) -> std::string;
 
-template <typename T>
-concept Int64OrDouble = std::is_same_v<T, int64_t> || std::is_same_v<T, double>;
-template <Int64OrDouble T>
-[[nodiscard]] auto stringTo(std::string_view str) -> std::optional<T>;
-
 //=================================================================================================
 // Implementation
 //=================================================================================================
@@ -56,18 +51,6 @@ constexpr auto truncate(std::string_view str, std::string_view start_token, std:
 
   return (start_pos != std::string_view::npos) ? str.substr(start_pos, end_pos - start_pos) :
                                                  str.substr(0, end_pos);
-}
-
-template <Int64OrDouble T>
-auto stringTo(std::string_view str) -> std::optional<T> {
-  std::istringstream iss(std::string{ str });  // From C++26 we would be able to pass a string_view directly.
-  T result = 0;
-
-  if (!(iss >> std::noskipws >> result) || iss.peek() != EOF) {
-    return std::nullopt;
-  }
-
-  return result;
 }
 
 }  // namespace heph::utils::string

--- a/modules/utils/include/hephaestus/utils/string/string_utils.h
+++ b/modules/utils/include/hephaestus/utils/string/string_utils.h
@@ -25,12 +25,6 @@ namespace heph::utils::string {
                                       std::string_view end_token = std::string_view(""),
                                       bool include_end_token = true) -> std::string_view;
 
-/// aNy_CaSe -> ANY_CASE
-[[nodiscard]] auto toUpperCase(std::string_view any_case) -> std::string;
-
-/// aNy_CaSe -> any_case
-[[nodiscard]] auto toLowerCase(std::string_view any_case) -> std::string;
-
 /// camelCase -> camel_case
 [[nodiscard]] auto toSnakeCase(std::string_view camel_case) -> std::string;
 

--- a/modules/utils/include/hephaestus/utils/string/string_utils.h
+++ b/modules/utils/include/hephaestus/utils/string/string_utils.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <optional>
+#include <sstream>
 #include <string>
 
 namespace heph::utils::string {
@@ -25,15 +26,20 @@ namespace heph::utils::string {
                                       bool include_end_token = true) -> std::string_view;
 
 /// aNy_CaSe -> ANY_CASE
-[[nodiscard]] auto toUpperCase(const std::string_view& any_case) -> std::string;
+[[nodiscard]] auto toUpperCase(std::string_view any_case) -> std::string;
+
+[[nodiscard]] auto toLowerCase(std::string_view any_case) -> std::string;
 
 /// camelCase -> camel_case
-[[nodiscard]] auto toSnakeCase(const std::string_view& camel_case) -> std::string;
+[[nodiscard]] auto toSnakeCase(std::string_view camel_case) -> std::string;
 
 /// camelCase -> CAMEL_CASE
-[[nodiscard]] auto toScreamingSnakeCase(const std::string_view& camel_case) -> std::string;
+[[nodiscard]] auto toScreamingSnakeCase(std::string_view camel_case) -> std::string;
 
-[[nodiscard]] auto stringToInt64(const std::string& str) -> std::optional<int64_t>;
+template <typename T>
+concept IntOrDouble = std::is_same_v<T, int64_t> || std::is_same_v<T, double>;
+template <IntOrDouble T>
+[[nodiscard]] auto stringTo(const std::string& str) -> std::optional<T>;
 
 //=================================================================================================
 // Implementation
@@ -49,6 +55,18 @@ constexpr auto truncate(std::string_view str, std::string_view start_token, std:
 
   return (start_pos != std::string_view::npos) ? str.substr(start_pos, end_pos - start_pos) :
                                                  str.substr(0, end_pos);
+}
+
+template <IntOrDouble T>
+auto stringTo(const std::string& str) -> std::optional<T> {
+  std::istringstream iss(str);
+  T result = 0;
+
+  if (!(iss >> std::noskipws >> result) || iss.peek() != EOF) {
+    return std::nullopt;
+  }
+
+  return result;
 }
 
 }  // namespace heph::utils::string

--- a/modules/utils/include/hephaestus/utils/string/string_utils.h
+++ b/modules/utils/include/hephaestus/utils/string/string_utils.h
@@ -28,6 +28,7 @@ namespace heph::utils::string {
 /// aNy_CaSe -> ANY_CASE
 [[nodiscard]] auto toUpperCase(std::string_view any_case) -> std::string;
 
+/// aNy_CaSe -> any_case
 [[nodiscard]] auto toLowerCase(std::string_view any_case) -> std::string;
 
 /// camelCase -> camel_case
@@ -37,9 +38,9 @@ namespace heph::utils::string {
 [[nodiscard]] auto toScreamingSnakeCase(std::string_view camel_case) -> std::string;
 
 template <typename T>
-concept IntOrDouble = std::is_same_v<T, int64_t> || std::is_same_v<T, double>;
-template <IntOrDouble T>
-[[nodiscard]] auto stringTo(const std::string& str) -> std::optional<T>;
+concept Int64OrDouble = std::is_same_v<T, int64_t> || std::is_same_v<T, double>;
+template <Int64OrDouble T>
+[[nodiscard]] auto stringTo(std::string_view str) -> std::optional<T>;
 
 //=================================================================================================
 // Implementation
@@ -57,9 +58,9 @@ constexpr auto truncate(std::string_view str, std::string_view start_token, std:
                                                  str.substr(0, end_pos);
 }
 
-template <IntOrDouble T>
-auto stringTo(const std::string& str) -> std::optional<T> {
-  std::istringstream iss(str);
+template <Int64OrDouble T>
+auto stringTo(std::string_view str) -> std::optional<T> {
+  std::istringstream iss(std::string{ str });  // From C++26 we would be able to pass a string_view directly.
   T result = 0;
 
   if (!(iss >> std::noskipws >> result) || iss.peek() != EOF) {

--- a/modules/utils/src/string/string_utils.cpp
+++ b/modules/utils/src/string/string_utils.cpp
@@ -6,18 +6,14 @@
 
 #include <algorithm>
 #include <cctype>
-#include <charconv>
-#include <cstdint>
 #include <cstdio>
 #include <iterator>
-#include <optional>
 #include <string>
 #include <string_view>
-#include <system_error>
 
 namespace heph::utils::string {
 
-auto toUpperCase(const std::string_view& any_case) -> std::string {
+auto toUpperCase(std::string_view any_case) -> std::string {
   std::string upper_case;
   upper_case.reserve(any_case.size());
   std::transform(any_case.begin(), any_case.end(), std::back_inserter(upper_case),
@@ -26,7 +22,16 @@ auto toUpperCase(const std::string_view& any_case) -> std::string {
   return upper_case;
 }
 
-auto toSnakeCase(const std::string_view& camel_case) -> std::string {
+auto toLowerCase(std::string_view any_case) -> std::string {
+  std::string lower_case;
+  lower_case.reserve(any_case.size());
+  std::transform(any_case.begin(), any_case.end(), std::back_inserter(lower_case),
+                 [](unsigned char c) { return std::tolower(c); });
+
+  return lower_case;
+}
+
+auto toSnakeCase(std::string_view camel_case) -> std::string {
   std::string snake_case;
   snake_case.reserve(camel_case.size() * 2);  // Reserve enough space to avoid reallocations
 
@@ -44,21 +49,9 @@ auto toSnakeCase(const std::string_view& camel_case) -> std::string {
   return snake_case;
 }
 
-auto toScreamingSnakeCase(const std::string_view& camel_case) -> std::string {
+auto toScreamingSnakeCase(std::string_view camel_case) -> std::string {
   auto snake_case = toSnakeCase(camel_case);
   return toUpperCase(snake_case);
-}
-
-auto stringToInt64(const std::string& str) -> std::optional<int64_t> {
-  int64_t result = 0;
-  const auto* end = str.data() + str.size();  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-  const auto [ptr, ec] = std::from_chars(str.data(), end, result);
-
-  if (ec == std::errc() && ptr == end) {
-    return result;
-  }
-
-  return std::nullopt;
 }
 
 }  // namespace heph::utils::string

--- a/modules/utils/src/string/string_utils.cpp
+++ b/modules/utils/src/string/string_utils.cpp
@@ -4,32 +4,14 @@
 
 #include "hephaestus/utils/string/string_utils.h"
 
-#include <algorithm>
 #include <cctype>
 #include <cstdio>
-#include <iterator>
 #include <string>
 #include <string_view>
 
+#include <absl/strings/ascii.h>
+
 namespace heph::utils::string {
-
-auto toUpperCase(std::string_view any_case) -> std::string {
-  std::string upper_case;
-  upper_case.reserve(any_case.size());
-  std::transform(any_case.begin(), any_case.end(), std::back_inserter(upper_case),
-                 [](unsigned char c) { return std::toupper(c); });
-
-  return upper_case;
-}
-
-auto toLowerCase(std::string_view any_case) -> std::string {
-  std::string lower_case;
-  lower_case.reserve(any_case.size());
-  std::transform(any_case.begin(), any_case.end(), std::back_inserter(lower_case),
-                 [](unsigned char c) { return std::tolower(c); });
-
-  return lower_case;
-}
 
 auto toSnakeCase(std::string_view camel_case) -> std::string {
   std::string snake_case;
@@ -51,7 +33,7 @@ auto toSnakeCase(std::string_view camel_case) -> std::string {
 
 auto toScreamingSnakeCase(std::string_view camel_case) -> std::string {
   auto snake_case = toSnakeCase(camel_case);
-  return toUpperCase(snake_case);
+  return absl::AsciiStrToUpper(snake_case);
 }
 
 }  // namespace heph::utils::string

--- a/modules/utils/src/utils.cpp
+++ b/modules/utils/src/utils.cpp
@@ -2,6 +2,20 @@
 // Copyright (C) 2023-2024 HEPHAESTUS Contributors
 //=================================================================================================
 
-#include "hephaestus/utils/utils.h"  // NOLINT(misc-include-cleaner)
+#include "hephaestus/utils/utils.h"
 
-namespace heph::utils {}  // namespace heph::utils
+#include <string>
+
+#include <sys/param.h>  // NOLINT(misc-include-cleaner)
+#include <unistd.h>
+
+namespace heph::utils {
+auto getHostName() -> std::string {
+  char host_name[MAXHOSTNAMELEN + 1] = { '\0' };  // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                  // misc-include-cleaner)
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+  const auto ret = ::gethostname(host_name, sizeof(host_name));
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+  return ((ret == 0) ? (std::string(host_name)) : (""));
+}
+}  // namespace heph::utils

--- a/modules/utils/tests/string_utils_tests.cpp
+++ b/modules/utils/tests/string_utils_tests.cpp
@@ -3,12 +3,9 @@
 //=================================================================================================
 
 #include <array>
-#include <cstdint>
-#include <optional>
 #include <string>
 #include <string_view>
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "hephaestus/utils/string/string_utils.h"

--- a/modules/utils/tests/string_utils_tests.cpp
+++ b/modules/utils/tests/string_utils_tests.cpp
@@ -75,20 +75,6 @@ TEST(StringUtilsTests, Truncate) {
   static_assert(CONSTEXPR_TRUNCATED == CONSTEXPR_TEST_CASE.expected);
 }
 
-TEST(StringUtilsTests, toUpperCase) {
-  const std::string test_string = "aNy_TEST_CaSe_42!";
-  const auto upper_case = toUpperCase(test_string);
-
-  EXPECT_EQ(upper_case, "ANY_TEST_CASE_42!");
-}
-
-TEST(StringUtilsTests, toLowerCase) {
-  const std::string test_string = "aNy_TEST_CaSe_42!";
-  const auto upper_case = toLowerCase(test_string);
-
-  EXPECT_EQ(upper_case, "any_test_case_42!");
-}
-
 TEST(StringUtilsTests, toSnakeCase) {
   const std::string camel_case = "snakeCaseTest42!";
   const auto snake_case = toSnakeCase(camel_case);

--- a/modules/utils/tests/string_utils_tests.cpp
+++ b/modules/utils/tests/string_utils_tests.cpp
@@ -3,6 +3,7 @@
 //=================================================================================================
 
 #include <array>
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -100,23 +101,45 @@ TEST(StringUtilsTests, toScreamingSnakeCase) {
 
 TEST(StringUtilsTests, stringToInt64) {
   const std::string int_str = "42";
-  auto int_value = stringToInt64(int_str);
+  auto int_value = stringTo<int64_t>(int_str);
   EXPECT_THAT(int_value, Optional(42));
 
   const std::string negative_int_str = "-42";
-  int_value = stringToInt64(negative_int_str);
+  int_value = stringTo<int64_t>(negative_int_str);
   EXPECT_THAT(int_value, Optional(-42));
 
   const std::string invalid_str = "42a";
-  auto invalid_value = stringToInt64(invalid_str);
+  auto invalid_value = stringTo<int64_t>(invalid_str);
   EXPECT_THAT(invalid_value, Eq(std::nullopt));
 
   const std::string double_str = "42.0";
-  invalid_value = stringToInt64(double_str);
+  invalid_value = stringTo<int64_t>(double_str);
   EXPECT_THAT(invalid_value, Eq(std::nullopt));
 
   const std::string empty_str;
-  invalid_value = stringToInt64(empty_str);
+  invalid_value = stringTo<int64_t>(empty_str);
+  EXPECT_THAT(invalid_value, Eq(std::nullopt));
+}
+
+TEST(StringUtilsTests, stringToDouble) {
+  const std::string int_str = "42";
+  auto double_value = stringTo<double>(int_str);
+  EXPECT_THAT(double_value, Optional(42));
+
+  const std::string negative_int_str = "-42";
+  double_value = stringTo<double>(negative_int_str);
+  EXPECT_THAT(double_value, Optional(-42));
+
+  const std::string invalid_str = "42a";
+  auto invalid_value = stringTo<double>(invalid_str);
+  EXPECT_THAT(invalid_value, Eq(std::nullopt));
+
+  const std::string double_str = "42.1";
+  invalid_value = stringTo<double>(double_str);
+  EXPECT_THAT(invalid_value, Optional(42.1));
+
+  const std::string empty_str;
+  invalid_value = stringTo<double>(empty_str);
   EXPECT_THAT(invalid_value, Eq(std::nullopt));
 }
 

--- a/modules/utils/tests/string_utils_tests.cpp
+++ b/modules/utils/tests/string_utils_tests.cpp
@@ -85,6 +85,13 @@ TEST(StringUtilsTests, toUpperCase) {
   EXPECT_EQ(upper_case, "ANY_TEST_CASE_42!");
 }
 
+TEST(StringUtilsTests, toLowerCase) {
+  const std::string test_string = "aNy_TEST_CaSe_42!";
+  const auto upper_case = toLowerCase(test_string);
+
+  EXPECT_EQ(upper_case, "any_test_case_42!");
+}
+
 TEST(StringUtilsTests, toSnakeCase) {
   const std::string camel_case = "snakeCaseTest42!";
   const auto snake_case = toSnakeCase(camel_case);

--- a/modules/utils/tests/string_utils_tests.cpp
+++ b/modules/utils/tests/string_utils_tests.cpp
@@ -106,48 +106,4 @@ TEST(StringUtilsTests, toScreamingSnakeCase) {
   EXPECT_EQ(screaming_snake_case, "SCREAMING_SNAKE_CASE_TEST42!");
 }
 
-TEST(StringUtilsTests, stringToInt64) {
-  const std::string int_str = "42";
-  auto int_value = stringTo<int64_t>(int_str);
-  EXPECT_THAT(int_value, Optional(42));
-
-  const std::string negative_int_str = "-42";
-  int_value = stringTo<int64_t>(negative_int_str);
-  EXPECT_THAT(int_value, Optional(-42));
-
-  const std::string invalid_str = "42a";
-  auto invalid_value = stringTo<int64_t>(invalid_str);
-  EXPECT_THAT(invalid_value, Eq(std::nullopt));
-
-  const std::string double_str = "42.0";
-  invalid_value = stringTo<int64_t>(double_str);
-  EXPECT_THAT(invalid_value, Eq(std::nullopt));
-
-  const std::string empty_str;
-  invalid_value = stringTo<int64_t>(empty_str);
-  EXPECT_THAT(invalid_value, Eq(std::nullopt));
-}
-
-TEST(StringUtilsTests, stringToDouble) {
-  const std::string int_str = "42";
-  auto double_value = stringTo<double>(int_str);
-  EXPECT_THAT(double_value, Optional(42));
-
-  const std::string negative_int_str = "-42";
-  double_value = stringTo<double>(negative_int_str);
-  EXPECT_THAT(double_value, Optional(-42));
-
-  const std::string invalid_str = "42a";
-  auto invalid_value = stringTo<double>(invalid_str);
-  EXPECT_THAT(invalid_value, Eq(std::nullopt));
-
-  const std::string double_str = "42.1";
-  invalid_value = stringTo<double>(double_str);
-  EXPECT_THAT(invalid_value, Optional(42.1));
-
-  const std::string empty_str;
-  invalid_value = stringTo<double>(empty_str);
-  EXPECT_THAT(invalid_value, Eq(std::nullopt));
-}
-
 }  // namespace heph::utils::string::tests


### PR DESCRIPTION
# Description
Add a couple of new string utilities:
* Extend `stringToInt64` to support also `double` -> `stringTo<T>`
* Add `toLowerCase`
* Update the interface of the other functions to use `std::string_view` instead of `const&`.
  * Why? See this article https://quuxplusone.github.io/blog/2021/11/09/pass-string-view-by-value/ 
