### PR TITLE
File utils: read/write do not throw anymore; add search for file; add get hostname

### DIFF
--- a/modules/utils/include/hephaestus/utils/filesystem/file.h
+++ b/modules/utils/include/hephaestus/utils/filesystem/file.h
@@ -1,14 +1,32 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
 #pragma once
+
 #include <filesystem>
+#include <optional>
 #include <span>
 #include <vector>
 
 namespace heph::utils::filesystem {
 
-[[nodiscard]] auto readFile(const std::filesystem::path& path) -> std::string;
-[[nodiscard]] auto readBinaryFile(const std::filesystem::path& path) -> std::vector<std::byte>;
+/// Read the whole content of the input file into a string.
+/// \return std::nullopt if the file doesn't exists.
+[[nodiscard]] auto readFile(const std::filesystem::path& path) -> std::optional<std::string>;
+/// Read the whole content of the input binary file into a binary buffer.
+/// \return std::nullopt if the file doesn't exists.
+[[nodiscard]] auto readBinaryFile(const std::filesystem::path& path) -> std::optional<std::vector<std::byte>>;
 
-void writeStringToFile(const std::filesystem::path& path, std::string_view content);
-void writeBufferToFile(const std::filesystem::path& path, std::span<const std::byte> content);
+[[nodiscard]] auto writeStringToFile(const std::filesystem::path& path, std::string_view content) -> bool;
+[[nodiscard]] auto writeBufferToFile(const std::filesystem::path& path,
+                                     std::span<const std::byte> content) -> bool;
+
+[[nodiscard]] auto searchFilenameInPaths(const std::string& filename,
+                                         const std::vector<std::filesystem::path>& paths)
+    -> std::optional<std::filesystem::path>;
+
+/// Return the full path of the executable calling this function.
+[[nodiscard]] auto getThisExecutableFullPath() -> std::filesystem::path;
 
 }  // namespace heph::utils::filesystem

--- a/modules/utils/include/hephaestus/utils/utils.h
+++ b/modules/utils/include/hephaestus/utils/utils.h
@@ -23,4 +23,6 @@ inline auto getTypeName() -> std::string {
   return (status == 0) ? res.get() : mangled_name;
 }
 
+[[nodiscard]] auto getHostName() -> std::string;
+
 }  // namespace heph::utils

--- a/modules/utils/src/filesystem/file.cpp
+++ b/modules/utils/src/filesystem/file.cpp
@@ -14,12 +14,15 @@
 #ifdef __linux__
 #include <linux/limits.h>
 #endif
+#include <absl/log/log.h>
+#include <fmt/core.h>
 #include <unistd.h>
 
 namespace heph::utils::filesystem {
 auto readFile(const std::filesystem::path& path) -> std::optional<std::string> {
   std::ifstream infile{ path };
   if (!infile) {
+    LOG(WARNING) << fmt::format("Failed to open file for reading: {}", path.string());
     return {};
   }
 
@@ -33,6 +36,7 @@ auto readFile(const std::filesystem::path& path) -> std::optional<std::string> {
 auto readBinaryFile(const std::filesystem::path& path) -> std::optional<std::vector<std::byte>> {
   std::ifstream infile{ path, std::ios::binary };
   if (!infile) {
+    LOG(WARNING) << fmt::format("Failed to open binary file for reading: {}", path.string());
     return {};
   }
 
@@ -47,6 +51,7 @@ auto readBinaryFile(const std::filesystem::path& path) -> std::optional<std::vec
 auto writeStringToFile(const std::filesystem::path& path, std::string_view content) -> bool {
   std::ofstream outfile{ path, std::ios::out };
   if (!outfile) {
+    LOG(WARNING) << fmt::format("Failed to open file for writing: {}", path.string());
     return false;
   }
 
@@ -57,6 +62,7 @@ auto writeStringToFile(const std::filesystem::path& path, std::string_view conte
 auto writeBufferToFile(const std::filesystem::path& path, std::span<const std::byte> content) -> bool {
   std::ofstream outfile{ path, std::ios::out | std::ios::binary };
   if (!outfile) {
+    LOG(WARNING) << fmt::format("Failed to open file for writing: {}", path.string());
     return false;
   }
 

--- a/modules/utils/src/filesystem/file.cpp
+++ b/modules/utils/src/filesystem/file.cpp
@@ -5,20 +5,23 @@
 #include <fstream>
 #include <ios>
 #include <iterator>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
 #include <vector>
 
-#include <fmt/core.h>
-
-#include "hephaestus/utils/exception.h"
+#ifdef __linux__
+#include <linux/limits.h>
+#endif
+#include <unistd.h>
 
 namespace heph::utils::filesystem {
-auto readFile(const std::filesystem::path& path) -> std::string {
+auto readFile(const std::filesystem::path& path) -> std::optional<std::string> {
   std::ifstream infile{ path };
-  throwExceptionIf<InvalidDataException>(!infile,
-                                         fmt::format("Could not open file {} to read", path.string()));
+  if (!infile) {
+    return {};
+  }
 
   std::string text;
   text.reserve(std::filesystem::file_size(path));
@@ -27,10 +30,11 @@ auto readFile(const std::filesystem::path& path) -> std::string {
   return text;
 }
 
-auto readBinaryFile(const std::filesystem::path& path) -> std::vector<std::byte> {
+auto readBinaryFile(const std::filesystem::path& path) -> std::optional<std::vector<std::byte>> {
   std::ifstream infile{ path, std::ios::binary };
-  throwExceptionIf<InvalidDataException>(!infile,
-                                         fmt::format("Could not open file {} to read", path.string()));
+  if (!infile) {
+    return {};
+  }
 
   const auto file_size = std::filesystem::file_size(path);
   std::vector<std::byte> buffer(file_size);
@@ -40,21 +44,54 @@ auto readBinaryFile(const std::filesystem::path& path) -> std::vector<std::byte>
   return buffer;
 }
 
-void writeStringToFile(const std::filesystem::path& path, std::string_view content) {
+auto writeStringToFile(const std::filesystem::path& path, std::string_view content) -> bool {
   std::ofstream outfile{ path, std::ios::out };
-  throwExceptionIf<InvalidDataException>(!outfile,
-                                         fmt::format("Could not open file {} to write", path.string()));
+  if (!outfile) {
+    return false;
+  }
 
   outfile.write(content.data(), static_cast<std::streamsize>(content.size()));
+  return true;
 }
 
-void writeBufferToFile(const std::filesystem::path& path, std::span<const std::byte> content) {
+auto writeBufferToFile(const std::filesystem::path& path, std::span<const std::byte> content) -> bool {
   std::ofstream outfile{ path, std::ios::out | std::ios::binary };
-  throwExceptionIf<InvalidDataException>(!outfile,
-                                         fmt::format("Could not open file {} to write", path.string()));
+  if (!outfile) {
+    return false;
+  }
 
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   outfile.write(reinterpret_cast<const char*>(content.data()), static_cast<std::streamsize>(content.size()));
+  return true;
+}
+
+auto searchFilenameInPaths(const std::string& filename, const std::vector<std::filesystem::path>& paths)
+    -> std::optional<std::filesystem::path> {
+  if (std::filesystem::exists(filename)) {
+    return filename;
+  }
+
+  for (const auto& path : paths) {
+    auto file = path / filename;
+    if (std::filesystem::exists(file)) {
+      return file;
+    }
+  }
+
+  return {};
+}
+
+auto getThisExecutableFullPath() -> std::filesystem::path {
+/// \note This implementation only works for Linux
+#ifdef __linux__
+  // NOLINTBEGIN(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+  char path[PATH_MAX + 1] = { '\0' };  // NOLINT(cppcoreguidelines-avoid-c-arrays)
+  const auto path_length = readlink("/proc/self/exe", path, PATH_MAX);
+  return ((path_length > 0) ? std::filesystem::path{ path } : (""));
+#elif
+  return {};
+#endif
+  // NOLINTEND(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
 }  // namespace heph::utils::filesystem

--- a/modules/utils/tests/file_tests.cpp
+++ b/modules/utils/tests/file_tests.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2023-2024 HEPHAESTUS Contributors
 //=================================================================================================
 #include <cstddef>
+#include <filesystem>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -13,11 +14,34 @@
 using namespace ::testing;
 
 namespace heph::utils::filesystem::tests {
+TEST(Filesystem, WriteFileFail) {
+  const std::filesystem::path output_file =
+      "/tmp/this_folder_should_not_exist/this_file_should_not_exist.txt";
+  ASSERT_FALSE(std::filesystem::exists(output_file));
+
+  auto res = writeStringToFile(output_file, "Hello, World!");
+  EXPECT_FALSE(res);
+  res = writeBufferToFile(output_file, {});
+  EXPECT_FALSE(res);
+}
+
+TEST(Filesystem, ReadFileFail) {
+  const std::filesystem::path output_file =
+      "/tmp/this_folder_should_not_exist/this_file_should_not_exist.txt";
+  ASSERT_FALSE(std::filesystem::exists(output_file));
+
+  const auto content = readFile(output_file);
+  EXPECT_FALSE(content);
+  const auto buffer = readBinaryFile(output_file);
+  EXPECT_FALSE(buffer);
+}
+
 TEST(Filesystem, ReadWriteBinaryFile) {
   const auto path = ScopedPath::createFile();
   const auto content = std::vector<std::byte>{ std::byte{ 0x01 }, std::byte{ 0x02 }, std::byte{ 0x03 } };
 
-  writeBufferToFile(path, { content.data(), content.size() });
+  auto res = writeBufferToFile(path, { content.data(), content.size() });
+  EXPECT_TRUE(res);
   const auto read_content = readBinaryFile(path);
 
   EXPECT_EQ(content, read_content);
@@ -27,7 +51,8 @@ TEST(Filesystem, ReadWriteTextFile) {
   const auto path = ScopedPath::createFile();
   const auto content = std::string{ "Hello, World!" };
 
-  writeStringToFile(path, content);
+  auto res = writeStringToFile(path, content);
+  EXPECT_TRUE(res);
   const auto read_content = readFile(path);
 
   EXPECT_EQ(content, read_content);


### PR DESCRIPTION
# Description
* Read/write file utilities do not throw anymore.
  * In this case it is too aggressive to throw for such a generic function, we need to let the caller decide if the error is at exception level
* Add function to search a file in a list of possible paths
* Add function that return the path of the running executable that calls the function
* Add `getHostname` function: this is used for example to prefix all topics  with the hostname  
