### PR TITLE
bump zenoh version to 1.0.0-alpha.6

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN  update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$CLANG_VE
 
 RUN ln -s /usr/bin/clangd-${CLANG_VERSION} /usr/bin/clangd
 
-RUN export ZENOH_VERSION="0.11.0-rc.3" && \
+RUN export ZENOH_VERSION="1.0.0~alpha.6-1" && \
     echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | tee /etc/apt/sources.list.d/zenoh.list >/dev/null && \
     (apt-get update && apt-get install --no-install-recommends -y --allow-downgrades zenohd=${ZENOH_VERSION} zenoh-plugin-rest=${ZENOH_VERSION} || true) && \
     sed -i 's/systemctl /# remove if fixed by zenoh: systemctl /' /var/lib/dpkg/info/zenohd.postinst && \

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -39,8 +39,7 @@ endif()
 # --------------------------------------------------------------------------------------------------
 # zenoh
 
-# As soon as zenohcxx commit makes to a release, move back to the release. set(ZENOH_VERSION "1.0.0.4")
-set(ZENOH_VERSION "c75ce16e855e8b1f0562523cdf6be6c37f4ebb56")
+set(ZENOH_VERSION "1.0.0.6")
 add_cmake_dependency(
   NAME zenohc URL https://github.com/eclipse-zenoh/zenoh-c/archive/${ZENOH_VERSION}.zip
   CMAKE_ARGS -DZENOHC_CARGO_CHANNEL=+stable

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -45,8 +45,7 @@ add_cmake_dependency(
   CMAKE_ARGS -DZENOHC_CARGO_CHANNEL=+stable
 )
 
-# This should be equal to ${ZENOH_VERSION}, but we need to point to the fix coming from this commit.
-set(ZENOHCXX_VERSION "535b3629db7fc1e52aecba90238a8caec2f6c947")
+set(ZENOHCXX_VERSION ${ZENOH_VERSION})
 add_cmake_dependency(
   NAME zenohcxx
   DEPENDS ${ZENOHCXX_DEPENDS} URL https://github.com/eclipse-zenoh/zenoh-cpp/archive/${ZENOHCXX_VERSION}.zip


### PR DESCRIPTION
# Description
Bumps zenoh and zenohc versions to 1.0.0-alpha.6 


Changelog: 
* zenoh https://github.com/eclipse-zenoh/zenoh/releases/tag/1.0.0-alpha.6
* zenohc https://github.com/eclipse-zenoh/zenoh-c/releases/tag/1.0.0.6

## Type of change
- Potential breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
