### PR TITLE
CI: split build & test into two jobs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,12 +78,12 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build --preset CI
+      run: mkdir -p build && make -B build --preset CI
     - name: Check format
       run: cd ${{github.workspace}}/build && ninja format
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build -- all examples
+      run: cmake --build build -- all examples
     - name: Upload build folder as artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,11 +84,31 @@ jobs:
     - name: Build
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build -- all examples
-
+    - name: Upload build folder as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-folder-artifact
+        path: ${{github.workspace}}/build
+  test:
+    needs: build
+    # TODO: use the docker image published at the step over
+    runs-on: ubuntu-latest
+    permissions: read-all
+    container:
+      image: ghcr.io/olympus-robotics/x86_64/hephaestus-dev_deps:latest
+      credentials:
+        username: ${{ github.actor}}
+        password: ${{secrets.GITHUB_TOKEN}}
+    steps:
+    - uses: actions/checkout@v4.1.1
+    - name: Download build folder artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: build-folder-artifact
+          path: build
     - name: Test
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: |
-        cd ${{github.workspace}}/build
-        ninja tests_build
-        ninja test
+        cd build
+        ninja check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: build-folder-artifact
-        path: ${{github.workspace}}/build
+        path: ${{github.workspace}}/build/
   test:
     needs: build
     # TODO: use the docker image published at the step over
@@ -105,7 +105,7 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: build-folder-artifact
-        path: build
+        path: build/
     - name: Test
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,10 +102,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.1
     - name: Download build folder artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: build-folder-artifact
-          path: build
+      uses: actions/download-artifact@v3
+      with:
+        name: build-folder-artifact
+        path: build
     - name: Test
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: mkdir -p build && cmake -B build --preset CI
     - name: Check format
-      run: cd ${{github.workspace}}/build && ninja format
+      run: cd build && ninja format
     - name: Build
       # Build your program with the given configuration
       run: cmake --build build -- all examples

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: mkdir -p build && make -B build --preset CI
+      run: mkdir -p build && cmake -B build --preset CI
     - name: Check format
       run: cd ${{github.workspace}}/build && ninja format
     - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: build-folder-artifact
-        path: ${{github.workspace}}/build/
+        path: build/
   test:
     needs: build
     # TODO: use the docker image published at the step over


### PR DESCRIPTION
This separation allows to more easily identify issues and re-run just the test step to detect flaky tests.