### PR TITLE
Update to Zenoh release 1.0.0.9

### DIFF
--- a/docker/version.sh
+++ b/docker/version.sh
@@ -3,4 +3,4 @@ VERSION=1.0.12
 IMAGE=hephaestus-dev
 
 # This is the version of the dep image. Increase this number everytime you change `external/CMakeLists.txt`
-DEPS_VERSION=1.0.26
+DEPS_VERSION=1.0.27

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -39,7 +39,9 @@ endif()
 # --------------------------------------------------------------------------------------------------
 # zenoh
 
-set(ZENOHC_CMAKE_ARGS -DZENOHC_CARGO_CHANNEL=+stable -DZENOHC_BUILD_WITH_SHARED_MEMORY=TRUE -DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE)
+set(ZENOHC_CMAKE_ARGS -DZENOHC_CARGO_CHANNEL=+stable -DZENOHC_BUILD_WITH_SHARED_MEMORY=TRUE
+                      -DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE
+)
 if(NOT BUILD_SHARED_LIBS)
   list(APPEND ZENOHC_CMAKE_ARGS "-DZENOHC_LIB_STATIC=TRUE" "-DZENOHC_INSTALL_STATIC_LIBRARY=TRUE")
 endif()
@@ -51,8 +53,7 @@ add_cmake_dependency(
 set(ZENOHCXX_VERSION ${ZENOH_VERSION})
 add_cmake_dependency(
   NAME zenohcxx
-  DEPENDS ${ZENOHCXX_DEPENDS}
-          URL https://github.com/eclipse-zenoh/zenoh-cpp/archive/${ZENOHCXX_VERSION}.zip
+  DEPENDS ${ZENOHCXX_DEPENDS} URL https://github.com/eclipse-zenoh/zenoh-cpp/archive/${ZENOHCXX_VERSION}.zip
   CMAKE_ARGS "-DZ_FEATURE_UNSTABLE_API=1"
 )
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -39,23 +39,21 @@ endif()
 # --------------------------------------------------------------------------------------------------
 # zenoh
 
-set(ZENOHC_CMAKE_ARGS -DZENOHC_CARGO_CHANNEL=+stable -DZENOHC_BUILD_WITH_SHARED_MEMORY=TRUE)
+set(ZENOHC_CMAKE_ARGS -DZENOHC_CARGO_CHANNEL=+stable -DZENOHC_BUILD_WITH_SHARED_MEMORY=TRUE -DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE)
 if(NOT BUILD_SHARED_LIBS)
   list(APPEND ZENOHC_CMAKE_ARGS "-DZENOHC_LIB_STATIC=TRUE" "-DZENOHC_INSTALL_STATIC_LIBRARY=TRUE")
 endif()
-# NOTE: There is a bug in the current release, so for now we are pointing to our fix. set(ZENOH_VERSION "1.0.0.6")
-set(ZENOH_VERSION "5a82ecfd6154adf30ff96efe9b7838018134a528") # from zenohcxx dev/1.0.0
+set(ZENOH_VERSION "1.0.0.9")
 add_cmake_dependency(
   NAME zenohc URL https://github.com/eclipse-zenoh/zenoh-c/archive/${ZENOH_VERSION}.zip CMAKE_ARGS ${ZENOHC_CMAKE_ARGS}
 )
 
-# set(ZENOHCXX_VERSION ${ZENOH_VERSION})
-set(ZENOHCXX_VERSION "5d8a4d6802b38bef4fe02d00d62fd96219eb3a06")
+set(ZENOHCXX_VERSION ${ZENOH_VERSION})
 add_cmake_dependency(
   NAME zenohcxx
   DEPENDS ${ZENOHCXX_DEPENDS}
-          # URL https://github.com/eclipse-zenoh/zenoh-cpp/archive/${ZENOHCXX_VERSION}.zip
-          URL https://github.com/filippobrizzi/zenoh-cpp/archive/${ZENOHCXX_VERSION}.zip
+          URL https://github.com/eclipse-zenoh/zenoh-cpp/archive/${ZENOHCXX_VERSION}.zip
+  CMAKE_ARGS "-DZ_FEATURE_UNSTABLE_API=1"
 )
 
 # --------------------------------------------------------------------------------------------------

--- a/modules/bag/tests/tests.cpp
+++ b/modules/bag/tests/tests.cpp
@@ -35,8 +35,8 @@ constexpr auto ROBOT_MSG_PERIOD = std::chrono::milliseconds{ 1 };
 constexpr std::size_t FLEET_MSG_COUNT = 5;
 constexpr auto FLEET_MSG_PERIOD = std::chrono::milliseconds{ 2 };
 constexpr auto SENDER_ID = "bag_tester";
-constexpr auto ROBOT_TOPIC = "robot";
-constexpr auto FLEET_TOPIC = "fleet";
+constexpr auto ROBOT_TOPIC = "bag_test/robot";
+constexpr auto FLEET_TOPIC = "bag_test/fleet";
 
 [[nodiscard]] auto createBag()
     -> std::tuple<utils::filesystem::ScopedPath, std::vector<Robot>, std::vector<Fleet>> {
@@ -77,6 +77,7 @@ constexpr auto FLEET_TOPIC = "fleet";
   return { std::move(scoped_path), std::move(robots), std::move(fleet) };
 }
 
+// TODO: figure out how to isolate the network to make sure that only the two topics here are visible.
 TEST(Bag, PlayAndRecord) {
   auto output_bag = utils::filesystem::ScopedPath::createFile();
   auto [bag_path, robots, companies] = createBag();
@@ -84,7 +85,7 @@ TEST(Bag, PlayAndRecord) {
     auto bag_writer = createMcapWriter({ output_bag });
     auto recorder = ZenohRecorder::create({ .session = ipc::zenoh::createSession({}),
                                             .bag_writer = std::move(bag_writer),
-                                            .topics_filter_params = {} });
+                                            .topics_filter_params = { .prefix = "bag_test/" } });
     {
       auto reader = std::make_unique<mcap::McapReader>();
       const auto status = reader->open(bag_path);

--- a/modules/ipc/CMakeLists.txt
+++ b/modules/ipc/CMakeLists.txt
@@ -20,7 +20,6 @@ add_subdirectory(proto)
 # library sources
 set(SOURCES
     src/topic.cpp
-    src/topic_database.cpp
     src/topic_filter.cpp
     src/zenoh/conversions.cpp
     src/zenoh/dynamic_subscriber.cpp
@@ -33,6 +32,7 @@ set(SOURCES
     src/zenoh/service.cpp
     src/zenoh/session.cpp
     src/zenoh/subscriber.cpp
+    src/zenoh/topic_database.cpp
     src/zenoh/action_server/action_server.cpp
     src/zenoh/action_server/client_helper.cpp
     src/zenoh/action_server/types.cpp

--- a/modules/ipc/apps/zenoh_topic_echo.cpp
+++ b/modules/ipc/apps/zenoh_topic_echo.cpp
@@ -12,7 +12,6 @@
 #include <optional>
 #include <span>
 #include <string>
-#include <thread>
 #include <tuple>
 #include <utility>
 

--- a/modules/ipc/apps/zenoh_topic_echo.cpp
+++ b/modules/ipc/apps/zenoh_topic_echo.cpp
@@ -12,6 +12,7 @@
 #include <optional>
 #include <span>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <utility>
 

--- a/modules/ipc/apps/zenoh_topic_list.cpp
+++ b/modules/ipc/apps/zenoh_topic_list.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <exception>
 #include <string_view>
+#include <thread>
 #include <tuple>
 #include <utility>
 
@@ -22,15 +23,12 @@
 
 void getListOfPublisher(const heph::ipc::zenoh::Session& session, std::string_view topic) {
   const auto publishers_info = heph::ipc::zenoh::getListOfPublishers(session, topic);
-  std::for_each(publishers_info.begin(), publishers_info.end(),
-                [](const auto& info) { heph::ipc::zenoh::printPublisherInfo(info); });
+  std::for_each(publishers_info.begin(), publishers_info.end(), &heph::ipc::zenoh::printPublisherInfo);
 }
 
 void getLiveListOfPublisher(heph::ipc::zenoh::SessionPtr session, heph::ipc::TopicConfig topic_config) {
-  auto callback = [](const auto& info) { heph::ipc::zenoh::printPublisherInfo(info); };
-
   const heph::ipc::zenoh::PublisherDiscovery discover{ std::move(session), std::move(topic_config),
-                                                       std::move(callback) };
+                                                       &heph::ipc::zenoh::printPublisherInfo };
 
   heph::utils::TerminationBlocker::waitForInterrupt();
 }
@@ -52,7 +50,7 @@ auto main(int argc, const char* argv[]) -> int {
     if (!args.getOption<bool>("live")) {
       getListOfPublisher(*session, topic_config.name);
     } else {
-      getLiveListOfPublisher(session, std::move(topic_config));
+      getLiveListOfPublisher(std::move(session), std::move(topic_config));
     }
 
     return EXIT_SUCCESS;

--- a/modules/ipc/apps/zenoh_topic_list.cpp
+++ b/modules/ipc/apps/zenoh_topic_list.cpp
@@ -7,7 +7,6 @@
 #include <cstdlib>
 #include <exception>
 #include <string_view>
-#include <thread>
 #include <tuple>
 #include <utility>
 
@@ -50,7 +49,7 @@ auto main(int argc, const char* argv[]) -> int {
     if (!args.getOption<bool>("live")) {
       getListOfPublisher(*session, topic_config.name);
     } else {
-      getLiveListOfPublisher(std::move(session), std::move(topic_config));
+      getLiveListOfPublisher(session, std::move(topic_config));
     }
 
     return EXIT_SUCCESS;

--- a/modules/ipc/include/hephaestus/ipc/zenoh/conversions.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/conversions.h
@@ -10,6 +10,7 @@
 
 #include <zenoh.hxx>
 #include <zenoh/api/bytes.hxx>
+#include <zenoh/api/id.hxx>
 
 #include "hephaestus/ipc/zenoh/session.h"
 

--- a/modules/ipc/include/hephaestus/ipc/zenoh/dynamic_subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/dynamic_subscriber.h
@@ -6,8 +6,6 @@
 
 #include <future>
 
-#include <absl/base/thread_annotations.h>
-
 #include "hephaestus/ipc/topic_database.h"
 #include "hephaestus/ipc/topic_filter.h"
 #include "hephaestus/ipc/zenoh/liveliness.h"

--- a/modules/ipc/include/hephaestus/ipc/zenoh/dynamic_subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/dynamic_subscriber.h
@@ -6,6 +6,8 @@
 
 #include <future>
 
+#include <absl/base/thread_annotations.h>
+
 #include "hephaestus/ipc/topic_database.h"
 #include "hephaestus/ipc/topic_filter.h"
 #include "hephaestus/ipc/zenoh/liveliness.h"
@@ -54,7 +56,9 @@ private:
   SessionPtr topic_info_query_session_;  // Session used to query topic service.
   std::unique_ptr<ITopicDatabase> topic_db_;
 
-  std::unordered_map<std::string, std::unique_ptr<RawSubscriber>> subscribers_;
+  std::mutex subscribers_mutex_;
+  std::unordered_map<std::string, std::unique_ptr<RawSubscriber>>
+      subscribers_ ABSL_GUARDED_BY(subscribers_mutex_);
   TopicWithTypeInfoCallback init_subscriber_cb_;
   SubscriberWithTypeCallback subscriber_cb_;
 };

--- a/modules/ipc/include/hephaestus/ipc/zenoh/dynamic_subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/dynamic_subscriber.h
@@ -50,15 +50,11 @@ private:
   SessionPtr session_;
   TopicFilter topic_filter_;
 
-  zenoh::SessionPtr publisher_discovery_session_;
   std::unique_ptr<PublisherDiscovery> discover_publishers_;
 
-  SessionPtr topic_info_query_session_;  // Session used to query topic service.
   std::unique_ptr<ITopicDatabase> topic_db_;
 
-  std::mutex subscribers_mutex_;
-  std::unordered_map<std::string, std::unique_ptr<RawSubscriber>>
-      subscribers_ ABSL_GUARDED_BY(subscribers_mutex_);
+  std::unordered_map<std::string, std::unique_ptr<RawSubscriber>> subscribers_;
   TopicWithTypeInfoCallback init_subscriber_cb_;
   SubscriberWithTypeCallback subscriber_cb_;
 };

--- a/modules/ipc/include/hephaestus/ipc/zenoh/liveliness.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/liveliness.h
@@ -33,9 +33,6 @@ void printPublisherInfo(const PublisherInfo& info);
 class PublisherDiscovery {
 public:
   using Callback = std::function<void(const PublisherInfo& info)>;
-  // TODO: figure out why even if we kill the liveliness subscriber we still get messages.
-  /// The callback needs to be thread safe as they may be called in parallel for different publishers
-  /// discovered.
   explicit PublisherDiscovery(SessionPtr session, TopicConfig topic_config, Callback&& callback);
   ~PublisherDiscovery();
 

--- a/modules/ipc/include/hephaestus/ipc/zenoh/liveliness.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/liveliness.h
@@ -8,8 +8,10 @@
 #include <string>
 #include <string_view>
 
+#include <fmt/core.h>
 #include <zenoh/api/subscriber.hxx>
 
+#include "hephaestus/concurrency/message_queue_consumer.h"
 #include "hephaestus/ipc/topic.h"
 #include "hephaestus/ipc/zenoh/session.h"
 
@@ -31,10 +33,11 @@ void printPublisherInfo(const PublisherInfo& info);
 class PublisherDiscovery {
 public:
   using Callback = std::function<void(const PublisherInfo& info)>;
+  // TODO: figure out why even if we kill the liveliness subscriber we still get messages.
   /// The callback needs to be thread safe as they may be called in parallel for different publishers
   /// discovered.
   explicit PublisherDiscovery(SessionPtr session, TopicConfig topic_config, Callback&& callback);
-  ~PublisherDiscovery() = default;
+  ~PublisherDiscovery();
 
   PublisherDiscovery(const PublisherDiscovery&) = delete;
   PublisherDiscovery(PublisherDiscovery&&) = delete;
@@ -50,6 +53,9 @@ private:
   Callback callback_;
 
   std::unique_ptr<::zenoh::Subscriber<void>> liveliness_subscriber_;
+
+  static constexpr std::size_t DEFAULT_CACHE_RESERVES = 100;
+  std::unique_ptr<concurrency::MessageQueueConsumer<PublisherInfo>> infos_consumer_;
 };
 
 }  // namespace heph::ipc::zenoh

--- a/modules/ipc/include/hephaestus/ipc/zenoh/raw_publisher.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/raw_publisher.h
@@ -63,7 +63,6 @@ private:
 
   bool enable_cache_ = false;
   ze_owned_publication_cache_t cache_publisher_{};
-  z_owned_session_t zenoh_cache_session_{};
 
   std::size_t pub_msg_count_ = 0;
   std::unordered_map<std::string, std::string> attachment_;

--- a/modules/ipc/include/hephaestus/ipc/zenoh/raw_subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/raw_subscriber.h
@@ -53,7 +53,6 @@ private:
 
   bool enable_cache_ = false;
   ze_owned_querying_subscriber_t cache_subscriber_{};
-  z_owned_session_t zenoh_cache_session_{};
 
   bool dedicated_callback_thread_;
   static constexpr std::size_t DEFAULT_CACHE_RESERVES = 100;

--- a/modules/ipc/src/zenoh/dynamic_subscriber.cpp
+++ b/modules/ipc/src/zenoh/dynamic_subscriber.cpp
@@ -89,7 +89,7 @@ void DynamicSubscriber::onPublisherAdded(const PublisherInfo& info) {
 
 void DynamicSubscriber::onPublisherDropped(const PublisherInfo& info) {
   if (!subscribers_.contains(info.topic)) {
-    LOG(ERROR) << fmt::format("Dropping subscriber for topic: {}, but one doesn't exist", info.topic);
+    LOG(ERROR) << fmt::format("Trying to drop subscriber for topic: {}, but one doesn't exist", info.topic);
     return;
   }
 

--- a/modules/ipc/src/zenoh/dynamic_subscriber.cpp
+++ b/modules/ipc/src/zenoh/dynamic_subscriber.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <future>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <span>
 #include <utility>
@@ -22,7 +21,6 @@
 #include "hephaestus/ipc/zenoh/raw_subscriber.h"
 #include "hephaestus/ipc/zenoh/session.h"
 #include "hephaestus/serdes/type_info.h"
-#include "hephaestus/utils/exception.h"
 
 namespace heph::ipc::zenoh {
 // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved,-warnings-as-errors)
@@ -36,8 +34,7 @@ DynamicSubscriber::DynamicSubscriber(DynamicSubscriberParams&& params)
 
 [[nodiscard]] auto DynamicSubscriber::start() -> std::future<void> {
   discover_publishers_ = std::make_unique<PublisherDiscovery>(
-      zenoh::createSession(Config{ session_->config }), TopicConfig{ .name = "**" },
-      [this](const PublisherInfo& info) { onPublisher(info); });
+      session_, TopicConfig{ .name = "**" }, [this](const PublisherInfo& info) { onPublisher(info); });
 
   std::promise<void> promise;
   promise.set_value();

--- a/modules/ipc/src/zenoh/raw_publisher.cpp
+++ b/modules/ipc/src/zenoh/raw_publisher.cpp
@@ -63,6 +63,8 @@ RawPublisher::RawPublisher(SessionPtr session, TopicConfig topic_config, serdes:
   , type_info_(std::move(type_info))
   , enable_cache_(session_->config.cache_size > 0)
   , match_cb_(std ::move(match_cb)) {
+  createTypeInfoService();
+
   // Enable publishing of a liveliness token.
   const ::zenoh::KeyExpr keyexpr{ topic_config_.name };
   ::zenoh::ZResult result{};
@@ -88,8 +90,6 @@ RawPublisher::RawPublisher(SessionPtr session, TopicConfig topic_config, serdes:
   if (match_cb_ != nullptr) {
     enableMatchingListener();
   }
-
-  createTypeInfoService();
 }
 
 RawPublisher::~RawPublisher() {

--- a/modules/ipc/src/zenoh/raw_subscriber.cpp
+++ b/modules/ipc/src/zenoh/raw_subscriber.cpp
@@ -5,6 +5,7 @@
 #include "hephaestus/ipc/zenoh/raw_subscriber.h"
 
 #include <cstddef>
+#include <exception>
 #include <memory>
 #include <span>
 #include <string>
@@ -103,6 +104,13 @@ RawSubscriber::~RawSubscriber() {
 
   if (enable_cache_) {
     z_drop(z_move(cache_subscriber_));
+  } else {
+    try {
+      std::move(*subscriber_).undeclare();
+    } catch (std::exception& e) {
+      LOG(ERROR) << fmt::format("Failed to undeclare subscriber for: {}. Exception: {}", topic_config_.name,
+                                e.what());
+    }
   }
 }
 

--- a/modules/ipc/src/zenoh/raw_subscriber.cpp
+++ b/modules/ipc/src/zenoh/raw_subscriber.cpp
@@ -19,6 +19,7 @@
 #include <zenoh.h>
 #include <zenoh/api/base.hxx>
 #include <zenoh/api/closures.hxx>
+#include <zenoh/api/interop.hxx>
 #include <zenoh/api/keyexpr.hxx>
 #include <zenoh/api/sample.hxx>
 #include <zenoh/api/subscriber.hxx>
@@ -75,9 +76,9 @@ RawSubscriber::RawSubscriber(SessionPtr session, TopicConfig topic_config, DataC
 
     auto c_closure = createZenohcClosure(cb, ::zenoh::closures::none);
 
-    zenoh_cache_session_ = std::move(session_->zenoh_session.clone()).take();
-    const auto result = ze_declare_querying_subscriber(&cache_subscriber_, z_loan(zenoh_cache_session_),
-                                                       z_loan(keyexpr), z_move(c_closure), &sub_opts);
+    const auto result = ze_declare_querying_subscriber(
+        &cache_subscriber_, ::zenoh::interop::as_loaned_c_ptr(session_->zenoh_session), z_loan(keyexpr),
+        z_move(c_closure), &sub_opts);
 
     heph::throwExceptionIf<heph::FailedZenohOperation>(
         result != Z_OK,
@@ -102,7 +103,6 @@ RawSubscriber::~RawSubscriber() {
 
   if (enable_cache_) {
     z_drop(z_move(cache_subscriber_));
-    z_drop(z_move(zenoh_cache_session_));
   }
 }
 

--- a/modules/ipc/src/zenoh/session.cpp
+++ b/modules/ipc/src/zenoh/session.cpp
@@ -23,35 +23,35 @@ auto createZenohConfig(const Config& config) -> ::zenoh::Config {
 
   auto zconfig = ::zenoh::Config::create_default();
   // A timestamp is add to every published message.
-  zconfig.insert_json(Z_CONFIG_ADD_TIMESTAMP_KEY, "true");  // NOLINT(misc-include-cleaner)
+  zconfig.insert_json5(Z_CONFIG_ADD_TIMESTAMP_KEY, "true");  // NOLINT(misc-include-cleaner)
 
   // Enable shared memory support.
   if (config.enable_shared_memory) {
-    zconfig.insert_json("transport/shared_memory/enabled", "true");
+    zconfig.insert_json5("transport/shared_memory/enabled", "true");
   }
 
   // Set node in client mode.
   if (config.mode == Mode::CLIENT) {
-    zconfig.insert_json(Z_CONFIG_MODE_KEY, R"("client")");  // NOLINT(misc-include-cleaner)
+    zconfig.insert_json5(Z_CONFIG_MODE_KEY, R"("client")");  // NOLINT(misc-include-cleaner)
   }
 
   // Set the transport to UDP, but I am not sure it is the right way.
-  // zconfig.insert_json(Z_CONFIG_LISTEN_KEY, R"(["udp/localhost:7447"])");
+  // zconfig.insert_json5(Z_CONFIG_LISTEN_KEY, R"(["udp/localhost:7447"])");
   if (config.protocol == Protocol::UDP) {
-    zconfig.insert_json(Z_CONFIG_CONNECT_KEY, R"(["udp/0.0.0.0:0"])");  // NOLINT(misc-include-cleaner)
+    zconfig.insert_json5(Z_CONFIG_CONNECT_KEY, R"(["udp/0.0.0.0:0"])");  // NOLINT(misc-include-cleaner)
   } else if (config.protocol == Protocol::TCP) {
-    zconfig.insert_json(Z_CONFIG_CONNECT_KEY, R"(["tcp/0.0.0.0:0"])");  // NOLINT(misc-include-cleaner)
+    zconfig.insert_json5(Z_CONFIG_CONNECT_KEY, R"(["tcp/0.0.0.0:0"])");  // NOLINT(misc-include-cleaner)
   }
 
   // Add router endpoint.
   if (!config.router.empty()) {
     const auto router_endpoint = fmt::format(R"(["tcp/{}"])", config.router);
-    zconfig.insert_json(Z_CONFIG_CONNECT_KEY, router_endpoint);  // NOLINT(misc-include-cleaner)
+    zconfig.insert_json5(Z_CONFIG_CONNECT_KEY, router_endpoint);  // NOLINT(misc-include-cleaner)
   }
-  { zconfig.insert_json("transport/unicast/qos/enabled", config.qos ? "true" : "false"); }
+  { zconfig.insert_json5("transport/unicast/qos/enabled", config.qos ? "true" : "false"); }
   if (config.real_time) {
-    zconfig.insert_json("transport/unicast/qos/enabled", "false");
-    zconfig.insert_json("transport/unicast/lowlatency", "true");
+    zconfig.insert_json5("transport/unicast/qos/enabled", "false");
+    zconfig.insert_json5("transport/unicast/lowlatency", "true");
   }
 
   return zconfig;

--- a/modules/ipc/src/zenoh/topic_database.cpp
+++ b/modules/ipc/src/zenoh/topic_database.cpp
@@ -66,7 +66,7 @@ auto ZenohTopicDatabase::getTypeInfo(const std::string& topic) -> const serdes::
 }
 
 // ----------------------------------------------------------------------------------------------------------
-auto createZenohTopicDatabase(std::shared_ptr<zenoh::Session> session) -> std::unique_ptr<ITopicDatabase> {
+auto createZenohTopicDatabase(zenoh::SessionPtr session) -> std::unique_ptr<ITopicDatabase> {
   return std::make_unique<ZenohTopicDatabase>(std::move(session));
 }
 


### PR DESCRIPTION
# Description
As part of this upgrade, I have:
* Improved the publisher discovery:
  * User callbacks are now called in a separate thread
    * This simplifies `DynamicSubscriber` as it allows the re-use of the same sessions for the discovery and subscribers. 
* Fixed a bug in the publisher where the type info service was created after the creation of the publisher and dynamic subscriber where sometimes failing to get the type info .
* Made bag test more robust by adding prefixes to topics so that when running locally we do not risk subscribing to other topics.