### PR TITLE
Feat/Add limits to random module.

### DIFF
--- a/modules/random/include/hephaestus/random/random_object_creator.h
+++ b/modules/random/include/hephaestus/random/random_object_creator.h
@@ -16,9 +16,17 @@
 
 #include "hephaestus/utils/concepts.h"
 #include "hephaestus/utils/exception.h"
-#include "hephaestus/types/bounds.h"
 
 namespace heph::random {
+
+template <NumericType T>
+struct Limits {
+  T min;
+  T max;
+};
+
+template <NumericType T>
+constexpr Limits<T> NO_LIMITS{ .min = std::numeric_limits<T>::min(), .max = std::numeric_limits<T>::max() };
 
 //=================================================================================================
 // Random boolean creation
@@ -36,8 +44,8 @@ template <typename T>
 concept NonBooleanIntegralType = std::integral<T> && !BooleanType<T>;
 
 template <NonBooleanIntegralType T>
-[[nodiscard]] auto random(std::mt19937_64& mt) -> T {
-  std::uniform_int_distribution<T> dist;
+[[nodiscard]] auto random(std::mt19937_64& mt, Limits<T> limits = NO_LIMITS<T>) -> T {
+  std::uniform_int_distribution<T> dist(limits.min, limits.max);
   return dist(mt);
 }
 
@@ -45,9 +53,8 @@ template <NonBooleanIntegralType T>
 // Random floating point value creation
 //=================================================================================================
 template <std::floating_point T>
-[[nodiscard]] auto random(std::mt19937_64& mt, std::optional < Bounds<T>> bounds) -> T {
-  auto bounds = bounds.value_or(Bounds<T>{ std::numeric_limits<T>::min(), std::numeric_limits<T>::max() });
-  std::uniform_real_distribution<T> dist(bounds.min, bounds.max);
+[[nodiscard]] auto random(std::mt19937_64& mt, Limits<T> limits = NO_LIMITS<T>) -> T {
+  std::uniform_real_distribution<T> dist(limits.min, limits.max);
   return dist(mt);
 }
 

--- a/modules/random/tests/random_object_creator_tests.cpp
+++ b/modules/random/tests/random_object_creator_tests.cpp
@@ -3,6 +3,7 @@
 //=================================================================================================
 
 #include <chrono>
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -85,9 +86,10 @@ TYPED_TEST(RandomTypeTests, RandomnessTest) {
 
 TYPED_TEST(RandomTypeTests, LimitsTest) {
   if constexpr (NonBooleanIntegralType<TypeParam> || std::floating_point<TypeParam>) {
-    constexpr auto limit_min = std::is_signed<TypeParam>::value ? -42 : 0;
+    constexpr auto LIM_MIN = std::is_signed_v<TypeParam> ? -42 : 0;
+    constexpr auto LIM_MAX = 42;
     auto mt = createRNG();
-    auto limits = random::Limits<TypeParam>{ .min = limit_min, .max = 42 };
+    auto limits = random::Limits<TypeParam>{ .min = LIM_MIN, .max = LIM_MAX };
     auto val = random::random<TypeParam>(mt, limits);
     EXPECT_GE(val, limits.min);
     EXPECT_LE(val, limits.max);

--- a/modules/random/tests/random_object_creator_tests.cpp
+++ b/modules/random/tests/random_object_creator_tests.cpp
@@ -84,7 +84,21 @@ TYPED_TEST(RandomTypeTests, RandomnessTest) {
 }
 
 template <typename T>
-concept ContainerWithSizeMethod = requires(TypeParam t) {
+concept HasLimitsMethod = requires(T t, Limits<T> limits) { random::random<T>(t, limits); };
+
+TYPED_TEST(RandomTypeTests, LimitsTest) {
+  if constexpr (HasLimitsMethod<TypeParam>) {
+    constexpr auto limit_min = std::is_signed<TypeParam>::value ? -42 : 0;
+    auto mt = createRNG();
+    auto limits = random::Limits<TypeParam>{ .min = 0, .max = 42 };
+    auto val = random::random<TypeParam>(mt, limits);
+    EXPECT_GE(val, limits.min);
+    EXPECT_LE(val, limits.max);
+  }
+}
+
+template <typename T>
+concept ContainerWithSizeMethod = requires(T t) {
   { t.size() } -> std::convertible_to<std::size_t>;
 };
 

--- a/modules/random/tests/random_object_creator_tests.cpp
+++ b/modules/random/tests/random_object_creator_tests.cpp
@@ -80,11 +80,16 @@ TYPED_TEST(RandomTypeTests, RandomnessTest) {
   EXPECT_FALSE(compareRandomEqualMultipleTimes<TypeParam>(gen, mt));
 }
 
+template <typename T>
+concept ContainerWithSizeMethod = requires(TypeParam t) {
+  { t.size() } -> std::convertible_to<std::size_t>;
+};
+
 // Note: If the size of the container is not specified, the size is randomly generated. No need to test this
 // case, as it is already included in testing for randomness. Repeadedly creating an empty container would
 // fail the RandomnessTest.
 TYPED_TEST(RandomTypeTests, ContainerSizeTest) {
-  if constexpr (RandomCreatableVector<TypeParam> || StringType<TypeParam>) {
+  if constexpr (ContainerWithSizeMethod<TypeParam>) {
     auto mt = createRNG();
 
     static constexpr std::size_t SIZE_ZERO = 0;

--- a/modules/random/tests/random_object_creator_tests.cpp
+++ b/modules/random/tests/random_object_creator_tests.cpp
@@ -84,7 +84,7 @@ TYPED_TEST(RandomTypeTests, RandomnessTest) {
 // case, as it is already included in testing for randomness. Repeadedly creating an empty container would
 // fail the RandomnessTest.
 TYPED_TEST(RandomTypeTests, ContainerSizeTest) {
-  if constexpr (IsRandomCreatableVector<TypeParam> || IsString<TypeParam>) {
+  if constexpr (RandomCreatableVector<TypeParam> || StringType<TypeParam>) {
     auto mt = createRNG();
 
     static constexpr std::size_t SIZE_ZERO = 0;

--- a/modules/random/tests/random_object_creator_tests.cpp
+++ b/modules/random/tests/random_object_creator_tests.cpp
@@ -83,24 +83,16 @@ TYPED_TEST(RandomTypeTests, RandomnessTest) {
   EXPECT_FALSE(compareRandomEqualMultipleTimes<TypeParam>(gen_fn, mt));
 }
 
-template <typename T>
-concept HasLimitsMethod = requires(T t, Limits<T> limits) { random::random<T>(t, limits); };
-
 TYPED_TEST(RandomTypeTests, LimitsTest) {
-  if constexpr (HasLimitsMethod<TypeParam>) {
+  if constexpr (NonBooleanIntegralType<TypeParam> || std::floating_point<TypeParam>) {
     constexpr auto limit_min = std::is_signed<TypeParam>::value ? -42 : 0;
     auto mt = createRNG();
-    auto limits = random::Limits<TypeParam>{ .min = 0, .max = 42 };
+    auto limits = random::Limits<TypeParam>{ .min = limit_min, .max = 42 };
     auto val = random::random<TypeParam>(mt, limits);
     EXPECT_GE(val, limits.min);
     EXPECT_LE(val, limits.max);
   }
 }
-
-template <typename T>
-concept ContainerWithSizeMethod = requires(T t) {
-  { t.size() } -> std::convertible_to<std::size_t>;
-};
 
 // Note: If the size of the container is not specified, the size is randomly generated. No need to test this
 // case, as it is already included in testing for randomness. Repeadedly creating an empty container would

--- a/modules/utils/include/hephaestus/utils/concepts.h
+++ b/modules/utils/include/hephaestus/utils/concepts.h
@@ -19,6 +19,12 @@ template <typename T>
 concept EnumType = std::is_enum_v<T>;
 
 template <typename T>
+concept BooleanType = std::is_same_v<T, bool>;
+
+template <typename T>
+concept StringType = std::is_same_v<T, std::string>;
+
+template <typename T>
 concept ArrayType = requires {
   typename T::value_type;
   requires std::same_as<T, std::array<typename T::value_type, T().size()>>;
@@ -46,6 +52,28 @@ concept ChronoSystemClockType = std::is_same_v<T, std::chrono::system_clock>;
 
 template <typename T>
 concept ChronoSteadyClockType = std::is_same_v<T, std::chrono::steady_clock>;
+
+template <typename T>
+concept ChronoClock = ChronoSystemClockType<T> || ChronoSteadyClockType<T>;
+
+template <typename T>
+concept ChronoSystemClockTimestampType = requires {
+  typename T::clock;
+  typename T::duration;
+  requires std::is_same_v<typename T::clock, std::chrono::system_clock>;
+  requires std::is_same_v<T, typename std::chrono::time_point<typename T::clock, typename T::duration>>;
+};
+
+template <typename T>
+concept ChronoSteadyClockTimestampType = requires {
+  typename T::clock;
+  typename T::duration;
+  requires std::is_same_v<typename T::clock, std::chrono::steady_clock>;
+  requires std::is_same_v<T, typename std::chrono::time_point<typename T::clock, typename T::duration>>;
+};
+
+template <typename T>
+concept ChronoTimestampType = ChronoSystemClockTimestampType<T> || ChronoSteadyClockTimestampType<T>;
 
 template <typename T>
 concept NumericType = (std::integral<T> || std::floating_point<T>)&&!std::same_as<T, bool>;


### PR DESCRIPTION
# Description
* Allow to specify limits for certain methods of the `random` module.
Note that `Bounds<T>` cannot be used here, as the module `types` depends on the module `random`, which would lead to cyclic dependencies.

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
