### PR TITLE
Upgrade to clang 19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ modules/utils/src/version_impl.h
 .cache/
 .vscode/
 build/
+build-gcc/
 
 # Prerequisites
 *.d

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,6 +13,17 @@
    }
   },
   {
+    "name": "gcc",
+    "description": "Configuration setting for all modules with preferred toolchain",
+    "generator": "Ninja",
+    "binaryDir": "${sourceDir}/build-gcc",
+    "installDir": "/install",
+    "cacheVariables": {
+     "BUILD_MODULES": "all;examples",
+     "ENABLE_LINTER": "OFF"
+    }
+   },
+  {
     "name": "fast",
     "description": "Configuration setting for all modules with preferred toolchain",
     "generator": "Ninja",

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ When should you use this over ROS? Click [here](doc/comparison_to_ros.md)!
 
 ### Env
 The best way to build hephaestus is to do it inside the docker container provided in the `docker` folder. You can build the container with `build.sh` and start it using `run.sh`.
-If you add or update a dependency, bump `DEPS_VERSION`.
 
 ### Compilation
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
     apt install -y kitware-archive-keyring cmake && \
     rm -rf /var/lib/apt/lists/*
 
-ENV CLANG_VERSION=17
+ENV CLANG_VERSION=19
 RUN wget https://apt.llvm.org/llvm.sh && \
     sed -i "s/add-apt-repository \"${REPO_NAME}\"/add-apt-repository \"${REPO_NAME}\" -y/g" llvm.sh && \
     chmod +x llvm.sh && \
@@ -35,7 +35,7 @@ RUN  update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$CLANG_VE
 
 RUN ln -s /usr/bin/clangd-${CLANG_VERSION} /usr/bin/clangd
 
-RUN export ZENOH_VERSION="1.0.0~alpha.6-1" && \
+RUN export ZENOH_VERSION="1.0.0~beta.3-1" && \
     echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | tee /etc/apt/sources.list.d/zenoh.list >/dev/null && \
     (apt-get update && apt-get install --no-install-recommends -y --allow-downgrades zenohd=${ZENOH_VERSION} zenoh-plugin-rest=${ZENOH_VERSION} || true) && \
     sed -i 's/systemctl /# remove if fixed by zenoh: systemctl /' /var/lib/dpkg/info/zenohd.postinst && \

--- a/docker/build_deps.sh
+++ b/docker/build_deps.sh
@@ -14,19 +14,10 @@ docker pull ${BASE_IMAGE}
 SUFFIX=deps
 IMAGE_NAME="${HOST}/${ARCH}/${IMAGE}_${SUFFIX}"
 
-function docker_tag_exists() {
-    docker manifest inspect ${IMAGE_NAME}:${DEPS_VERSION} > /dev/null
-}
+echo "Building image: ${IMAGE_NAME}"
+pushd ../
+docker build . -t ${IMAGE_NAME} -f docker/Dockerfile_deps --cpuset-cpus "0-$ncores" --build-arg BASE_IMAGE=${BASE_IMAGE} --tag ${IMAGE_NAME}:latest
+popd
 
-if docker_tag_exists; then
-    echo "Image already exists, you can pull it with:"
-    echo "$ docker pull ${IMAGE_NAME}:${DEPS_VERSION}"
-else
-    echo "Building image: ${IMAGE_NAME}:${DEPS_VERSION}"
-    pushd ../
-    docker build . -t ${IMAGE_NAME}:${DEPS_VERSION} -f docker/Dockerfile_deps --cpuset-cpus "0-$ncores" --build-arg BASE_IMAGE=${BASE_IMAGE} --tag ${IMAGE_NAME}:latest
-    popd
-
-    docker push ${IMAGE_NAME}:${DEPS_VERSION}
-    docker push ${IMAGE_NAME}:latest
-fi
+docker push ${IMAGE_NAME}
+docker push ${IMAGE_NAME}:latest

--- a/docker/version.sh
+++ b/docker/version.sh
@@ -1,6 +1,3 @@
 HOST=ghcr.io/olympus-robotics
-VERSION=1.0.12
+VERSION=1.0.13
 IMAGE=hephaestus-dev
-
-# This is the version of the dep image. Increase this number everytime you change `external/CMakeLists.txt`
-DEPS_VERSION=1.0.27

--- a/modules/bag/tests/tests.cpp
+++ b/modules/bag/tests/tests.cpp
@@ -38,8 +38,8 @@ constexpr auto SENDER_ID = "bag_tester";
 constexpr auto ROBOT_TOPIC = "bag_test/robot";
 constexpr auto FLEET_TOPIC = "bag_test/fleet";
 
-[[nodiscard]] auto createBag()
-    -> std::tuple<utils::filesystem::ScopedPath, std::vector<Robot>, std::vector<Fleet>> {
+[[nodiscard]] auto
+createBag() -> std::tuple<utils::filesystem::ScopedPath, std::vector<Robot>, std::vector<Fleet>> {
   auto scoped_path = utils::filesystem::ScopedPath::createFile();
   auto mcap_writer = createMcapWriter({ scoped_path });
 
@@ -85,7 +85,11 @@ TEST(Bag, PlayAndRecord) {
     auto bag_writer = createMcapWriter({ output_bag });
     auto recorder = ZenohRecorder::create({ .session = ipc::zenoh::createSession({}),
                                             .bag_writer = std::move(bag_writer),
-                                            .topics_filter_params = { .prefix = "bag_test/" } });
+                                            .topics_filter_params = {
+                                                .include_topics_only = {},
+                                                .prefix = "bag_test/",
+                                                .exclude_topics = {},
+                                            } });
     {
       auto reader = std::make_unique<mcap::McapReader>();
       const auto status = reader->open(bag_path);

--- a/modules/cli/include/hephaestus/cli/program_options.h
+++ b/modules/cli/include/hephaestus/cli/program_options.h
@@ -86,8 +86,8 @@ public:
   /// @param description A brief text describing the option
   /// @return Reference to the object. Enables daisy-chained calls
   template <StringStreamable T>
-  auto defineOption(const std::string& key, char short_key, const std::string& description)
-      -> ProgramDescription&;
+  auto defineOption(const std::string& key, char short_key,
+                    const std::string& description) -> ProgramDescription&;
 
   /// @brief Defines a command line option (--key=value) that is optional
   /// @tparam T Value type
@@ -96,8 +96,8 @@ public:
   /// @param default_value Default value to use if the option is not specified on the command line
   /// @return Reference to the object. Enables daisy-chained calls
   template <StringStreamable T>
-  auto defineOption(const std::string& key, const std::string& description, const T& default_value)
-      -> ProgramDescription&;
+  auto defineOption(const std::string& key, const std::string& description,
+                    const T& default_value) -> ProgramDescription&;
 
   /// @brief Defines a command line option (--key=value) that is optional
   /// @tparam T Value type
@@ -116,8 +116,8 @@ public:
   /// @param short_key Single char (can be used as alias for --key)
   /// @param description A brief text describing the option
   /// @return Reference to the object. Enables daisy-chained calls
-  auto defineFlag(const std::string& key, char short_key, const std::string& description)
-      -> ProgramDescription&;
+  auto defineFlag(const std::string& key, char short_key,
+                  const std::string& description) -> ProgramDescription&;
 
   /// @brief Defines a boolean option (flag) (--key=value) on the command line. If the flag is
   /// passed the value of the option is true, false otherwise.
@@ -156,14 +156,14 @@ private:
 };
 
 template <StringStreamable T>
-auto ProgramDescription::defineOption(const std::string& key, const std::string& description)
-    -> ProgramDescription& {
+auto ProgramDescription::defineOption(const std::string& key,
+                                      const std::string& description) -> ProgramDescription& {
   return defineOption<T>(key, '\0', description);
 }
 
 template <StringStreamable T>
-auto ProgramDescription::defineOption(const std::string& key, char short_key, const std::string& description)
-    -> ProgramDescription& {
+auto ProgramDescription::defineOption(const std::string& key, char short_key,
+                                      const std::string& description) -> ProgramDescription& {
   checkOptionAlreadyExists(key, short_key);
 
   options_.emplace_back(key, short_key, description, utils::getTypeName<T>(), "", true, false);

--- a/modules/cli/src/program_options.cpp
+++ b/modules/cli/src/program_options.cpp
@@ -33,8 +33,8 @@ ProgramOptions::ProgramOptions(std::vector<Option>&& options) : options_(std::mo
 }
 
 auto ProgramOptions::hasOption(const std::string& option) const -> bool {
-  return (options_.end() != std::find_if(options_.begin(), options_.end(),
-                                         [&option](const auto& opt) { return option == opt.key; }));
+  return (options_.end() !=
+          std::ranges::find_if(options_, [&option](const auto& opt) { return option == opt.key; }));
 }
 
 ProgramDescription::ProgramDescription(std::string brief) : brief_(std::move(brief)) {
@@ -42,8 +42,7 @@ ProgramDescription::ProgramDescription(std::string brief) : brief_(std::move(bri
 }
 
 void ProgramDescription::checkOptionAlreadyExists(const std::string& key, char k) const {
-  const auto it =
-      std::find_if(options_.begin(), options_.end(), [&key](const auto& opt) { return key == opt.key; });
+  const auto it = std::ranges::find_if(options_, [&key](const auto& opt) { return key == opt.key; });
   throwExceptionIf<InvalidOperationException>(it != options_.end(),
                                               fmt::format("Attempted redefinition of option '{}'", key));
 
@@ -51,23 +50,22 @@ void ProgramDescription::checkOptionAlreadyExists(const std::string& key, char k
     return;
   }
 
-  const auto short_it =
-      std::find_if(options_.begin(), options_.end(), [k](const auto& opt) { return k == opt.short_key; });
+  const auto short_it = std::ranges::find_if(options_, [k](const auto& opt) { return k == opt.short_key; });
   throwExceptionIf<InvalidOperationException>(
       short_it != options_.end(),
       fmt::format("Attempted redefinition of short key '{}' for option '{}'", k, key));
 }
 
-auto ProgramDescription::defineFlag(const std::string& key, char short_key, const std::string& description)
-    -> ProgramDescription& {
+auto ProgramDescription::defineFlag(const std::string& key, char short_key,
+                                    const std::string& description) -> ProgramDescription& {
   checkOptionAlreadyExists(key, short_key);
 
   options_.emplace_back(key, short_key, description, utils::getTypeName<bool>(), "false", false, false);
   return *this;
 }
 
-auto ProgramDescription::defineFlag(const std::string& key, const std::string& description)
-    -> ProgramDescription& {
+auto ProgramDescription::defineFlag(const std::string& key,
+                                    const std::string& description) -> ProgramDescription& {
   return defineFlag(key, '\0', description);
 }
 
@@ -119,8 +117,7 @@ auto ProgramDescription::parse(const std::vector<std::string>& args) && -> Progr
 auto ProgramDescription::getOptionFromArg(const std::string& arg) -> ProgramOptions::Option& {
   if (arg.starts_with("--")) {
     const auto key = arg.substr(2);
-    const auto it =
-        std::find_if(options_.begin(), options_.end(), [&key](const auto& opt) { return key == opt.key; });
+    const auto it = std::ranges::find_if(options_, [&key](const auto& opt) { return key == opt.key; });
 
     throwExceptionIf<InvalidParameterException>(it == options_.end(),
                                                 fmt::format("Undefined option '{}'", key));
@@ -131,8 +128,8 @@ auto ProgramDescription::getOptionFromArg(const std::string& arg) -> ProgramOpti
     throwExceptionIf<InvalidParameterException>(arg.size() != 2,
                                                 fmt::format("Undefined option '{}'", arg.substr(1)));
     const auto short_key = arg[1];
-    const auto it = std::find_if(options_.begin(), options_.end(),
-                                 [short_key](const auto& opt) { return short_key == opt.short_key; });
+    const auto it =
+        std::ranges::find_if(options_, [short_key](const auto& opt) { return short_key == opt.short_key; });
     return *it;
   }
 

--- a/modules/concurrency/tests/queue_consumer_tests.cpp
+++ b/modules/concurrency/tests/queue_consumer_tests.cpp
@@ -48,8 +48,7 @@ TEST(MessageQueueConsumer, ProcessMessages) {
   spinner.start();
   auto mt = random::createRNG();
   std::vector<Message> messages(MESSAGE_COUNT);
-  std::for_each(messages.begin(), messages.end(),
-                [&mt](Message& message) { message.value = random::random<int>(mt); });
+  std::ranges::for_each(messages, [&mt](Message& message) { message.value = random::random<int>(mt); });
   for (const auto& message : messages) {
     spinner.queue().forcePush(message);
   }

--- a/modules/containers/examples/blocking_queue_example.cpp
+++ b/modules/containers/examples/blocking_queue_example.cpp
@@ -10,6 +10,7 @@
 
 #include "hephaestus/containers/blocking_queue.h"
 
+namespace {
 class String {
 public:
   String() {
@@ -74,6 +75,7 @@ void pushVsEmplace() {
     }
   }
 }
+}  // namespace
 
 auto main() -> int {
   try {

--- a/modules/containers/include/hephaestus/containers/blocking_queue.h
+++ b/modules/containers/include/hephaestus/containers/blocking_queue.h
@@ -41,8 +41,10 @@ public:
       if (max_size_.has_value() && queue_.size() == *max_size_) {
         return false;
       }
+
       queue_.push_back(std::forward<U>(obj));
     }
+
     reader_signal_.notify_one();
     return true;
   }
@@ -60,8 +62,10 @@ public:
         element_dropped.emplace(std::move(queue_.front()));
         queue_.pop_front();
       }
+
       queue_.push_back(std::forward<U>(obj));
     }
+
     reader_signal_.notify_one();
     return element_dropped;
   }
@@ -78,8 +82,10 @@ public:
       if (stop_) {
         return;
       }
+
       queue_.push_back(std::forward<U>(obj));
     }
+
     reader_signal_.notify_one();
   }
 
@@ -94,8 +100,10 @@ public:
       if (max_size_.has_value() && queue_.size() == *max_size_) {
         return false;
       }
+
       queue_.emplace_back(std::forward<Args>(args)...);
     }
+
     reader_signal_.notify_one();
     return true;
   }
@@ -113,8 +121,10 @@ public:
         element_dropped.emplace(std::move(queue_.front()));
         queue_.pop_front();
       }
+
       queue_.emplace_back(std::forward<Args>(args)...);
     }
+
     reader_signal_.notify_one();
     return element_dropped;
   }
@@ -132,8 +142,10 @@ public:
       if (stop_) {
         return;
       }
+
       queue_.emplace_back(std::forward<Args>(args)...);
     }
+
     reader_signal_.notify_one();
   }
 
@@ -147,6 +159,7 @@ public:
     if (stop_) {
       return {};
     }
+
     auto value = std::move(queue_.front());
     queue_.pop_front();
     writer_signal_.notify_one();  // Notifying a writer waiting that there is an empty space.
@@ -161,6 +174,7 @@ public:
     if (queue_.empty()) {
       return {};
     }
+
     auto value = std::move(queue_.front());
     queue_.pop_front();
     writer_signal_.notify_one();  // Notifying a writer waiting that there is an empty space.
@@ -189,7 +203,7 @@ public:
   }
 
 private:
-  std::deque<T> queue_;
+  std::deque<T> queue_{};
   std::optional<std::size_t> max_size_;
   std::condition_variable reader_signal_;
   std::condition_variable writer_signal_;

--- a/modules/containers/tests/blocking_queue_tests.cpp
+++ b/modules/containers/tests/blocking_queue_tests.cpp
@@ -75,8 +75,8 @@ TEST(BlockingQueue, WaitPush) {
   const std::string message = "hello";
   block_queue.waitAndPush(message);
   auto future = std::async([&block_queue]() {
-    std::string message = "hello again";
-    block_queue.waitAndPush(std::move(message));
+    std::string msg = "hello again";
+    block_queue.waitAndPush(std::move(msg));
   });
   auto data = block_queue.tryPop();
   EXPECT_TRUE(data);

--- a/modules/examples/examples/mcap_reader.cpp
+++ b/modules/examples/examples/mcap_reader.cpp
@@ -2,7 +2,6 @@
 // Copyright (C) 2023-2024 HEPHAESTUS Contributors
 //=================================================================================================
 
-#include <cstdio>
 #include <cstdlib>
 #include <exception>
 #include <filesystem>

--- a/modules/examples/examples/mcap_writer.cpp
+++ b/modules/examples/examples/mcap_writer.cpp
@@ -4,7 +4,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <exception>
 #include <filesystem>

--- a/modules/examples/examples/zenoh_action_server.cpp
+++ b/modules/examples/examples/zenoh_action_server.cpp
@@ -27,6 +27,7 @@
 #include "hephaestus/utils/stack_trace.h"
 #include "zenoh_program_options.h"
 
+namespace {
 [[nodiscard]] auto request(const heph::examples::types::SampleRequest& sample)
     -> heph::ipc::zenoh::action_server::TriggerStatus {
   LOG(INFO) << fmt::format("Request received: {}", sample);
@@ -53,15 +54,16 @@ execute(const heph::examples::types::SampleRequest& request,
     }
 
     accumulated += 1;
-    const auto result =
-        status_update_publisher.publish(heph::examples::types::SampleReply{ accumulated, counter });
+    const auto result = status_update_publisher.publish(
+        heph::examples::types::SampleReply{ .value = accumulated, .counter = counter });
     LOG_IF(ERROR, !result) << "Failed to publish status update";
     fmt::println("- Update {}: {} ", counter, accumulated);
     std::this_thread::sleep_for(WAIT_FOR);
   }
 
-  return { accumulated, counter };
+  return { .value = accumulated, .counter = counter };
 }
+}  // namespace
 
 // We create a simple action server that accumulates a value for a given number of iterations.
 // See VectorAccumulator class for more details.

--- a/modules/examples/examples/zenoh_program_options.h
+++ b/modules/examples/examples/zenoh_program_options.h
@@ -19,4 +19,6 @@ enum class ExampleType : uint8_t { PUBSUB, SERVICE, ACTION_SERVER };
     case ExampleType::ACTION_SERVER:
       return DEFAULT_ACTION_SERVER_KEY;
   }
+
+  __builtin_unreachable();  // TODO(C++23): replace with std::unreachable.
 }

--- a/modules/examples/examples/zenoh_service_client.cpp
+++ b/modules/examples/examples/zenoh_service_client.cpp
@@ -45,8 +45,8 @@ auto main(int argc, const char* argv[]) -> int {
             *session, topic_config, query, K_TIMEOUT);
     if (!replies.empty()) {
       std::string reply_str;
-      std::for_each(replies.begin(), replies.end(),
-                    [&reply_str](const auto& reply) { reply_str += fmt::format("-\t {}\n", reply.value); });
+      std::ranges::for_each(
+          replies, [&reply_str](const auto& reply) { reply_str += fmt::format("-\t {}\n", reply.value); });
       fmt::println("Received: \n{}\n", reply_str);
     } else {
       LOG(ERROR) << "Error or no messages received after " << fmt::format("{}", K_TIMEOUT);

--- a/modules/examples/examples/zenoh_string_service_client.cpp
+++ b/modules/examples/examples/zenoh_string_service_client.cpp
@@ -41,7 +41,7 @@ auto main(int argc, const char* argv[]) -> int {
         heph::ipc::zenoh::callService<std::string, std::string>(*session, topic_config, query, K_TIMEOUT);
     if (!replies.empty()) {
       std::string reply_str;
-      std::for_each(replies.begin(), replies.end(), [&reply_str](const auto& reply) {
+      std::ranges::for_each(replies, [&reply_str](const auto& reply) {
         reply_str = fmt::format("{}\n-\t{}: {}", reply_str, reply.topic, reply.value);
       });
       LOG(INFO) << "Received: " << reply_str;

--- a/modules/examples/tests/zenoh_tests.cpp
+++ b/modules/examples/tests/zenoh_tests.cpp
@@ -24,7 +24,6 @@ namespace heph::examples::types::tests {
 
 namespace {
 constexpr auto kSeed = 42;  // NOLINT(readability-identifier-naming)
-}  // namespace
 
 void checkMessageExchange(bool subscriber_dedicated_callback_thread) {
   auto mt = random::createRNG();
@@ -137,4 +136,5 @@ TEST(ZenohTests, ServiceCallExchange) {
   EXPECT_EQ(reply.front().value, request_message);
 }
 
+}  // namespace
 }  // namespace heph::examples::types::tests

--- a/modules/ipc/apps/zenoh_node_list.cpp
+++ b/modules/ipc/apps/zenoh_node_list.cpp
@@ -23,8 +23,8 @@ auto main(int argc, const char* argv[]) -> int {
     fmt::println("Scouting..");
 
     auto nodes_info = heph::ipc::zenoh::getListOfNodes();
-    std::for_each(nodes_info.begin(), nodes_info.end(),
-                  [](const auto& info) { fmt::println("{}", heph::ipc::zenoh::toString(info)); });
+    std::ranges::for_each(nodes_info,
+                          [](const auto& info) { fmt::println("{}", heph::ipc::zenoh::toString(info)); });
 
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/modules/ipc/apps/zenoh_string_service.cpp
+++ b/modules/ipc/apps/zenoh_string_service.cpp
@@ -39,8 +39,8 @@ auto main(int argc, const char* argv[]) -> int {
 
     auto results = heph::ipc::zenoh::callService<std::string, std::string>(*session, topic_config, value);
 
-    std::for_each(results.begin(), results.end(),
-                  [](const auto& res) { fmt::println(">> Received ('{}': '{}')", res.topic, res.value); });
+    std::ranges::for_each(
+        results, [](const auto& res) { fmt::println(">> Received ('{}': '{}')", res.topic, res.value); });
 
     return EXIT_SUCCESS;
   } catch (const std::exception& ex) {

--- a/modules/ipc/apps/zenoh_topic_list.cpp
+++ b/modules/ipc/apps/zenoh_topic_list.cpp
@@ -20,9 +20,11 @@
 #include "hephaestus/utils/signal_handler.h"
 #include "hephaestus/utils/stack_trace.h"
 
+namespace {
 void getListOfPublisher(const heph::ipc::zenoh::Session& session, std::string_view topic) {
   const auto publishers_info = heph::ipc::zenoh::getListOfPublishers(session, topic);
-  std::for_each(publishers_info.begin(), publishers_info.end(), &heph::ipc::zenoh::printPublisherInfo);
+  std::ranges::for_each(publishers_info.begin(), publishers_info.end(),
+                        &heph::ipc::zenoh::printPublisherInfo);
 }
 
 void getLiveListOfPublisher(heph::ipc::zenoh::SessionPtr session, heph::ipc::TopicConfig topic_config) {
@@ -31,6 +33,7 @@ void getLiveListOfPublisher(heph::ipc::zenoh::SessionPtr session, heph::ipc::Top
 
   heph::utils::TerminationBlocker::waitForInterrupt();
 }
+}  // namespace
 
 auto main(int argc, const char* argv[]) -> int {
   const heph::utils::StackTrace stack_trace;

--- a/modules/ipc/include/hephaestus/ipc/topic_database.h
+++ b/modules/ipc/include/hephaestus/ipc/topic_database.h
@@ -22,7 +22,7 @@ namespace zenoh {
 struct Session;
 }
 
-[[nodiscard]] auto createZenohTopicDatabase(std::shared_ptr<zenoh::Session> session)
-    -> std::unique_ptr<ITopicDatabase>;
+[[nodiscard]] auto
+createZenohTopicDatabase(std::shared_ptr<zenoh::Session> session) -> std::unique_ptr<ITopicDatabase>;
 
 }  // namespace heph::ipc

--- a/modules/ipc/include/hephaestus/ipc/zenoh/action_server/action_server.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/action_server/action_server.h
@@ -109,8 +109,8 @@ template <typename RequestT, typename StatusT, typename ReplyT>
     -> std::future<Response<ReplyT>>;
 
 /// Request the action server to stop.
-[[nodiscard]] auto requestActionServerToStopExecution(Session& session, const TopicConfig& topic_config)
-    -> bool;
+[[nodiscard]] auto requestActionServerToStopExecution(Session& session,
+                                                      const TopicConfig& topic_config) -> bool;
 
 // TODO: add a function to get notified when the server is idle again.
 
@@ -242,8 +242,9 @@ auto callActionServer(SessionPtr session, const TopicConfig& topic_config, const
   }
 
   return std::async(
+      std::launch::async,
       // NOLINTNEXTLINE(bugprone-exception-escape)
-      std::launch::async, [session, topic_config, status_update_cb = std::move(status_update_cb)]() mutable {
+      [session = std::move(session), topic_config, status_update_cb = std::move(status_update_cb)]() mutable {
         auto client_helper = internal::ClientHelper<RequestT, StatusT, ReplyT>{ session, topic_config,
                                                                                 std::move(status_update_cb) };
 

--- a/modules/ipc/include/hephaestus/ipc/zenoh/program_options.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/program_options.h
@@ -13,7 +13,7 @@ static constexpr auto DEFAULT_TOPIC = "**";
 void appendProgramOption(cli::ProgramDescription& program_description,
                          const std::string& default_topic = DEFAULT_TOPIC);
 
-[[nodiscard]] auto parseProgramOptions(const heph::cli::ProgramOptions& args)
-    -> std::pair<Config, TopicConfig>;
+[[nodiscard]] auto
+parseProgramOptions(const heph::cli::ProgramOptions& args) -> std::pair<Config, TopicConfig>;
 
 }  // namespace heph::ipc::zenoh

--- a/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
@@ -37,10 +37,10 @@ private:
 };
 
 template <typename T>
-[[nodiscard]] auto createSubscriber(zenoh::SessionPtr session, TopicConfig topic_config,
-                                    typename Subscriber<T>::DataCallback&& callback,
-                                    bool dedicated_callback_thread = false)
-    -> std::unique_ptr<Subscriber<T>> {
+[[nodiscard]] auto
+createSubscriber(zenoh::SessionPtr session, TopicConfig topic_config,
+                 typename Subscriber<T>::DataCallback&& callback,
+                 bool dedicated_callback_thread = false) -> std::unique_ptr<Subscriber<T>> {
   return std::make_unique<Subscriber<T>>(std::move(session), std::move(topic_config), std::move(callback),
                                          dedicated_callback_thread);
 }

--- a/modules/ipc/src/topic_filter.cpp
+++ b/modules/ipc/src/topic_filter.cpp
@@ -64,7 +64,7 @@ auto TopicFilter::anyExcluding(const std::vector<std::string>& topic_names) && -
 
 /// Return true if the input topic passes the concatenated list of filters.
 auto TopicFilter::isAcceptable(const std::string& topic) const -> bool {
-  return std::all_of(match_cb_.begin(), match_cb_.end(), [&topic](const auto& cb) { return cb(topic); });
+  return std::ranges::all_of(match_cb_, [&topic](const auto& cb) { return cb(topic); });
 }
 
 }  // namespace heph::ipc

--- a/modules/ipc/src/zenoh/action_server/types_protobuf.cpp
+++ b/modules/ipc/src/zenoh/action_server/types_protobuf.cpp
@@ -9,6 +9,8 @@
 #include "hephaestus/ipc/zenoh/action_server/types.h"
 
 namespace heph::ipc::zenoh::action_server {
+// TODO(@fbrizzi): for some reason clang-tidy doesn't understand that this are public function declared in the
+// header.
 // NOLINTBEGIN(misc-use-internal-linkage)
 void toProto(proto::RequestStatus& proto_status, const RequestStatus& status) {
   switch (status) {

--- a/modules/ipc/src/zenoh/action_server/types_protobuf.cpp
+++ b/modules/ipc/src/zenoh/action_server/types_protobuf.cpp
@@ -9,6 +9,7 @@
 #include "hephaestus/ipc/zenoh/action_server/types.h"
 
 namespace heph::ipc::zenoh::action_server {
+// NOLINTBEGIN(misc-use-internal-linkage)
 void toProto(proto::RequestStatus& proto_status, const RequestStatus& status) {
   switch (status) {
     case RequestStatus::SUCCESSFUL:
@@ -61,4 +62,5 @@ void toProto(proto::RequestResponse& proto_response, const RequestResponse& resp
 void fromProto(const proto::RequestResponse& proto_response, RequestResponse& response) {
   fromProto(proto_response.status(), response.status);
 }
+// NOLINTEND(misc-use-internal-linkage)
 }  // namespace heph::ipc::zenoh::action_server

--- a/modules/ipc/src/zenoh/liveliness.cpp
+++ b/modules/ipc/src/zenoh/liveliness.cpp
@@ -63,7 +63,7 @@ auto getListOfPublishers(const Session& session, std::string_view topic) -> std:
 
   std::vector<PublisherInfo> infos;
   infos.reserve(topics.size());
-  std::transform(topics.begin(), topics.end(), std::back_inserter(infos), [](const std::string& topic_name) {
+  std::ranges::transform(topics, std::back_inserter(infos), [](const std::string& topic_name) {
     return PublisherInfo{ .topic = topic_name, .status = PublisherStatus::ALIVE };
   });
   return infos;

--- a/modules/ipc/src/zenoh/raw_publisher.cpp
+++ b/modules/ipc/src/zenoh/raw_publisher.cpp
@@ -43,8 +43,8 @@ inline void zenohOnMatchingStatus(const ::zc_matching_status_t* matching_status,
 }
 
 template <typename C, typename D>
-[[nodiscard]] auto createZenohcClosureMatchingStatus(C&& on_matching_status, D&& on_drop)
-    -> zc_owned_closure_matching_status_t {
+[[nodiscard]] auto createZenohcClosureMatchingStatus(C&& on_matching_status,
+                                                     D&& on_drop) -> zc_owned_closure_matching_status_t {
   zc_owned_closure_matching_status_t c_closure;
   using Cval = std::remove_reference_t<C>;
   using Dval = std::remove_reference_t<D>;

--- a/modules/ipc/src/zenoh/scout.cpp
+++ b/modules/ipc/src/zenoh/scout.cpp
@@ -33,8 +33,8 @@ namespace heph::ipc::zenoh {
 
 namespace {
 
-[[nodiscard]] inline auto toStringVector(const std::vector<std::string_view>& str_vec)
-    -> std::vector<std::string> {
+[[nodiscard]] inline auto
+toStringVector(const std::vector<std::string_view>& str_vec) -> std::vector<std::string> {
   std::vector<std::string> output_vec;
   output_vec.reserve(str_vec.size());
   for (const auto& str : str_vec) {
@@ -103,8 +103,7 @@ auto getListOfNodes() -> std::vector<NodeInfo> {
   ScoutDataManager manager;
 
   auto config = ::zenoh::Config::create_default();
-  ::zenoh::scout(
-      std::move(config), [&manager](const auto& hello) { manager.onDiscovery(hello); }, []() {});
+  ::zenoh::scout(std::move(config), [&manager](const auto& hello) { manager.onDiscovery(hello); }, []() {});
 
   auto nodes = manager.getNodesInfo();
 

--- a/modules/ipc/src/zenoh/session.cpp
+++ b/modules/ipc/src/zenoh/session.cpp
@@ -48,7 +48,9 @@ auto createZenohConfig(const Config& config) -> ::zenoh::Config {
     const auto router_endpoint = fmt::format(R"(["tcp/{}"])", config.router);
     zconfig.insert_json5(Z_CONFIG_CONNECT_KEY, router_endpoint);  // NOLINT(misc-include-cleaner)
   }
-  { zconfig.insert_json5("transport/unicast/qos/enabled", config.qos ? "true" : "false"); }
+  {
+    zconfig.insert_json5("transport/unicast/qos/enabled", config.qos ? "true" : "false");
+  }
   if (config.real_time) {
     zconfig.insert_json5("transport/unicast/qos/enabled", "false");
     zconfig.insert_json5("transport/unicast/lowlatency", "true");

--- a/modules/ipc/tests/topic_filter_tests.cpp
+++ b/modules/ipc/tests/topic_filter_tests.cpp
@@ -12,7 +12,7 @@
 using namespace ::testing;
 
 namespace heph::bag::tests {
-
+namespace {
 using TestCasesT = std::vector<std::pair<std::string, bool>>;
 
 auto runTestCases(const ipc::TopicFilter& filter, const TestCasesT& test_cases) -> void {
@@ -132,5 +132,5 @@ TEST(TopicFilter, IncludeOnly) {
     runTestCases(filter, test_cases);
   }
 }
-
+}  // namespace
 }  // namespace heph::bag::tests

--- a/modules/random/include/hephaestus/random/random_number_generator.h
+++ b/modules/random/include/hephaestus/random/random_number_generator.h
@@ -15,8 +15,8 @@ static constexpr bool IS_DETERMINISTIC = false;
 
 /// \brief Returns a random number generator (RNG) which is preconfigured to be deterministic or not.
 /// 'is_deterministic' is exposed for unit testing, but shall in general not be set by the caller.
-[[nodiscard]] auto createRNG(bool is_deterministic = random_number_generator::IS_DETERMINISTIC)
-    -> std::mt19937_64;
+[[nodiscard]] auto
+createRNG(bool is_deterministic = random_number_generator::IS_DETERMINISTIC) -> std::mt19937_64;
 
 /// \brief Returns a pair (but not a copy) of identical random number generators (RNG) which are preconfigured
 /// to be deterministic, or not. This is useful for testing functions which require two random number

--- a/modules/random/include/hephaestus/random/random_object_creator.h
+++ b/modules/random/include/hephaestus/random/random_object_creator.h
@@ -120,8 +120,8 @@ concept RandomCreatable = requires(std::mt19937_64& mt) {
 // Internal helper functions for container types
 //=================================================================================================
 namespace internal {
-[[nodiscard]] inline auto getSize(std::mt19937_64& mt, std::optional<size_t> fixed_size, bool allow_empty)
-    -> size_t {
+[[nodiscard]] inline auto getSize(std::mt19937_64& mt, std::optional<size_t> fixed_size,
+                                  bool allow_empty) -> size_t {
   if (fixed_size.has_value()) {
     throwExceptionIf<InvalidParameterException>(
         allow_empty == false && fixed_size.value() == 0,

--- a/modules/random/tests/random_object_creator_tests.cpp
+++ b/modules/random/tests/random_object_creator_tests.cpp
@@ -79,8 +79,8 @@ TYPED_TEST(RandomTypeTests, DeterminismTest) {
 
 TYPED_TEST(RandomTypeTests, RandomnessTest) {
   auto mt = createRNG();
-  auto gen = [](std::mt19937_64& gen) -> TypeParam { return random::random<TypeParam>(gen); };
-  EXPECT_FALSE(compareRandomEqualMultipleTimes<TypeParam>(gen, mt));
+  auto gen_fn = [](std::mt19937_64& gen) -> TypeParam { return random::random<TypeParam>(gen); };
+  EXPECT_FALSE(compareRandomEqualMultipleTimes<TypeParam>(gen_fn, mt));
 }
 
 // Note: If the size of the container is not specified, the size is randomly generated. No need to test this

--- a/modules/random/tests/random_object_creator_tests.cpp
+++ b/modules/random/tests/random_object_creator_tests.cpp
@@ -14,16 +14,17 @@
 
 #include "hephaestus/random/random_number_generator.h"
 #include "hephaestus/random/random_object_creator.h"
+#include "hephaestus/utils/concepts.h"
 #include "hephaestus/utils/exception.h"
 
 // NOLINTNEXTLINE(google-build-using-namespace)
 using namespace ::testing;
 
 namespace heph::random {
-
+namespace {
 /// Compare the results of a randomly generated type multiple times to ensure that it is not equal by chance.
 template <class T>
-[[nodiscard]] auto compareRandomEqualMultipleTimes(std::function<T(std::mt19937_64&)> gen,
+[[nodiscard]] auto compareRandomEqualMultipleTimes(const std::function<T(std::mt19937_64&)>& gen,
                                                    std::mt19937_64& mt) -> bool {
   static constexpr std::size_t MAX_COMPARISON_COUNT = 10;
 
@@ -50,8 +51,10 @@ struct TestStruct {
   [[nodiscard]] auto operator==(const TestStruct&) const -> bool = default;
 
   [[nodiscard]] static auto random(std::mt19937_64& mt) -> TestStruct {
-    return { random::random<int>(mt), random::random<double>(mt), random::random<std::string>(mt),
-             random::random<std::vector<int>>(mt) };
+    return { .a = random::random<int>(mt),
+             .b = random::random<double>(mt),
+             .c = random::random<std::string>(mt),
+             .d = random::random<std::vector<int>>(mt) };
   }
 };
 
@@ -104,4 +107,5 @@ TYPED_TEST(RandomTypeTests, ContainerSizeTest) {
   }
 }
 
+}  // namespace
 }  // namespace heph::random

--- a/modules/serdes/include/hephaestus/serdes/protobuf/dynamic_deserializer.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/dynamic_deserializer.h
@@ -23,8 +23,8 @@ public:
   [[nodiscard]] auto toText(const std::string& type, std::span<const std::byte> data) -> std::string;
 
 private:
-  [[nodiscard]] auto getMessage(const std::string& type, std::span<const std::byte> data)
-      -> google::protobuf::Message*;
+  [[nodiscard]] auto getMessage(const std::string& type,
+                                std::span<const std::byte> data) -> google::protobuf::Message*;
 
 private:
   google::protobuf::SimpleDescriptorDatabase proto_db_;

--- a/modules/serdes/src/protobuf/dynamic_deserializer.cpp
+++ b/modules/serdes/src/protobuf/dynamic_deserializer.cpp
@@ -76,8 +76,8 @@ auto DynamicDeserializer::toText(const std::string& type, std::span<const std::b
   return msg_text;
 }
 
-auto DynamicDeserializer::getMessage(const std::string& type, std::span<const std::byte> data)
-    -> google::protobuf::Message* {
+auto DynamicDeserializer::getMessage(const std::string& type,
+                                     std::span<const std::byte> data) -> google::protobuf::Message* {
   const auto* descriptor = proto_pool_.FindMessageTypeByName(type);
   throwExceptionIf<InvalidDataException>(
       descriptor == nullptr,

--- a/modules/serdes/tests/tests.cpp
+++ b/modules/serdes/tests/tests.cpp
@@ -22,18 +22,19 @@
 using namespace ::testing;
 
 namespace heph::serdes::tests {
+namespace {
 
-static constexpr int NUMBER = 42;
+constexpr int NUMBER = 42;
 
 class MockProtoMessage {
 public:
-  // NOLINTNEXTLINE(modernize-use-trailing-return-type,bugprone-exception-escape)
+  // NOLINTNEXTLINE(modernize-use-trailing-return-type,readability-identifier-naming,bugprone-exception-escape)
   MOCK_METHOD(std::size_t, ByteSizeLong, (), (const));
 
-  // NOLINTNEXTLINE(modernize-use-trailing-return-type,bugprone-exception-escape)
+  // NOLINTNEXTLINE(modernize-use-trailing-return-type,readability-identifier-naming,bugprone-exception-escape)
   MOCK_METHOD(bool, SerializeToArray, (void*, int), (const));
 
-  // NOLINTNEXTLINE(modernize-use-trailing-return-type,bugprone-exception-escape)
+  // NOLINTNEXTLINE(modernize-use-trailing-return-type,readability-identifier-naming,bugprone-exception-escape)
   MOCK_METHOD(bool, ParseFromArray, (const void*, int), (const));
 };
 
@@ -51,7 +52,7 @@ struct DummyJSONSerializable {
 }
 
 void fromJSON(std::string_view json, DummyJSONSerializable& data) {
-  data.dummy = std::stoi(json.data());
+  data.dummy = std::stoi(json.data());  // NOLINT(bugprone-suspicious-stringview-data-usage)
 }
 
 struct DummyNlohmannJSONSerializable {
@@ -60,16 +61,18 @@ struct DummyNlohmannJSONSerializable {
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(DummyNlohmannJSONSerializable, dummy)
 
+}  // namespace
 }  // namespace heph::serdes::tests
 
 namespace heph::serdes::protobuf {
 template <>
-struct ProtoAssociation<heph::serdes::tests::Data> {
+struct ProtoAssociation<tests::Data> {
   using Type = heph::serdes::tests::MockProtoMessage;
 };
 }  // namespace heph::serdes::protobuf
 
 namespace heph::serdes::tests {
+namespace {
 
 TEST(Protobuf, SerializerBuffers) {
   protobuf::SerializerBuffer buffer;
@@ -169,4 +172,5 @@ TEST(SerDesText, Protobuf) {
   EXPECT_EQ(user, user_des);
 }
 
+}  // namespace
 }  // namespace heph::serdes::tests

--- a/modules/telemetry/telemetry/include/hephaestus/telemetry/metric_record.h
+++ b/modules/telemetry/telemetry/include/hephaestus/telemetry/metric_record.h
@@ -10,8 +10,8 @@
 
 namespace heph::telemetry {
 namespace internal {
-[[nodiscard]] auto jsonToValuesMap(std::string_view json)
-    -> std::unordered_map<std::string, Metric::ValueType>;
+[[nodiscard]] auto
+jsonToValuesMap(std::string_view json) -> std::unordered_map<std::string, Metric::ValueType>;
 }
 
 /// @brief Register a new metric sink.

--- a/modules/telemetry/telemetry_influxdb_sink/examples/influxdb_measure_example.cpp
+++ b/modules/telemetry/telemetry_influxdb_sink/examples/influxdb_measure_example.cpp
@@ -24,6 +24,7 @@
 #include "hephaestus/utils/stack_trace.h"
 
 namespace telemetry_example {
+namespace {
 constexpr auto MIN_DURATION = std::chrono::milliseconds{ 1000 }.count();
 constexpr auto MAX_DURATION = std::chrono::milliseconds{ 5000 }.count();
 
@@ -32,8 +33,7 @@ struct DummyMeasure {
   int64_t counter;
   std::string message;
 };
-// NOLINTNEXTLINE
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(DummyMeasure, error, counter, message)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(DummyMeasure, error, counter, message)
 
 void run() {
   auto mt = heph::random::createRNG();
@@ -49,7 +49,7 @@ void run() {
                             });
   }
 }
-
+}  // namespace
 }  // namespace telemetry_example
 
 auto main(int argc, const char* argv[]) -> int {

--- a/modules/types/include/hephaestus/types/bounds.h
+++ b/modules/types/include/hephaestus/types/bounds.h
@@ -70,6 +70,8 @@ constexpr auto isWithinBounds(T value, const Bounds<T>& bounds) -> bool {
     default:
       throwException<InvalidParameterException>("Incorrect Type");
   }
+
+  __builtin_unreachable();  // TODO(C++23): replace with std::unreachable.
 }
 
 template <NumericType T>

--- a/modules/types/include/hephaestus/types/bounds.h
+++ b/modules/types/include/hephaestus/types/bounds.h
@@ -27,7 +27,7 @@ enum class BoundsType : uint8_t {
 /// @brief A class representing range bounds.
 template <NumericType T>
 struct Bounds {
-  [[nodiscard]] inline constexpr auto operator==(const Bounds&) const -> bool = default;
+  [[nodiscard]] constexpr auto operator==(const Bounds&) const -> bool = default;
 
   [[nodiscard]] static auto random(std::mt19937_64& mt) -> Bounds;
 
@@ -37,10 +37,10 @@ struct Bounds {
 };
 
 template <NumericType T>
-[[nodiscard]] static inline constexpr auto isWithinBounds(T value, const Bounds<T>& bounds) -> bool;
+[[nodiscard]] static constexpr auto isWithinBounds(T value, const Bounds<T>& bounds) -> bool;
 
 template <NumericType T>
-[[nodiscard]] static inline constexpr auto clampValue(T value, const Bounds<T>& bounds) -> T;
+[[nodiscard]] static constexpr auto clampValue(T value, const Bounds<T>& bounds) -> T;
 
 template <NumericType T>
 auto operator<<(std::ostream& os, const Bounds<T>& bounds) -> std::ostream&;
@@ -57,7 +57,7 @@ auto Bounds<T>::random(std::mt19937_64& mt) -> Bounds {
 }
 
 template <NumericType T>
-inline constexpr auto isWithinBounds(T value, const Bounds<T>& bounds) -> bool {
+constexpr auto isWithinBounds(T value, const Bounds<T>& bounds) -> bool {
   switch (bounds.type) {
     case BoundsType::INCLUSIVE:
       return value >= bounds.lower && value <= bounds.upper;
@@ -73,7 +73,7 @@ inline constexpr auto isWithinBounds(T value, const Bounds<T>& bounds) -> bool {
 }
 
 template <NumericType T>
-inline constexpr auto clampValue(T value, const Bounds<T>& bounds) -> T {
+constexpr auto clampValue(T value, const Bounds<T>& bounds) -> T {
   return std::clamp(value, bounds.lower, bounds.upper);
 }
 

--- a/modules/types/include/hephaestus/types/dummy_type.h
+++ b/modules/types/include/hephaestus/types/dummy_type.h
@@ -59,8 +59,8 @@ struct DummyType {
   InternalDummyEnum internal_dummy_enum{};
   ExternalDummyEnum external_dummy_enum{};
 
-  std::string dummy_string{};
-  std::vector<int32_t> dummy_vector{};
+  std::string dummy_string;
+  std::vector<int32_t> dummy_vector;
 };
 
 auto operator<<(std::ostream& os, const DummyType& dummy_type) -> std::ostream&;

--- a/modules/types_proto/src/dummy_type.cpp
+++ b/modules/types_proto/src/dummy_type.cpp
@@ -12,13 +12,13 @@
 #include "hephaestus/types/proto/dummy_type.pb.h"
 
 namespace heph::types {
-
+namespace {
 //=================================================================================================
 // Vector
 //=================================================================================================
 template <typename T, typename ProtoT>
-auto toProto(google::protobuf::RepeatedField<ProtoT>& proto_repeated_field, const std::vector<T>& vec)
-    -> void {
+auto toProto(google::protobuf::RepeatedField<ProtoT>& proto_repeated_field,
+             const std::vector<T>& vec) -> void {
   proto_repeated_field.Clear();  // Ensure that the repeated field is empty before adding elements.
   proto_repeated_field.Reserve(static_cast<int>(vec.size()));
   for (const auto& value : vec) {
@@ -27,15 +27,15 @@ auto toProto(google::protobuf::RepeatedField<ProtoT>& proto_repeated_field, cons
 }
 
 template <typename T, typename ProtoT>
-auto fromProto(const google::protobuf::RepeatedField<ProtoT>& proto_repeated_field, std::vector<T>& vec)
-    -> void {
+auto fromProto(const google::protobuf::RepeatedField<ProtoT>& proto_repeated_field,
+               std::vector<T>& vec) -> void {
   vec.clear();  // Ensure that the vector is empty before adding elements.
   vec.reserve(static_cast<size_t>(proto_repeated_field.size()));
   for (const auto& proto_value : proto_repeated_field) {
     vec.push_back(proto_value);
   }
 }
-
+}  // namespace
 //=================================================================================================
 // DummyPrimitivesType
 //=================================================================================================

--- a/modules/utils/include/hephaestus/utils/concepts.h
+++ b/modules/utils/include/hephaestus/utils/concepts.h
@@ -76,7 +76,7 @@ template <typename T>
 concept ChronoTimestampType = ChronoSystemClockTimestampType<T> || ChronoSteadyClockTimestampType<T>;
 
 template <typename T>
-concept NumericType = (std::integral<T> || std::floating_point<T>)&&!std::same_as<T, bool>;
+concept NumericType = (std::integral<T> || std::floating_point<T>) && !std::same_as<T, bool>;
 
 /// Types that are convertable to and from a string
 template <typename T>

--- a/modules/utils/include/hephaestus/utils/filesystem/file.h
+++ b/modules/utils/include/hephaestus/utils/filesystem/file.h
@@ -19,8 +19,8 @@ namespace heph::utils::filesystem {
 [[nodiscard]] auto readBinaryFile(const std::filesystem::path& path) -> std::optional<std::vector<std::byte>>;
 
 [[nodiscard]] auto writeStringToFile(const std::filesystem::path& path, std::string_view content) -> bool;
-[[nodiscard]] auto writeBufferToFile(const std::filesystem::path& path, std::span<const std::byte> content)
-    -> bool;
+[[nodiscard]] auto writeBufferToFile(const std::filesystem::path& path,
+                                     std::span<const std::byte> content) -> bool;
 
 [[nodiscard]] auto searchFilenameInPaths(const std::string& filename,
                                          const std::vector<std::filesystem::path>& paths)

--- a/modules/utils/include/hephaestus/utils/format/format.h
+++ b/modules/utils/include/hephaestus/utils/format/format.h
@@ -67,7 +67,8 @@ template <EnumType T>
 
 template <ChronoSystemClockType T>
 [[nodiscard]] inline auto toString(const std::chrono::time_point<T>& timestamp) -> std::string {
-  return fmt::format("{:%Y-%m-%d %H:%M:%S}", timestamp);
+  return fmt::format("{:%Y-%m-%d %H:%M:%S}",
+                     std::chrono::time_point_cast<std::chrono::microseconds, T>(timestamp));
 }
 
 template <ChronoSteadyClockType T>

--- a/modules/utils/src/stack_trace.cpp
+++ b/modules/utils/src/stack_trace.cpp
@@ -29,7 +29,7 @@ private:
 };
 
 StackTrace::Impl::Impl() {
-  struct sigaction sa {};
+  struct sigaction sa{};
   sa.sa_flags = SA_SIGINFO;
   sa.sa_sigaction = StackTrace::Impl::abort;  // NOLINT(cppcoreguidelines-pro-type-union-access)
   sigemptyset(&sa.sa_mask);

--- a/modules/utils/src/version.cpp
+++ b/modules/utils/src/version.cpp
@@ -9,11 +9,11 @@
 
 namespace heph::utils {
 auto getBuildInfo() -> BuildInfo {
-  return { REPO_BRANCH, BUILD_PROFILE, REPO_HASH };
+  return { .branch = REPO_BRANCH, .profile = BUILD_PROFILE, .hash = REPO_HASH };
 }
 
 auto getVersion() -> Version {
-  return { VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH };
+  return { .major = VERSION_MAJOR, .minor = VERSION_MINOR, .patch = VERSION_PATCH };
 }
 
 }  // namespace heph::utils

--- a/modules/utils/tests/format_tests.cpp
+++ b/modules/utils/tests/format_tests.cpp
@@ -147,7 +147,7 @@ TEST(TypeFormattingTests, ChronoTimestampFormattingSteadyClock) {
 
   ASSERT_LE(str.length(), 24);
 
-  const auto it = std::find(str.begin(), str.end(), 'd');
+  const auto it = std::ranges::find(str, 'd');
   ASSERT_TRUE(it != str.end());
   ASSERT_EQ(*(it + 1), ' ');
   ASSERT_EQ(*(it + 4), 'h');

--- a/modules/utils/tests/format_tests.cpp
+++ b/modules/utils/tests/format_tests.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <fmt/core.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "hephaestus/utils/format/format.h"
@@ -47,6 +48,7 @@ TEST(TypeFormattingTests, ConvertDoubleArray) {
   EXPECT_EQ(result, expected);
 }
 
+#ifndef __GNUC__
 TEST(TypeFormattingTests, ConvertStringArray) {
   const std::array<std::string, 3> arr = { "one", "two", "three" };
   const std::string result = toString(arr);
@@ -55,6 +57,8 @@ TEST(TypeFormattingTests, ConvertStringArray) {
                                "  Index: 2, Value: three\n";
   EXPECT_EQ(result, expected);
 }
+#endif
+
 //=================================================================================================
 // Vector
 //=================================================================================================
@@ -163,7 +167,7 @@ TEST(TypeFormattingTests, ChronoTimestampFormattingSystemClock) {
   const auto timestamp = std::chrono::system_clock::now();
   const auto str = fmt::format("{}", toString(timestamp));
 
-  ASSERT_TRUE(str.length() <= 27);
+  ASSERT_LE(str.size(), 26);
 
   ASSERT_EQ(str[0], '2');
   ASSERT_EQ(str[1], '0');

--- a/modules/utils/tests/format_tests.cpp
+++ b/modules/utils/tests/format_tests.cpp
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include <fmt/core.h>
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "hephaestus/utils/format/format.h"


### PR DESCRIPTION
# Description
Upgrade to clang 19 and fix new errors, no major change, just following compiler suggestions. 
Some changes also came from making it compile for GCC.

* Fix `zenohd` version installed in docker to match the one from the library.
* Remove dependency docker version, to simplify and reduce the chance of errors that often happen from forgetting to increment the number when upgrading a dependency.
* Add a CMake prefix `gcc` to allow to easily build with GCC.
* To make the test pass for GCC I changed the resolution of the formatted for `time_point` to microseconds as GCC and clang have different default resolution.
