### PR TITLE
[IPC/Zenoh] add type info to message metadata for publisher

### DIFF
--- a/modules/bag/tests/tests.cpp
+++ b/modules/bag/tests/tests.cpp
@@ -25,9 +25,13 @@
 #include "hephaestus/types/dummy_type.h"
 #include "hephaestus/types_proto/dummy_type.h"  // NOLINT(misc-include-cleaner)
 #include "hephaestus/utils/filesystem/scoped_path.h"
+<<<<<<< HEAD
+=======
+#include "hephaestus/utils/utils.h"
+    >>>>>>> 168fd6d (squash)
 
-// NOLINTNEXTLINE(google-build-using-namespace)
-using namespace ::testing;
+    // NOLINTNEXTLINE(google-build-using-namespace)
+    using namespace ::testing;
 
 namespace heph::bag::tests {
 namespace {
@@ -58,11 +62,15 @@ constexpr auto DUMMY_PRIMITIVE_TYPE_TOPIC = "bag_test/dummy_primitive_type";
   std::vector<types::DummyType> dummy_types(DUMMY_TYPE_MSG_COUNT);
   for (std::size_t i = 0; i < DUMMY_TYPE_MSG_COUNT; ++i) {
     dummy_types[i] = types::DummyType::random(mt);
-    mcap_writer->writeRecord({ .sender_id = SENDER_ID,
-                               .topic = DUMMY_TYPE_TOPIC,
-                               .timestamp = start_time + i * DUMMY_TYPE_MSG_PERIOD,
-                               .sequence_id = i },
-                             serdes::serialize(dummy_types[i]));
+    mcap_writer->writeRecord(
+        {
+            .sender_id = SENDER_ID,
+            .topic = DUMMY_TYPE_TOPIC,
+            .type_info = utils::getTypeName<types::DummyType>(),
+            .timestamp = start_time + i * DUMMY_TYPE_MSG_PERIOD,
+            .sequence_id = i,
+        },
+        serdes::serialize(dummy_types[i]));
   }
 
   std::vector<types::DummyPrimitivesType> dummy_primitive_type(DUMMY_PRIMITIVE_TYPE_MSG_COUNT);
@@ -70,6 +78,7 @@ constexpr auto DUMMY_PRIMITIVE_TYPE_TOPIC = "bag_test/dummy_primitive_type";
     dummy_primitive_type[i] = types::DummyPrimitivesType::random(mt);
     mcap_writer->writeRecord({ .sender_id = SENDER_ID,
                                .topic = DUMMY_PRIMITIVE_TYPE_TOPIC,
+                               .type_info = utils::getTypeName<types::DummyType>(),
                                .timestamp = start_time + i * DUMMY_PRIMITIVE_TYPE_MSG_PERIOD,
                                .sequence_id = i },
                              serdes::serialize(dummy_primitive_type[i]));

--- a/modules/bag/tests/tests.cpp
+++ b/modules/bag/tests/tests.cpp
@@ -25,13 +25,10 @@
 #include "hephaestus/types/dummy_type.h"
 #include "hephaestus/types_proto/dummy_type.h"  // NOLINT(misc-include-cleaner)
 #include "hephaestus/utils/filesystem/scoped_path.h"
-<<<<<<< HEAD
-=======
 #include "hephaestus/utils/utils.h"
-    >>>>>>> 168fd6d (squash)
 
-    // NOLINTNEXTLINE(google-build-using-namespace)
-    using namespace ::testing;
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace ::testing;
 
 namespace heph::bag::tests {
 namespace {

--- a/modules/examples/examples/mcap_writer.cpp
+++ b/modules/examples/examples/mcap_writer.cpp
@@ -16,6 +16,7 @@
 #include "hephaestus/examples/types_proto/pose.h"  // NOLINT(misc-include-cleaner)
 #include "hephaestus/ipc/zenoh/raw_subscriber.h"
 #include "hephaestus/serdes/serdes.h"
+#include "hephaestus/utils/utils.h"
 
 auto main(int argc, const char* argv[]) -> int {
   try {
@@ -42,7 +43,11 @@ auto main(int argc, const char* argv[]) -> int {
       pose.position = Eigen::Vector3d{ static_cast<double>(i), 2, 3 };  // NOLINT
       const auto data = heph::serdes::serialize(pose);
       const heph::ipc::zenoh::MessageMetadata metadata{
-        .sender_id = "myself", .topic = "pose", .timestamp = frame_time, .sequence_id = i
+        .sender_id = "myself",
+        .topic = "pose",
+        .type_info = heph::utils::getTypeName<heph::examples::types::Pose>(),
+        .timestamp = frame_time,
+        .sequence_id = i
       };
 
       bag_writer->writeRecord(metadata, data);

--- a/modules/examples/examples/zenoh_service_server.cpp
+++ b/modules/examples/examples/zenoh_service_server.cpp
@@ -33,11 +33,10 @@ auto main(int argc, const char* argv[]) -> int {
 
     auto callback = [](const heph::examples::types::Pose& sample) {
       LOG(INFO) << fmt::format("Received query: {}", sample);
-      heph::examples::types::Pose sample_reply{
+      return heph::examples::types::Pose{
         .orientation = Eigen::Quaterniond{ 1., 0.1, 0.2, 0.3 },  // NOLINT
         .position = Eigen::Vector3d{ 1, 2, 3 },                  // NOLINT
       };
-      return sample_reply;
     };
 
     const heph::ipc::zenoh::Service<heph::examples::types::Pose, heph::examples::types::Pose> server(

--- a/modules/examples/examples/zenoh_string_service_server.cpp
+++ b/modules/examples/examples/zenoh_string_service_server.cpp
@@ -33,8 +33,7 @@ auto main(int argc, const char* argv[]) -> int {
 
     auto callback = [](const std::string& sample) {
       LOG(INFO) << "Received query: " << sample;
-      std::string reply = (sample == "Marco") ? "Polo" : "What?";
-      return reply;
+      return (sample == "Marco") ? "Polo" : "What?";
     };
 
     const heph::ipc::zenoh::Service<std::string, std::string> server(session, topic_config, callback);

--- a/modules/examples/tests/CMakeLists.txt
+++ b/modules/examples/tests/CMakeLists.txt
@@ -8,12 +8,3 @@ define_module_test(
         PUBLIC_INCLUDE_PATHS
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
         PUBLIC_LINK_LIBS "")
-
-
-# TODO: This test should be in the IPC package, as soon as we have a proto helper package in there
-define_module_test(
-        NAME zenoh_tests
-        SOURCES zenoh_tests.cpp helpers.h
-        PUBLIC_INCLUDE_PATHS
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-        PUBLIC_LINK_LIBS hephaestus::random)

--- a/modules/ipc/include/hephaestus/ipc/zenoh/conversions.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/conversions.h
@@ -20,6 +20,7 @@ static constexpr auto TEXT_PLAIN_ENCODING = "text/plain";
 /// We use single char key to reduce the overhead of the attachment.
 static constexpr auto PUBLISHER_ATTACHMENT_MESSAGE_COUNTER_KEY = "0";
 static constexpr auto PUBLISHER_ATTACHMENT_MESSAGE_SESSION_ID_KEY = "1";
+static constexpr auto PUBLISHER_ATTACHMENT_MESSAGE_TYPE_INFO = "2";
 
 [[nodiscard]] auto toByteVector(const ::zenoh::Bytes& bytes) -> std::vector<std::byte>;
 

--- a/modules/ipc/include/hephaestus/ipc/zenoh/raw_publisher.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/raw_publisher.h
@@ -50,6 +50,7 @@ private:
   [[nodiscard]] auto createPublisherOptions() -> ::zenoh::Publisher::PutOptions;
   void enableMatchingListener();
   void createTypeInfoService();
+  void initializeAttachment();
 
 private:
   SessionPtr session_;

--- a/modules/ipc/include/hephaestus/ipc/zenoh/raw_subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/raw_subscriber.h
@@ -19,6 +19,7 @@ struct MessageMetadata {
   // TODO: convert this to a uuid
   std::string sender_id;
   std::string topic;
+  std::string type_info;
   std::chrono::nanoseconds timestamp{};
   std::size_t sequence_id{};
 };

--- a/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
@@ -4,14 +4,17 @@
 
 #pragma once
 
+#include <mutex>
 #include <span>
 
+#include <absl/log/log.h>
 #include <zenoh.h>
 #include <zenoh.hxx>
 
 #include "hephaestus/ipc/zenoh/raw_subscriber.h"
 #include "hephaestus/ipc/zenoh/session.h"
 #include "hephaestus/serdes/serdes.h"
+#include "hephaestus/utils/utils.h"
 
 namespace heph::ipc::zenoh {
 
@@ -23,8 +26,10 @@ public:
              bool dedicated_callback_thread = false)
     : subscriber_(
           std::move(session), std::move(topic_config),
-          [callback = std::move(callback)](const MessageMetadata& metadata,
-                                           std::span<const std::byte> buffer) mutable {
+          [callback = std::move(callback), this](const MessageMetadata& metadata,
+                                                 std::span<const std::byte> buffer) mutable {
+            std::call_once(subscriber_check_flag_, [this, &metadata]() { checkTypeInfo(metadata); });
+
             auto data = std::make_shared<T>();
             heph::serdes::deserialize(buffer, *data);
             callback(metadata, std::move(data));
@@ -33,9 +38,26 @@ public:
   }
 
 private:
+  void checkTypeInfo(const MessageMetadata& metadata) {
+    throwExceptionIf<FailedZenohOperation>(
+        metadata.type_info != utils::getTypeName<T>(),
+        fmt::format("Topic '{}' is of type '{}', but subscriber expect type '{}'", metadata.topic,
+                    metadata.type_info, utils::getTypeName<T>()));
+  }
+
+private:
   RawSubscriber subscriber_;
+  std::once_flag subscriber_check_flag_;
 };
 
+/// Create a subscriber for a specific topic.
+/// \tparam T The type of the message to subscribe to.
+/// \param session The Zenoh session to use.
+/// \param topic_config The topic to subscribe to.
+/// \param callback The callback to call when a message is received.
+/// \param dedicated_callback_thread Whether to use a dedicated thread for the callback. If set to false the
+/// callback will be invoked on the Zenoh callback thread.
+/// \return A new subscriber.
 template <typename T>
 [[nodiscard]] auto createSubscriber(zenoh::SessionPtr session, TopicConfig topic_config,
                                     typename Subscriber<T>::DataCallback&& callback,

--- a/modules/ipc/src/zenoh/raw_publisher.cpp
+++ b/modules/ipc/src/zenoh/raw_publisher.cpp
@@ -16,6 +16,7 @@
 #include <zenoh/api/base.hxx>
 #include <zenoh/api/encoding.hxx>
 #include <zenoh/api/enums.hxx>
+#include <zenoh/api/ext/serialization.hxx>
 #include <zenoh/api/interop.hxx>
 #include <zenoh/api/keyexpr.hxx>
 #include <zenoh/api/liveliness.hxx>

--- a/modules/ipc/src/zenoh/raw_subscriber.cpp
+++ b/modules/ipc/src/zenoh/raw_subscriber.cpp
@@ -16,6 +16,7 @@
 #include <absl/log/log.h>
 #include <absl/strings/numbers.h>
 #include <fmt/core.h>
+#include <range/v3/range/primitives.hpp>
 #include <zenoh.h>
 #include <zenoh/api/base.hxx>
 #include <zenoh/api/closures.hxx>
@@ -46,6 +47,35 @@ template <typename C, typename D>
   ::z_closure(&c_closure, ::zenoh::detail::closures::_zenoh_on_sample_call,
               ::zenoh::detail::closures::_zenoh_on_drop, closure);
   return c_closure;
+}
+
+[[nodiscard]] auto getMetadata(const ::zenoh::Sample& sample, const std::string& topic) -> MessageMetadata {
+  std::string sender_id;
+  std::string type_info;
+  std::size_t sequence_id{};
+  if (const auto attachment = sample.get_attachment(); attachment.has_value()) {
+    auto attachment_data =
+        ::zenoh::ext::deserialize<std::unordered_map<std::string, std::string>>(attachment->get());
+
+    auto res = absl::SimpleAtoi(attachment_data[PUBLISHER_ATTACHMENT_MESSAGE_COUNTER_KEY], &sequence_id);
+    LOG_IF(ERROR, !res) << fmt::format("[Subscriber {}] failed to read message counter from attachment",
+                                       topic);
+    sender_id = attachment_data[PUBLISHER_ATTACHMENT_MESSAGE_SESSION_ID_KEY];
+    type_info = attachment_data[PUBLISHER_ATTACHMENT_MESSAGE_TYPE_INFO];
+  }
+
+  auto timestamp = std::chrono::nanoseconds{ 0 };
+  if (const auto zenoh_timestamp = sample.get_timestamp(); zenoh_timestamp.has_value()) {
+    timestamp = toChrono(zenoh_timestamp.value());
+  }
+
+  return {
+    .sender_id = std::move(sender_id),
+    .topic = std::string{ sample.get_keyexpr().as_string_view() },
+    .type_info = std::move(type_info),
+    .timestamp = timestamp,
+    .sequence_id = sequence_id,
+  };
 }
 }  // namespace
 
@@ -114,26 +144,7 @@ RawSubscriber::~RawSubscriber() {
 }
 
 void RawSubscriber::callback(const ::zenoh::Sample& sample) {
-  MessageMetadata metadata;
-  if (const auto attachment = sample.get_attachment(); attachment.has_value()) {
-    // TODO(@filippobrizzi): remove the NOLINT once they fix
-    // https://github.com/eclipse-zenoh/zenoh-cpp/pull/244
-    auto attachment_data = ::zenoh::ext::deserialize<  // NOLINT(misc-include-cleaner)
-        std::unordered_map<std::string, std::string>>(attachment->get());
-
-    auto res =
-        absl::SimpleAtoi(attachment_data[PUBLISHER_ATTACHMENT_MESSAGE_COUNTER_KEY], &metadata.sequence_id);
-    LOG_IF(ERROR, !res) << fmt::format("[Subscriber {}] failed to read message counter from attachment",
-                                       topic_config_.name);
-    metadata.sender_id = attachment_data[PUBLISHER_ATTACHMENT_MESSAGE_SESSION_ID_KEY];
-  }
-
-  if (const auto timestamp = sample.get_timestamp(); timestamp.has_value()) {
-    metadata.timestamp = toChrono(timestamp.value());
-  }
-
-  metadata.topic = sample.get_keyexpr().as_string_view();
-
+  const auto metadata = getMetadata(sample, topic_config_.name);
   auto payload = toByteVector(sample.get_payload());
 
   if (dedicated_callback_thread_) {

--- a/modules/ipc/src/zenoh/raw_subscriber.cpp
+++ b/modules/ipc/src/zenoh/raw_subscriber.cpp
@@ -16,10 +16,10 @@
 #include <absl/log/log.h>
 #include <absl/strings/numbers.h>
 #include <fmt/core.h>
-#include <range/v3/range/primitives.hpp>
 #include <zenoh.h>
 #include <zenoh/api/base.hxx>
 #include <zenoh/api/closures.hxx>
+#include <zenoh/api/ext/serialization.hxx>
 #include <zenoh/api/interop.hxx>
 #include <zenoh/api/keyexpr.hxx>
 #include <zenoh/api/sample.hxx>

--- a/modules/ipc/tests/pub_sub_tests.cpp
+++ b/modules/ipc/tests/pub_sub_tests.cpp
@@ -16,8 +16,9 @@
 #include "hephaestus/random/random_object_creator.h"
 #include "hephaestus/types/dummy_type.h"
 #include "hephaestus/types_proto/dummy_type.h"  // NOLINT(misc-include-cleaner)
+#include "hephaestus/utils/exception.h"
 
-namespace heph::ipc::tests {
+namespace heph::ipc::zenoh::tests {
 
 namespace {
 void checkMessageExchange(bool subscriber_dedicated_callback_thread) {
@@ -90,4 +91,4 @@ TEST(PublisherSubscriber, MismatchType) {
 }
 
 }  // namespace
-}  // namespace heph::ipc::tests
+}  // namespace heph::ipc::zenoh::tests


### PR DESCRIPTION
# Description
Zenoh allows to attach metadata to every message, we already use it to share the sequence number and session id. Now it also pass the type info. 

In the subscriber and Service we use it check that the types match, in this way we can better catch the issue.

