### PR TITLE
Add Spinner manager

### DIFF
--- a/modules/concurrency/CMakeLists.txt
+++ b/modules/concurrency/CMakeLists.txt
@@ -12,8 +12,14 @@ find_package(absl REQUIRED)
 find_package(fmt REQUIRED)
 
 # library sources
-set(SOURCES src/message_queue_consumer.cpp src/spinner.cpp README.md
-            include/hephaestus/concurrency/message_queue_consumer.h include/hephaestus/concurrency/spinner.h
+set(SOURCES
+    src/message_queue_consumer.cpp
+    src/spinner.cpp
+    src/spinner_manager.cpp
+    README.md
+    include/hephaestus/concurrency/message_queue_consumer.h
+    include/hephaestus/concurrency/spinner.h
+    include/hephaestus/concurrency/spinner_manager.h
 )
 
 # library target

--- a/modules/concurrency/include/hephaestus/concurrency/spinner.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner.h
@@ -8,7 +8,6 @@
 #include <chrono>
 #include <functional>
 #include <future>
-#include <thread>
 
 namespace heph::concurrency {
 
@@ -52,6 +51,7 @@ private:
 
   std::atomic_bool stop_requested_ = false;
   std::future<void> async_spinner_handle_;
+  std::atomic_flag spinner_completed_ = ATOMIC_FLAG_INIT;
 
   std::chrono::microseconds spin_period_;
   std::chrono::system_clock::time_point start_timestamp_;

--- a/modules/concurrency/include/hephaestus/concurrency/spinner.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner.h
@@ -40,6 +40,10 @@ public:
   auto stop() -> std::future<void>;
   void wait();
 
+  /// @brief  Set a callback that will be called when the spinner is stopped.
+  /// This callback could be extendend to pass the reason why the spinner was stopped, e.g. exceptions, ...
+  void setTerminationCallback(Callback&& termination_callback);
+
   [[nodiscard]] auto spinCount() const -> uint64_t;
 
 private:
@@ -48,6 +52,7 @@ private:
 
 private:
   StoppableCallback stoppable_callback_;
+  Callback termination_callback_ = []() {};
 
   std::atomic_bool stop_requested_ = false;
   std::future<void> async_spinner_handle_;

--- a/modules/concurrency/include/hephaestus/concurrency/spinner_manager.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner_manager.h
@@ -29,7 +29,7 @@ public:
   /// propagated as the other spinners are still blocking.
   void waitAll();
   /// @brief wait until any spinner terminates or throws an exception, which allows for immediate exception
-  /// handling. Not that the exception will be re-thrown when calling `stopAll`.
+  /// handling. Note that the exceptions will be re-thrown when calling `stopAll`.
   void waitAny();
   void stopAll();
 

--- a/modules/concurrency/include/hephaestus/concurrency/spinner_manager.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner_manager.h
@@ -36,7 +36,7 @@ public:
 private:
   std::vector<Spinner*> spinners_;
 
-  std::vector<std::future<void>> wait_futures_;
+  std::atomic_flag termination_flag_ = ATOMIC_FLAG_INIT;
 };
 
 }  // namespace heph::concurrency

--- a/modules/concurrency/include/hephaestus/concurrency/spinner_manager.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner_manager.h
@@ -25,7 +25,11 @@ public:
   explicit SpinnersManager(std::vector<Spinner*> spinners);
 
   void startAll();
+  /// @brief blocks until all spinners are finished. If a single spinner throws an exception, it will not be
+  /// propagated as the other spinners are still blocking.
   void waitAll();
+  /// @brief wait until any spinner terminates or throws an exception, which allows for immediate exception
+  /// handling. Not that the exception will be re-thrown when calling `stopAll`.
   void waitAny();
   void stopAll();
 

--- a/modules/concurrency/include/hephaestus/concurrency/spinner_manager.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner_manager.h
@@ -11,7 +11,7 @@
 
 namespace heph::concurrency {
 
-/// @brief SpinnerManager allows to orchestrate the execution of multiple spinners.
+/// @brief SpinnersManager allows to orchestrate the execution of multiple spinners.
 /// The main feature is `waitAny` which allows to unblock as soon as one of the spinners is done.
 /// This allows to catch errors in spinner execution as soon as possible and stop the others.
 /// NOTE: right now we do not have any concept of error for the spinners: we cannot know if a spinner
@@ -20,9 +20,9 @@ namespace heph::concurrency {
 /// NOTE: this logic is quite generic and can be extended to any type of object that has `wait()` and `stop()`
 /// methods. To be faitful to the principle of implement only what you need now, we limit the scope to
 /// spinners and consider to expand the scope when an use case arises.
-class SpinnerManager {
+class SpinnersManager {
 public:
-  explicit SpinnerManager(std::vector<Spinner*> spinners);
+  explicit SpinnersManager(std::vector<Spinner*> spinners);
 
   void startAll();
   void waitAll();

--- a/modules/concurrency/include/hephaestus/concurrency/spinner_manager.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner_manager.h
@@ -1,0 +1,38 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#pragma once
+
+#include <future>
+#include <vector>
+
+#include "hephaestus/concurrency/spinner.h"
+
+namespace heph::concurrency {
+
+/// @brief SpinnerManager allows to orchestrate the execution of multiple spinners.
+/// The main feature is `waitAny` which allows to unblock as soon as one of the spinners is done.
+/// This allows to catch errors in spinner execution as soon as possible and stop the others.
+/// NOTE: right now we do not have any concept of error for the spinners: we cannot know if a spinner
+/// terminated with an error or not. If an exception is thrown inside the runner, it will be re-throwed when
+/// we call runner.stop().get(). We leave it to the user to handle it outside of the runner manager.
+/// NOTE: this logic is quite generic and can be extended to any type of object that has `wait()` and `stop()`
+/// methods. To be faitful to the principle of implement only what you need now, we limit the scope to
+/// spinners and consider to expand the scope when an use case arises.
+class SpinnerManager {
+public:
+  explicit SpinnerManager(std::vector<Spinner*> spinners);
+
+  void startAll();
+  void waitAll();
+  void waitAny();
+  void stopAll();
+
+private:
+  std::vector<Spinner*> spinners_;
+
+  std::vector<std::future<void>> wait_futures_;
+};
+
+}  // namespace heph::concurrency

--- a/modules/concurrency/src/spinner.cpp
+++ b/modules/concurrency/src/spinner.cpp
@@ -85,11 +85,13 @@ void Spinner::spin() {
   } catch (std::exception& e) {
     spinner_completed_.test_and_set();
     spinner_completed_.notify_all();
+    termination_callback_();
     throw;  // TODO(@filippo) consider if we want to handle this error in a different way.
   }
 
   spinner_completed_.test_and_set();
   spinner_completed_.notify_all();
+  termination_callback_();
 }
 
 auto Spinner::stop() -> std::future<void> {
@@ -111,6 +113,10 @@ void Spinner::wait() {
 
 auto Spinner::spinCount() const -> uint64_t {
   return spin_count_;
+}
+
+void Spinner::setTerminationCallback(Callback&& termination_callback) {
+  termination_callback_ = std::move(termination_callback);
 }
 
 }  // namespace heph::concurrency

--- a/modules/concurrency/src/spinner.cpp
+++ b/modules/concurrency/src/spinner.cpp
@@ -54,12 +54,13 @@ Spinner::~Spinner() {
 void Spinner::start() {
   throwExceptionIf<InvalidOperationException>(async_spinner_handle_.valid(), "Spinner is already started.");
 
+  stop_requested_.store(false);
+  spinner_completed_.clear();
   async_spinner_handle_ = std::async(std::launch::async, [this]() mutable { spin(); });
 }
 
 void Spinner::spin() {
   // TODO: set thread name
-  spinner_completed_.clear();
 
   try {
     start_timestamp_ = std::chrono::system_clock::now();

--- a/modules/concurrency/src/spinner_manager.cpp
+++ b/modules/concurrency/src/spinner_manager.cpp
@@ -15,18 +15,18 @@
 #include "hephaestus/concurrency/spinner.h"
 
 namespace heph::concurrency {
-SpinnerManager::SpinnerManager(std::vector<Spinner*> spinners) : spinners_{ std::move(spinners) } {
+SpinnersManager::SpinnersManager(std::vector<Spinner*> spinners) : spinners_{ std::move(spinners) } {
 }
 
-void SpinnerManager::startAll() {
+void SpinnersManager::startAll() {
   std::ranges::for_each(spinners_, [](auto* runner) { runner->start(); });
 }
 
-void SpinnerManager::waitAll() {
+void SpinnersManager::waitAll() {
   std::ranges::for_each(spinners_, [](auto* runner) { runner->wait(); });
 }
 
-void SpinnerManager::waitAny() {
+void SpinnersManager::waitAny() {
   std::atomic_flag flag = ATOMIC_FLAG_INIT;
   wait_futures_.reserve(spinners_.size());
   for (auto* runner : spinners_) {
@@ -41,7 +41,7 @@ void SpinnerManager::waitAny() {
   flag.wait(false);
 }
 
-void SpinnerManager::stopAll() {
+void SpinnersManager::stopAll() {
   std::vector<std::future<void>> futures;
   futures.reserve(spinners_.size());
 

--- a/modules/concurrency/src/spinner_manager.cpp
+++ b/modules/concurrency/src/spinner_manager.cpp
@@ -1,0 +1,56 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#include "hephaestus/concurrency/spinner_manager.h"
+
+#include <algorithm>
+#include <atomic>
+#include <future>
+#include <utility>
+#include <vector>
+
+#include <fmt/core.h>
+
+#include "hephaestus/concurrency/spinner.h"
+
+namespace heph::concurrency {
+SpinnerManager::SpinnerManager(std::vector<Spinner*> spinners) : spinners_{ std::move(spinners) } {
+}
+
+void SpinnerManager::startAll() {
+  std::ranges::for_each(spinners_, [](auto* runner) { runner->start(); });
+}
+
+void SpinnerManager::waitAll() {
+  std::ranges::for_each(spinners_, [](auto* runner) { runner->wait(); });
+}
+
+void SpinnerManager::waitAny() {
+  std::atomic_flag flag = ATOMIC_FLAG_INIT;
+  wait_futures_.reserve(spinners_.size());
+  for (auto* runner : spinners_) {
+    auto future = std::async(std::launch::async, [runner, &flag]() {
+      runner->wait();
+      flag.test_and_set();
+      flag.notify_all();
+    });
+    wait_futures_.push_back(std::move(future));
+  }
+
+  flag.wait(false);
+}
+
+void SpinnerManager::stopAll() {
+  std::vector<std::future<void>> futures;
+  futures.reserve(spinners_.size());
+
+  std::ranges::for_each(spinners_,
+                        [&futures](auto* runner) { futures.push_back(std::move(runner->stop())); });
+
+  // If we called `waitAny`, we need to wait for the remaining futures.
+  std::ranges::for_each(wait_futures_, [](auto& future) { future.get(); });
+
+  std::ranges::for_each(futures, [](auto& f) { f.get(); });
+}
+}  // namespace heph::concurrency

--- a/modules/concurrency/src/spinner_manager.cpp
+++ b/modules/concurrency/src/spinner_manager.cpp
@@ -10,8 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/core.h>
-
 #include "hephaestus/concurrency/spinner.h"
 
 namespace heph::concurrency {

--- a/modules/concurrency/tests/CMakeLists.txt
+++ b/modules/concurrency/tests/CMakeLists.txt
@@ -15,3 +15,10 @@ define_module_test(
         PUBLIC_INCLUDE_PATHS
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
         PUBLIC_LINK_LIBS "")
+
+define_module_test(
+          NAME sync_tests
+          SOURCES sync_tests.cpp
+          PUBLIC_INCLUDE_PATHS
+          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+          PUBLIC_LINK_LIBS "")

--- a/modules/concurrency/tests/CMakeLists.txt
+++ b/modules/concurrency/tests/CMakeLists.txt
@@ -17,8 +17,8 @@ define_module_test(
         PUBLIC_LINK_LIBS "")
 
 define_module_test(
-          NAME sync_tests
-          SOURCES sync_tests.cpp
+          NAME spinner_manager_tests
+          SOURCES spinner_manager_tests.cpp
           PUBLIC_INCLUDE_PATHS
           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
           PUBLIC_LINK_LIBS "")

--- a/modules/concurrency/tests/spinner_manager_tests.cpp
+++ b/modules/concurrency/tests/spinner_manager_tests.cpp
@@ -2,70 +2,99 @@
 // Copyright (C) 2023-2024 HEPHAESTUS Contributors
 //=================================================================================================
 
-#include <cstddef>
-#include <span>
+#include <atomic>
+#include <stdexcept>
 
+#include <fmt/core.h>
 #include <gtest/gtest.h>
 
 #include "hephaestus/concurrency/spinner.h"
+#include "hephaestus/concurrency/spinner_manager.h"
+#include "hephaestus/utils/stack_trace.h"
 
 namespace heph::concurrency::tests {
 
-/// @brief SpinnerManager allows to orchestrate the execution of multiple spinners.
-/// The main feature is `waitAny` which allows to unblock as soon as one of the spinners is done.
-/// This allows to catch errors in spinner execution as soon as possible and stop the others.
-/// NOTE: right now we do not have any concept of error for the spinners: we cannot know if a spinner
-/// terminated with an error or not. If an exception is thrown inside the runner, it will be re-throwed when
-/// we call runner.stop().get(). We leave it to the user to handle it outside of the runner manager.
-/// NOTE: this logic is quite generic and can be extended to any type of object that has `wait()` and `stop()`
-/// methods. To be faitful to the principle of implement only what you need now, we limit the scope to
-/// spinners and consider to expand the scope when an use case arises.
-class SpinnerManager {
-public:
-  explicit SpinnerManager(std::span<Spinner*> spinners) : spinners_{ spinners } {
-  }
-
-  void startAll() {
-    std::ranges::for_each(spinners_, [](auto* runner) { runner->start(); });
-  }
-
-  void waitAll() {
-    std::ranges::for_each(spinners_, [](auto* runner) { runner->wait(); });
-  }
-
-  void waitAny() {
-    std::atomic_flag flag = ATOMIC_FLAG_INIT;
-    wait_futures_.reserve(spinners_.size());
-    for (auto* runner : spinners_) {
-      auto future = std::async(std::launch::async, [runner, &flag]() {
-        runner->wait();
-        flag.test_and_set();
-        flag.notify_all();
-      });
-      wait_futures_.push_back(std::move(future));
-    }
-
-    flag.wait(false);
-  }
-
-  void stopAll() {
-    std::vector<std::future<void>> futures;
-    futures.reserve(spinners_.size());
-    std::ranges::for_each(spinners_, [&futures](auto* runner) { futures.push_back(runner->stop()); });
-
-    std::ranges::for_each(wait_futures_, [](auto& future) { future.get(); });
-
-    std::ranges::for_each(futures, [](auto& f) { f.get(); });
-  }
-
-private:
-  std::span<Spinner*> spinners_;
-
-  std::vector<std::future<void>> wait_futures_;
-};
-
 TEST(RunnerManager, Empty) {
   SpinnerManager runner_manager{ {} };
+  runner_manager.startAll();
+  runner_manager.waitAll();
+  runner_manager.stopAll();
+}
+
+TEST(RunnerManager, OneSpinnerSuccessful) {
+  std::atomic_bool flag = false;
+  Spinner spinner{ Spinner::StoppableCallback{ [&flag]() -> Spinner::SpinResult {
+    flag = true;
+    return Spinner::SpinResult::STOP;
+  } } };
+
+  SpinnerManager runner_manager{ { &spinner } };
+  runner_manager.startAll();
+  runner_manager.waitAll();
+  runner_manager.stopAll();
+
+  EXPECT_TRUE(flag);
+}
+
+TEST(RunnerManager, OneSpinnerError) {
+  Spinner spinner{ []() { throw std::runtime_error("fail"); } };
+
+  SpinnerManager runner_manager{ { &spinner } };
+  runner_manager.startAll();
+  runner_manager.waitAll();
+  EXPECT_THROW(runner_manager.stopAll(), std::runtime_error);
+}
+
+TEST(RunnerManager, MultipleSpinnersSuccessful) {
+  std::atomic_bool flag1 = false;
+  Spinner spinner1{ Spinner::StoppableCallback{ [&flag1]() -> Spinner::SpinResult {
+    flag1 = true;
+    return Spinner::SpinResult::STOP;
+  } } };
+
+  std::atomic_bool flag2 = false;
+  Spinner spinner2{ Spinner::StoppableCallback{ [&flag2]() -> Spinner::SpinResult {
+    flag2 = true;
+    return Spinner::SpinResult::STOP;
+  } } };
+
+  SpinnerManager runner_manager{ { &spinner1, &spinner2 } };
+  runner_manager.startAll();
+  runner_manager.waitAll();
+  runner_manager.stopAll();
+
+  EXPECT_TRUE(flag1);
+  EXPECT_TRUE(flag2);
+}
+
+TEST(RunnerManager, MultipleSpinnersWaitAny) {
+  utils::StackTrace trace;
+  Spinner spinner1{ []() {} };  // Run indefinitely until stopped
+
+  std::atomic_bool flag = false;
+  Spinner spinner2{ Spinner::StoppableCallback{ [&flag]() -> Spinner::SpinResult {
+    flag = true;
+    return Spinner::SpinResult::STOP;
+  } } };
+
+  SpinnerManager runner_manager{ { &spinner1, &spinner2 } };
+  runner_manager.startAll();
+  runner_manager.waitAny();
+  runner_manager.stopAll();
+
+  EXPECT_TRUE(flag);
+}
+
+TEST(RunnerManager, MultipleSpinnersOneError) {
+  utils::StackTrace trace;
+  Spinner spinner1{ []() {} };  // Run indefinitely until stopped
+
+  Spinner spinner2{ []() { throw std::runtime_error("fail"); } };
+
+  SpinnerManager runner_manager{ { &spinner1, &spinner2 } };
+  runner_manager.startAll();
+  runner_manager.waitAny();
+  EXPECT_THROW(runner_manager.stopAll(), std::runtime_error);
 }
 
 }  // namespace heph::concurrency::tests

--- a/modules/concurrency/tests/spinner_manager_tests.cpp
+++ b/modules/concurrency/tests/spinner_manager_tests.cpp
@@ -10,7 +10,6 @@
 
 #include "hephaestus/concurrency/spinner.h"
 #include "hephaestus/concurrency/spinner_manager.h"
-#include "hephaestus/utils/stack_trace.h"
 
 namespace heph::concurrency::tests {
 
@@ -68,7 +67,6 @@ TEST(RunnerManager, MultipleSpinnersSuccessful) {
 }
 
 TEST(RunnerManager, MultipleSpinnersWaitAny) {
-  utils::StackTrace trace;
   Spinner spinner1{ []() {} };  // Run indefinitely until stopped
 
   std::atomic_bool flag = false;
@@ -86,7 +84,6 @@ TEST(RunnerManager, MultipleSpinnersWaitAny) {
 }
 
 TEST(RunnerManager, MultipleSpinnersOneError) {
-  utils::StackTrace trace;
   Spinner spinner1{ []() {} };  // Run indefinitely until stopped
 
   Spinner spinner2{ []() { throw std::runtime_error("fail"); } };

--- a/modules/concurrency/tests/spinner_manager_tests.cpp
+++ b/modules/concurrency/tests/spinner_manager_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <atomic>
 #include <stdexcept>
+#include <thread>
 
 #include <gtest/gtest.h>
 

--- a/modules/concurrency/tests/spinner_manager_tests.cpp
+++ b/modules/concurrency/tests/spinner_manager_tests.cpp
@@ -5,7 +5,6 @@
 #include <atomic>
 #include <stdexcept>
 
-#include <fmt/core.h>
 #include <gtest/gtest.h>
 
 #include "hephaestus/concurrency/spinner.h"

--- a/modules/concurrency/tests/spinner_manager_tests.cpp
+++ b/modules/concurrency/tests/spinner_manager_tests.cpp
@@ -65,6 +65,15 @@ TEST(SpinnersManager, MultipleSpinnersSuccessful) {
   EXPECT_TRUE(flag2);
 }
 
+TEST(SpinnersManager, MultipleSpinnersSuccessfulNoTermination) {
+  Spinner spinner1{ []() {} };  // Run indefinitely until stopped
+  Spinner spinner2{ []() {} };  // Run indefinitely until stopped
+  SpinnersManager runner_manager{ { &spinner1, &spinner2 } };
+  runner_manager.startAll();
+  std::this_thread::sleep_for(std::chrono::milliseconds{ 1 });
+  runner_manager.stopAll();
+}
+
 TEST(SpinnersManager, MultipleSpinnersWaitAny) {
   Spinner spinner1{ []() {} };  // Run indefinitely until stopped
 

--- a/modules/concurrency/tests/spinner_manager_tests.cpp
+++ b/modules/concurrency/tests/spinner_manager_tests.cpp
@@ -1,0 +1,71 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#include <cstddef>
+#include <span>
+
+#include <gtest/gtest.h>
+
+#include "hephaestus/concurrency/spinner.h"
+
+namespace heph::concurrency::tests {
+
+/// @brief SpinnerManager allows to orchestrate the execution of multiple spinners.
+/// The main feature is `waitAny` which allows to unblock as soon as one of the spinners is done.
+/// This allows to catch errors in spinner execution as soon as possible and stop the others.
+/// NOTE: right now we do not have any concept of error for the spinners: we cannot know if a spinner
+/// terminated with an error or not. If an exception is thrown inside the runner, it will be re-throwed when
+/// we call runner.stop().get(). We leave it to the user to handle it outside of the runner manager.
+/// NOTE: this logic is quite generic and can be extended to any type of object that has `wait()` and `stop()`
+/// methods. To be faitful to the principle of implement only what you need now, we limit the scope to
+/// spinners and consider to expand the scope when an use case arises.
+class SpinnerManager {
+public:
+  explicit SpinnerManager(std::span<Spinner*> spinners) : spinners_{ spinners } {
+  }
+
+  void startAll() {
+    std::ranges::for_each(spinners_, [](auto* runner) { runner->start(); });
+  }
+
+  void waitAll() {
+    std::ranges::for_each(spinners_, [](auto* runner) { runner->wait(); });
+  }
+
+  void waitAny() {
+    std::atomic_flag flag = ATOMIC_FLAG_INIT;
+    wait_futures_.reserve(spinners_.size());
+    for (auto* runner : spinners_) {
+      auto future = std::async(std::launch::async, [runner, &flag]() {
+        runner->wait();
+        flag.test_and_set();
+        flag.notify_all();
+      });
+      wait_futures_.push_back(std::move(future));
+    }
+
+    flag.wait(false);
+  }
+
+  void stopAll() {
+    std::vector<std::future<void>> futures;
+    futures.reserve(spinners_.size());
+    std::ranges::for_each(spinners_, [&futures](auto* runner) { futures.push_back(runner->stop()); });
+
+    std::ranges::for_each(wait_futures_, [](auto& future) { future.get(); });
+
+    std::ranges::for_each(futures, [](auto& f) { f.get(); });
+  }
+
+private:
+  std::span<Spinner*> spinners_;
+
+  std::vector<std::future<void>> wait_futures_;
+};
+
+TEST(RunnerManager, Empty) {
+  SpinnerManager runner_manager{ {} };
+}
+
+}  // namespace heph::concurrency::tests

--- a/modules/concurrency/tests/spinner_manager_tests.cpp
+++ b/modules/concurrency/tests/spinner_manager_tests.cpp
@@ -13,21 +13,21 @@
 
 namespace heph::concurrency::tests {
 
-TEST(RunnerManager, Empty) {
-  SpinnerManager runner_manager{ {} };
+TEST(SpinnersManager, Empty) {
+  SpinnersManager runner_manager{ {} };
   runner_manager.startAll();
   runner_manager.waitAll();
   runner_manager.stopAll();
 }
 
-TEST(RunnerManager, OneSpinnerSuccessful) {
+TEST(SpinnersManager, OneSpinnerSuccessful) {
   std::atomic_bool flag = false;
   Spinner spinner{ Spinner::StoppableCallback{ [&flag]() -> Spinner::SpinResult {
     flag = true;
     return Spinner::SpinResult::STOP;
   } } };
 
-  SpinnerManager runner_manager{ { &spinner } };
+  SpinnersManager runner_manager{ { &spinner } };
   runner_manager.startAll();
   runner_manager.waitAll();
   runner_manager.stopAll();
@@ -35,16 +35,16 @@ TEST(RunnerManager, OneSpinnerSuccessful) {
   EXPECT_TRUE(flag);
 }
 
-TEST(RunnerManager, OneSpinnerError) {
+TEST(SpinnersManager, OneSpinnerError) {
   Spinner spinner{ []() { throw std::runtime_error("fail"); } };
 
-  SpinnerManager runner_manager{ { &spinner } };
+  SpinnersManager runner_manager{ { &spinner } };
   runner_manager.startAll();
   runner_manager.waitAll();
   EXPECT_THROW(runner_manager.stopAll(), std::runtime_error);
 }
 
-TEST(RunnerManager, MultipleSpinnersSuccessful) {
+TEST(SpinnersManager, MultipleSpinnersSuccessful) {
   std::atomic_bool flag1 = false;
   Spinner spinner1{ Spinner::StoppableCallback{ [&flag1]() -> Spinner::SpinResult {
     flag1 = true;
@@ -57,7 +57,7 @@ TEST(RunnerManager, MultipleSpinnersSuccessful) {
     return Spinner::SpinResult::STOP;
   } } };
 
-  SpinnerManager runner_manager{ { &spinner1, &spinner2 } };
+  SpinnersManager runner_manager{ { &spinner1, &spinner2 } };
   runner_manager.startAll();
   runner_manager.waitAll();
   runner_manager.stopAll();
@@ -66,7 +66,7 @@ TEST(RunnerManager, MultipleSpinnersSuccessful) {
   EXPECT_TRUE(flag2);
 }
 
-TEST(RunnerManager, MultipleSpinnersWaitAny) {
+TEST(SpinnersManager, MultipleSpinnersWaitAny) {
   Spinner spinner1{ []() {} };  // Run indefinitely until stopped
 
   std::atomic_bool flag = false;
@@ -75,7 +75,7 @@ TEST(RunnerManager, MultipleSpinnersWaitAny) {
     return Spinner::SpinResult::STOP;
   } } };
 
-  SpinnerManager runner_manager{ { &spinner1, &spinner2 } };
+  SpinnersManager runner_manager{ { &spinner1, &spinner2 } };
   runner_manager.startAll();
   runner_manager.waitAny();
   runner_manager.stopAll();
@@ -83,12 +83,12 @@ TEST(RunnerManager, MultipleSpinnersWaitAny) {
   EXPECT_TRUE(flag);
 }
 
-TEST(RunnerManager, MultipleSpinnersOneError) {
+TEST(SpinnersManager, MultipleSpinnersOneError) {
   Spinner spinner1{ []() {} };  // Run indefinitely until stopped
 
   Spinner spinner2{ []() { throw std::runtime_error("fail"); } };
 
-  SpinnerManager runner_manager{ { &spinner1, &spinner2 } };
+  SpinnersManager runner_manager{ { &spinner1, &spinner2 } };
   runner_manager.startAll();
   runner_manager.waitAny();
   EXPECT_THROW(runner_manager.stopAll(), std::runtime_error);

--- a/modules/concurrency/tests/spinner_tests.cpp
+++ b/modules/concurrency/tests/spinner_tests.cpp
@@ -116,4 +116,20 @@ TEST(SpinnerTest, ExceptionHandling) {
   EXPECT_THROW(spinner.stop().get(), heph::InvalidOperationException);
 }
 
+TEST(SpinnerTest, SpinStartAfterStop) {
+  size_t callback_called_counter = 0;
+  Spinner spinner(TestFixture::stoppingCallback(callback_called_counter));
+
+  spinner.start();
+  spinner.wait();
+  spinner.stop().get();
+  EXPECT_EQ(callback_called_counter, 10);
+
+  callback_called_counter = 0;
+  spinner.start();
+  spinner.wait();
+  spinner.stop().get();
+  EXPECT_EQ(callback_called_counter, 10);
+}
+
 }  // namespace heph::concurrency::tests

--- a/modules/concurrency/tests/spinner_tests.cpp
+++ b/modules/concurrency/tests/spinner_tests.cpp
@@ -54,6 +54,8 @@ TEST(SpinnerTest, StartStopTest) {
 TEST(SpinnerTest, SpinTest) {
   static constexpr auto WAIT_FOR = std::chrono::milliseconds{ 1 };
   Spinner spinner{ TestFixture::trivialCallback() };
+  bool callback_called = false;
+  spinner.setTerminationCallback([&callback_called]() { callback_called = true; });
 
   spinner.start();
 
@@ -63,9 +65,10 @@ TEST(SpinnerTest, SpinTest) {
 
   // The counter should have been incremented.
   EXPECT_GT(spinner.spinCount(), 0);
+  EXPECT_TRUE(callback_called);
 }
 
-TEST(SpinnerTest, StopCallback) {
+TEST(SpinnerTest, Stop) {
   static constexpr auto WAIT_FOR = std::chrono::milliseconds{ 10 };
 
   size_t callback_called_counter = 0;
@@ -111,9 +114,13 @@ TEST(SpinnerTest, ExceptionHandling) {
   static constexpr auto RATE_HZ = 1e3;
 
   Spinner spinner(TestFixture::throwingCallback(), RATE_HZ);
+  bool callback_called = false;
+  spinner.setTerminationCallback([&callback_called]() { callback_called = true; });
+
   spinner.start();
   spinner.wait();
   EXPECT_THROW(spinner.stop().get(), heph::InvalidOperationException);
+  EXPECT_TRUE(callback_called);
 }
 
 TEST(SpinnerTest, SpinStartAfterStop) {

--- a/modules/utils/include/hephaestus/utils/concepts.h
+++ b/modules/utils/include/hephaestus/utils/concepts.h
@@ -95,4 +95,7 @@ concept Waitable = requires(T value) {
   { value.wait() };
 };
 
+template <typename T>
+concept StoppableAndWaitable = requires { Stoppable<T>&& Waitable<T>; };
+
 }  // namespace heph

--- a/modules/utils/include/hephaestus/utils/signal_handler.h
+++ b/modules/utils/include/hephaestus/utils/signal_handler.h
@@ -12,9 +12,6 @@
 
 namespace heph::utils {
 
-template <typename T>
-concept StoppableAndWaitable = requires { Stoppable<T>&& Waitable<T>; };
-
 /// \brief Use this class to block until a signal is received.
 /// > NOTE: can be extended to call a generic callback when a signal is received.
 /// Usage:


### PR DESCRIPTION
# Description
The `SpinnersManager` allows to orchestrate the start and termination of multiple spinners. 

The most important functionality is the `waitAny` function which allows to unblock as soon as one of the spinner terminates. In this way we can proceed to stop all of the other. This is very useful in the context of errors.
