### PR TITLE
Feat/multicast scouting settings

### DIFF
--- a/modules/ipc/include/hephaestus/ipc/zenoh/session.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/session.h
@@ -25,7 +25,7 @@ struct Config {
   bool qos = false;
   bool real_time = false;
   Protocol protocol{ Protocol::ANY };
-  bool multicast_scouting_enabled = false;
+  bool multicast_scouting_enabled = true;
   std::string multicast_scouting_interface = "auto";
 };
 

--- a/modules/ipc/include/hephaestus/ipc/zenoh/session.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/session.h
@@ -25,6 +25,8 @@ struct Config {
   bool qos = false;
   bool real_time = false;
   Protocol protocol{ Protocol::ANY };
+  bool multicast_scouting_enabled = false;
+  std::string multicast_scouting_interface = "auto";
 };
 
 struct Session {

--- a/modules/ipc/src/zenoh/program_options.cpp
+++ b/modules/ipc/src/zenoh/program_options.cpp
@@ -24,7 +24,11 @@ void appendProgramOption(cli::ProgramDescription& program_description,
       .defineOption<std::string>("mode", 'm', "Running mode: options: peer, client", "peer")
       .defineOption<std::string>("router", 'r', "Router endpoint", "")
       .defineOption<std::string>("protocol", 'p', "Protocol to use, options: udp, tcp, any", "any")
+      .defineOption<std::string>("multicast_scouting_interface", 'i',
+                                 "Interface to use for multicast, options: auto, <INTERFACE_NAME>", "auto")
       .defineFlag("shared_memory", 's', "Enable shared memory")
+      .defineFlag("multicast_scouting_enabled", "Enable multicast scouting")
+
       .defineFlag("qos", 'q', "Enable QoS")
       .defineFlag("realtime", "Enable real-time communication");
 }
@@ -58,6 +62,8 @@ auto parseProgramOptions(const heph::cli::ProgramOptions& args) -> std::pair<Con
 
   config.router = args.getOption<std::string>("router");
   config.enable_shared_memory = args.getOption<bool>("shared_memory");
+  config.multicast_scouting_enabled = args.getOption<bool>("multicast_scouting_enabled");
+  config.multicast_scouting_interface = args.getOption<std::string>("multicast_scouting_interface");
   config.qos = args.getOption<bool>("qos");
   config.real_time = args.getOption<bool>("realtime");
 

--- a/modules/ipc/src/zenoh/session.cpp
+++ b/modules/ipc/src/zenoh/session.cpp
@@ -35,6 +35,14 @@ auto createZenohConfig(const Config& config) -> ::zenoh::Config {
     zconfig.insert_json5(Z_CONFIG_MODE_KEY, R"("client")");  // NOLINT(misc-include-cleaner)
   }
 
+  // Set multicast settings
+  if (config.multicast_scouting_enabled) {
+    zconfig.insert_json5("scouting/multicast/enabled", "true");  // NOLINT(misc-include-cleaner)
+  }
+  const auto multicast_scouting_interface = fmt::format(R"("{}")", config.multicast_scouting_interface);
+  zconfig.insert_json5(Z_CONFIG_MULTICAST_INTERFACE_KEY,
+                       multicast_scouting_interface);  // NOLINT(misc-include-cleaner)
+
   // Set the transport to UDP, but I am not sure it is the right way.
   // zconfig.insert_json5(Z_CONFIG_LISTEN_KEY, R"(["udp/localhost:7447"])");
   if (config.protocol == Protocol::UDP) {


### PR DESCRIPTION
# Description
Currently, default settings for multicast scouting is used which is enabled and automatically selects network devices for scouting. This could lead to issues on unstable networks. The new config parameters can be used to disable multicast scouting entirely or to define a specific multicast interface.

## Type of change
Configuration feature

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
