### PR TITLE
[Telemetry] InfluxDB sink remove id tag

### DIFF
--- a/modules/telemetry/telemetry_influxdb_sink/src/influxdb_metric_sink.cpp
+++ b/modules/telemetry/telemetry_influxdb_sink/src/influxdb_metric_sink.cpp
@@ -36,10 +36,7 @@ namespace {
 }
 
 [[nodiscard]] auto createInfluxdbPoint(const telemetry::Metric& entry) -> influxdb::Point {
-  auto point = influxdb::Point{ entry.component }
-                   .addTag("tag", entry.tag)
-                   .addTag("id", std::to_string(entry.id))
-                   .setTimestamp(entry.timestamp);
+  auto point = influxdb::Point{ entry.component }.addTag("tag", entry.tag).setTimestamp(entry.timestamp);
   for (const auto& [key, value] : entry.values) {
     std::visit(
         [&point, &key](auto&& arg) {


### PR DESCRIPTION
# Description
Remove adding the ID as a tag. Tag are not supposed to be dynamic.

