### PR TITLE
Feature/add structured logging interface

### DIFF
--- a/modules/telemetry/telemetry/CMakeLists.txt
+++ b/modules/telemetry/telemetry/CMakeLists.txt
@@ -11,14 +11,14 @@ declare_module(
 find_package(fmt REQUIRED)
 
 # library sources
-set(SOURCES src/metric_sink.cpp src/metric_record.cpp src/metric_sinks/terminal_sink.cpp include/hephaestus/telemetry/metric_sink.h
-            include/hephaestus/telemetry/metric_record.h include/hephaestus/telemetry/metric_sinks/terminal_sink.h
+set(SOURCES src/metric_sink.cpp src/metric_record.cpp src/struclog.cpp src/log_sinks/absl_sink.cpp src/metric_sinks/terminal_sink.cpp 
+            include/hephaestus/telemetry/metric_sink.h include/hephaestus/telemetry/metric_record.h include/hephaestus/telemetry/struclog.h include/hephaestus/telemetry/log_sinks/absl_sink.h include/hephaestus/telemetry/metric_sinks/terminal_sink.h
 )
 
 # library target
 define_module_library(
   NAME telemetry
-  PUBLIC_LINK_LIBS hephaestus::concurrency hephaestus::random hephaestus::serdes fmt::fmt
+  PUBLIC_LINK_LIBS hephaestus::concurrency hephaestus::random hephaestus::serdes hephaestus::utils fmt::fmt
   PRIVATE_LINK_LIBS ""
   SOURCES ${SOURCES}
   PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
@@ -26,5 +26,6 @@ define_module_library(
   SYSTEM_PRIVATE_INCLUDE_PATHS ""
 )
 
+add_subdirectory(examples)
 add_subdirectory(tests)
 add_subdirectory(examples)

--- a/modules/telemetry/telemetry/CMakeLists.txt
+++ b/modules/telemetry/telemetry/CMakeLists.txt
@@ -28,4 +28,3 @@ define_module_library(
 
 add_subdirectory(examples)
 add_subdirectory(tests)
-add_subdirectory(examples)

--- a/modules/telemetry/telemetry/examples/CMakeLists.txt
+++ b/modules/telemetry/telemetry/examples/CMakeLists.txt
@@ -3,6 +3,12 @@
 #=================================================================================================
 
 define_module_example(
+        NAME log_sink_example
+        SOURCES log_sink_example.cpp
+        PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+        PUBLIC_LINK_LIBS hephaestus::telemetry)
+        
+define_module_example(
         NAME metric_sink_example
         SOURCES metric_sink_example.cpp
         PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>

--- a/modules/telemetry/telemetry/examples/log_sink_example.cpp
+++ b/modules/telemetry/telemetry/examples/log_sink_example.cpp
@@ -1,0 +1,29 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "hephaestus/telemetry/log_sinks/absl_sink.h"
+#include "hephaestus/telemetry/struclog.h"
+#include "hephaestus/utils/stack_trace.h"
+
+namespace ht = heph::telemetry;
+// NOLINTNEXTLINE google-build-using-namespace
+using namespace heph::telemetry::literals;
+
+// NOLINTNEXTLINE(bugprone-exception-escape)
+auto main(int /*argc*/, const char* /*argv*/[]) -> int {
+  const heph::utils::StackTrace stack;
+
+  ht::registerLogSink(std::make_unique<ht::AbslLogSink>());
+
+  const int num = 1234;
+  ht::log(ht::LogEntry{ ht::Level::WARN, "examples", "testing absl log sink a" } | "num"_f(num));
+  ht::log({ ht::Level::WARN, "examples", "testing absl log sink" });
+
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  
+  return 0;
+}

--- a/modules/telemetry/telemetry/examples/log_sink_example.cpp
+++ b/modules/telemetry/telemetry/examples/log_sink_example.cpp
@@ -17,9 +17,7 @@ auto main(int /*argc*/, const char* /*argv*/[]) -> int {
 
   const int num = 1234;
   ht::log(ht::Level::WARN, "testing absl log sink");
-  // NOLINTBEGIN(modernize-use-designated-initializers)
-  ht::log(ht::Level::WARN, "testing absl log sink with field", ht::Field{ "num", num },
-          ht::Field{ "quoted_string", "test" });
-  // NOLINTEND(modernize-use-designated-initializers)
+  ht::log(ht::Level::WARN, "testing absl log sink with field", "num", num, "quoted_string", "test");
+
   return 0;
 }

--- a/modules/telemetry/telemetry/examples/log_sink_example.cpp
+++ b/modules/telemetry/telemetry/examples/log_sink_example.cpp
@@ -1,17 +1,13 @@
 //=================================================================================================
 // Copyright (C) 2023-2024 HEPHAESTUS Contributors
 //=================================================================================================
-#include <chrono>
 #include <memory>
-#include <thread>
 
 #include "hephaestus/telemetry/log_sinks/absl_sink.h"
 #include "hephaestus/telemetry/struclog.h"
 #include "hephaestus/utils/stack_trace.h"
 
 namespace ht = heph::telemetry;
-// NOLINTNEXTLINE google-build-using-namespace
-using namespace heph::telemetry::literals;
 
 // NOLINTNEXTLINE(bugprone-exception-escape)
 auto main(int /*argc*/, const char* /*argv*/[]) -> int {
@@ -20,10 +16,10 @@ auto main(int /*argc*/, const char* /*argv*/[]) -> int {
   ht::registerLogSink(std::make_unique<ht::AbslLogSink>());
 
   const int num = 1234;
-  ht::log(ht::LogEntry{ ht::Level::WARN, "examples", "testing absl log sink a" } | "num"_f(num));
-  ht::log({ ht::Level::WARN, "examples", "testing absl log sink" });
-
-  std::this_thread::sleep_for(std::chrono::seconds(1));
-  
+  ht::log(ht::Level::WARN, "testing absl log sink");
+  // NOLINTBEGIN(modernize-use-designated-initializers)
+  ht::log(ht::Level::WARN, "testing absl log sink with field", ht::Field{ "num", num },
+          ht::Field{ "quoted_string", "test" });
+  // NOLINTEND(modernize-use-designated-initializers)
   return 0;
 }

--- a/modules/telemetry/telemetry/include/hephaestus/telemetry/log_sinks/absl_sink.h
+++ b/modules/telemetry/telemetry/include/hephaestus/telemetry/log_sinks/absl_sink.h
@@ -8,10 +8,9 @@
 
 namespace heph::telemetry {
 
-
 /// @brief A simple sink that passes the struclogs to ABSL.
 ///        Per default entry is formatted via heph::telemetry::format.
-class AbslLogSink : public ILogSink {
+class AbslLogSink final : public ILogSink {
 public:
   explicit AbslLogSink();
   explicit AbslLogSink(ILogSink::Formatter&& f);

--- a/modules/telemetry/telemetry/include/hephaestus/telemetry/log_sinks/absl_sink.h
+++ b/modules/telemetry/telemetry/include/hephaestus/telemetry/log_sinks/absl_sink.h
@@ -1,0 +1,25 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#pragma once
+
+#include "hephaestus/telemetry/struclog.h"
+
+namespace heph::telemetry {
+
+
+/// @brief A simple sink that passes the struclogs to ABSL.
+///        Per default entry is formatted via heph::telemetry::format.
+class AbslLogSink : public ILogSink {
+public:
+  explicit AbslLogSink();
+  explicit AbslLogSink(ILogSink::Formatter&& f);
+
+  void send(const LogEntry& entry) override;
+
+private:
+  ILogSink::Formatter formatter_;
+};
+
+}  // namespace heph::telemetry

--- a/modules/telemetry/telemetry/include/hephaestus/telemetry/struclog.h
+++ b/modules/telemetry/telemetry/include/hephaestus/telemetry/struclog.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <functional>
+#include <iomanip>
+#include <source_location>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace heph::telemetry {
+
+enum class Level : std::uint8_t { TRACE, DEBUG, INFO, WARN, ERROR, FATAL };
+auto operator<<(std::ostream& /*os*/, const Level& /*level*/) -> std::ostream&;
+
+template <typename T>
+concept NotQuotable = !std::convertible_to<T, std::string> && requires(std::ostream& os, T t) {
+  { os << t } -> std::same_as<std::ostream&>;
+};
+
+template <typename T>
+concept Quotable = std::convertible_to<T, std::string>;
+
+template <typename T>
+struct Field final {
+  std::string key;
+  T val;
+};
+
+/// @brief A class that allows easy composition of logs for structured logging.
+///       Example(see also struclog.cpp):
+///       ```cpp
+///         namespace ht=heph::telemetry;
+///         log(ht::LogEntry{Level::INFO, "my module", "adding"} | "id"_f(12345) | ht::Field{"tag", "test"});
+///       ```
+///         logs
+///        'level=info hostname=goofy location=struclog.h:123 thread-id=5124 time=2023-12-3T8:52:02+0
+/// module="my module" message="adding" id=12345 tag="test"'
+///        Remark: We would like to use libfmt with quoted formatting as proposed in
+///                https://github.com/fmtlib/fmt/issues/825 once its included (instead of sstream).
+struct LogEntry {
+  using FieldsT = std::vector<Field<std::string>>;
+  using ClockT = std::chrono::system_clock;
+
+  LogEntry(Level level, std::string&& module, std::string&& message,
+           std::source_location location = std::source_location::current());
+
+
+  /// @brief General loginfo consumer, should be used like LogEntry("my message") | Field{"field", 1234}
+  ///        Converted to string with stringstream.
+  ///
+  /// @tparam T any type that is consumeable by stringstream
+  /// @param key identifier for the logging data
+  /// @param val value of the logging data
+  /// @return LogEntry&&
+
+  template <NotQuotable T>
+  auto operator|(const Field<T>& field) -> LogEntry&& {
+    std::stringstream ss;
+    ss << field.val;
+    fields.emplace_back(field.key, ss.str());
+
+    return std::move(*this);
+  }
+
+  /// @brief Specialized loginfo consumer for string types so that they are quoted, should be used like
+  ///        LogEntry("my message") | Field{"field", "mystring"}
+  ///
+  /// @tparam T any type that is consumeable by stringstream
+  /// @param key identifier for the logging data
+  /// @param val value of the logging data
+  /// @return LogEntry&&
+
+  template <Quotable S>
+  auto operator|(const Field<S>& field) -> LogEntry&& {
+    std::stringstream ss;
+    // Pointer decay is wanted here to catch char[n] messages
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+    ss << std::quoted(field.val);
+    fields.emplace_back(field.key, ss.str());
+
+    return std::move(*this);
+  }
+
+  Level level;
+  std::string module;
+  std::string message;
+  std::source_location location;
+  std::thread::id thread_id;
+  ClockT::time_point time;
+  std::string hostname;
+
+  FieldsT fields;
+};
+
+/// @brief format function from LogEntry to string. Currently its in logfmt.
+///
+/// @param log
+/// @return std::string
+[[nodiscard]] auto format(const LogEntry& log) -> std::string;
+
+inline auto operator<<(std::ostream& os, const LogEntry& log) -> std::ostream& {
+  os << format(log);
+
+  return os;
+}
+
+/// @brief Interface for sinks that log entries can be sent to.
+struct ILogSink {
+  using Formatter = std::function<std::string(const LogEntry& log)>;
+
+  virtual ~ILogSink() = default;
+
+  /// @brief Main interface to the sink, gets called on log.
+  ///
+  /// @param log_entry
+  virtual void send(const LogEntry& log_entry) = 0;
+};
+
+void log(const LogEntry& log_entry);
+
+void registerLogSink(std::unique_ptr<ILogSink> sink);
+
+}  // namespace heph::telemetry
+
+namespace heph::telemetry::literals {
+
+/// @brief User-defined string literal to enable `Field f="data"_f(mydata);`
+///        Hence we can use shorter log calls like `log(LogEntry{Severity::Info, "msg"} | "num"_f(1234));`
+constexpr auto operator""_f(const char* key, [[maybe_unused]] size_t _) {
+  return [key](auto&& value) { return heph::telemetry::Field{ key, std::forward<decltype(value)>(value) }; };
+}
+}  // namespace heph::telemetry::literals

--- a/modules/telemetry/telemetry/src/log_sinks/absl_sink.cpp
+++ b/modules/telemetry/telemetry/src/log_sinks/absl_sink.cpp
@@ -1,0 +1,44 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+#include "hephaestus/telemetry/log_sinks/absl_sink.h"
+
+#include <utility>
+
+#include <absl/log/absl_log.h>
+
+#include "hephaestus/telemetry/struclog.h"
+
+namespace heph::telemetry {
+
+AbslLogSink::AbslLogSink() : formatter_([](const LogEntry& l) { return format(l); }) {
+}
+
+AbslLogSink::AbslLogSink(ILogSink::Formatter&& f) : formatter_(std::move(f)) {
+}
+
+void AbslLogSink::send(const LogEntry& entry) {
+  // Use the ABSL_LOG version since it is more explicit than LOG
+  // Use NoPrefix since all information is contained in the entry and we want logfmt formatting.
+  switch (entry.level) {
+    case Level::TRACE:
+      ABSL_VLOG(2).NoPrefix() << formatter_(entry);
+      break;
+    case Level::DEBUG:
+      ABSL_VLOG(1).NoPrefix() << formatter_(entry);
+      break;
+    case Level::INFO:
+      ABSL_LOG(INFO).NoPrefix() << formatter_(entry);
+      break;
+    case Level::WARN:
+      ABSL_LOG(WARNING).NoPrefix() << formatter_(entry);
+      break;
+    case Level::ERROR:
+      ABSL_LOG(ERROR).NoPrefix() << formatter_(entry);
+      break;
+    case Level::FATAL:
+      ABSL_LOG(FATAL).NoPrefix() << formatter_(entry);
+      break;
+  }
+}
+}  // namespace heph::telemetry

--- a/modules/telemetry/telemetry/src/struclog.cpp
+++ b/modules/telemetry/telemetry/src/struclog.cpp
@@ -1,0 +1,158 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+// MIT License
+//=================================================================================================
+
+#include "hephaestus/telemetry/struclog.h"
+
+#include <array>
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <ostream>
+#include <source_location>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <absl/base/thread_annotations.h>
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+#include <unistd.h>
+
+#include "hephaestus/concurrency/message_queue_consumer.h"
+#include "hephaestus/utils.h"
+
+namespace heph::telemetry {
+auto operator<<(std::ostream& os, const Level& level) -> std::ostream& {
+  switch (level) {
+    case Level::TRACE:
+      os << "trace";
+      break;
+    case Level::DEBUG:
+      os << "debug";
+      break;
+    case Level::INFO:
+      os << "info";
+      break;
+    case Level::WARN:
+      os << "warn";
+      break;
+    case Level::ERROR:
+      os << "error";
+      break;
+    case Level::FATAL:
+      os << "fatal";
+      break;
+  }
+
+  return os;
+}
+
+class Logger final {
+public:
+  explicit Logger();
+  ~Logger();
+
+  Logger(const Logger&) = delete;
+  Logger(Logger&&) = delete;
+  auto operator=(const Logger&) -> Logger& = delete;
+  auto operator=(Logger&&) -> Logger& = delete;
+
+  static void registerSink(std::unique_ptr<ILogSink> sink);
+
+  static void log(const LogEntry& log_entry);
+
+private:
+  [[nodiscard]] static auto instance() -> Logger&;
+
+  /// @brief Do the actual logging. Take in LogEntry and send it to all sinks
+  /// @param LogEntry, class that takes in the structured logs and formats them.
+  /// @return void
+  void processLogEntries(const LogEntry& entry);
+
+private:
+  std::mutex sink_mutex_;
+  // This is used as registry for the log sinks
+  std::vector<std::unique_ptr<ILogSink>> sinks_ ABSL_GUARDED_BY(sink_mutex_);
+  concurrency::MessageQueueConsumer<LogEntry> log_entries_consumer_;
+};
+
+void registerLogSink(std::unique_ptr<ILogSink> sink) {
+  Logger::registerSink(std::move(sink));
+}
+
+void log(const LogEntry& log_entry) {
+  Logger::log(log_entry);
+}
+
+Logger::Logger()
+  : log_entries_consumer_([this](const LogEntry& entry) { processLogEntries(entry); }, std::nullopt) {
+  log_entries_consumer_.start();
+}
+
+Logger::~Logger() {
+  log_entries_consumer_.stop();
+}
+
+auto Logger::instance() -> Logger& {
+  static Logger telemetry;
+  return telemetry;
+}
+
+void Logger::registerSink(std::unique_ptr<ILogSink> sink) {
+  // Add the custom log sink
+  auto& telemetry = instance();
+  const std::lock_guard lock(telemetry.sink_mutex_);
+  telemetry.sinks_.emplace_back(std::move(sink));
+}
+
+void Logger::log(const LogEntry& log_entry) {
+  auto& telemetry = instance();
+  telemetry.log_entries_consumer_.queue().forcePush(log_entry);
+}
+
+void Logger::processLogEntries(const LogEntry& entry) {
+  const std::lock_guard lock(sink_mutex_);
+  for (auto& sink : sinks_) {
+    sink->send(entry);
+  }
+}
+
+LogEntry::LogEntry(Level level_in, std::string&& module_in, std::string&& message_in,
+                   std::source_location location_in)
+  : level{ level_in }
+  , module{ std::move(module_in) }
+  , message{ std::move(message_in) }
+  , location{ location_in }
+  , thread_id{ std::this_thread::get_id() }
+  , time{ LogEntry::ClockT::now() }
+  , hostname{ heph::utils::getHostName() } {
+}
+
+auto format(const LogEntry& log) -> std::string {
+  std::stringstream ss;
+  ss << "level=" << log.level;
+  ss << " hostname=" << std::quoted(log.hostname);
+  ss << " location="
+     << std::quoted(fmt::format("{}:{}",
+                                std::filesystem::path{ log.location.file_name() }.filename().string(),
+                                log.location.line()));
+  ss << " thread-id=" << log.thread_id;
+  ss << " time=" << fmt::format("{:%Y-%m-%dT%H:%M:%SZ}", log.time);
+  ss << " module=" << std::quoted(log.module);
+  ss << " message=" << std::quoted(log.message);
+
+  for (const Field<std::string>& field : log.fields) {
+    ss << " " << field.key << "=" << field.val;
+  }
+
+  return ss.str();
+}
+
+}  // namespace heph::telemetry

--- a/modules/telemetry/telemetry/tests/CMakeLists.txt
+++ b/modules/telemetry/telemetry/tests/CMakeLists.txt
@@ -8,3 +8,10 @@ define_module_test(
         PUBLIC_INCLUDE_PATHS
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
         PUBLIC_LINK_LIBS "")
+
+define_module_test(
+        NAME struclog_tests
+        SOURCES struclog_tests.cpp
+        PUBLIC_INCLUDE_PATHS
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+        PUBLIC_LINK_LIBS "")

--- a/modules/telemetry/telemetry/tests/struclog_tests.cpp
+++ b/modules/telemetry/telemetry/tests/struclog_tests.cpp
@@ -1,0 +1,132 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+#include <atomic>
+#include <format>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "hephaestus/telemetry/struclog.h"
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace ::testing;
+
+namespace hephtelemetry::tests {
+
+namespace ht = heph::telemetry;
+// NOLINTNEXTLINE google-build-using-namespace
+using namespace heph::telemetry::literals;
+
+namespace {
+auto printout(const ht::LogEntry& s) -> std::string {
+  return ht::format(s);
+}
+}  // namespace
+
+TEST(struclog, LogEntry) {
+  const std::string a = "test a great message";
+  const std::string b = "test \"great\" name";
+  // clang-format off
+  const int current_line = __LINE__; auto log_entry = ht::LogEntry{ht::Level::INFO, "tests", std::string(a)} | ht::Field{.key="b",.val="test \"great\" name"};
+  // clang-format on
+  auto s = printout(log_entry);
+  {
+    std::stringstream ss;
+    ss << "message=" << std::quoted(a);
+    EXPECT_TRUE(s.find(ss.str()) != std::string::npos);
+  }
+  {
+    std::stringstream ss;
+    ss << " b=" << std::quoted(b);
+    EXPECT_TRUE(s.find(ss.str()) != std::string::npos);
+  }
+  EXPECT_TRUE(s.find(std::format("location=\"struclog_tests.cpp:{}\"", current_line)) != std::string::npos);
+}
+
+TEST(struclog, Escapes) {
+  const std::string a = "test a great message";
+  const std::string b = "test \"great\" name";
+  const std::string c = "test 'great' name";
+  const int num = 123;
+  // clang-format off
+  const int current_line = __LINE__; auto log_entry = ht::LogEntry{ht::Level::INFO, "tests",std::string(a)} | "b"_f(b) | ht::Field{.key="c", .val=c} | "num"_f(num);
+  // clang-format on
+  auto s = printout(log_entry);
+  ht::log(log_entry);
+  {
+    std::stringstream ss;
+    ss << "level=info";
+    EXPECT_TRUE(s.find(ss.str()) != std::string::npos);
+  }
+  {
+    std::stringstream ss;
+    ss << "message=" << std::quoted(a);
+    EXPECT_TRUE(s.find(ss.str()) != std::string::npos);
+  }
+  {
+    std::stringstream ss;
+    ss << std::format("location=\"struclog_tests.cpp:{}\"", current_line);
+    EXPECT_TRUE(s.find(ss.str()) != std::string::npos);
+  }
+  {
+    std::stringstream ss;
+    ss << "b=" << std::quoted(b);
+    EXPECT_TRUE(s.find(ss.str()) != std::string::npos);
+  }
+  {
+    std::stringstream ss;
+    ss << "c=" << std::quoted(c);
+    EXPECT_TRUE(s.find(ss.str()) != std::string::npos);
+  }
+  {
+    std::stringstream ss;
+    ss << "num=" << num;
+    EXPECT_TRUE(s.find(ss.str()) != std::string::npos);
+  }
+}
+
+/// @brief Custom sink that will write the log to a string.
+class MockLogSink final : public ht::ILogSink {
+public:
+  void send(const ht::LogEntry& s) override {
+    log_ = format(s);
+    flag_.test_and_set();
+    flag_.notify_all();
+  }
+
+  [[nodiscard]] auto getLog() const -> const std::string& {
+    return log_;
+  }
+
+  void wait() const {
+    flag_.wait(false);
+  }
+
+private:
+  std::string log_;
+  std::atomic_flag flag_ = ATOMIC_FLAG_INIT;
+};
+
+TEST(struclog, sink) {
+  const int num = 123;
+
+  const auto log_entry =
+      ht::LogEntry{ ht::Level::ERROR, "tests", "test another great message" } | "num"_f(num);
+  auto mock_sink = std::make_unique<MockLogSink>();
+  const MockLogSink* sink_ptr = mock_sink.get();
+  ht::registerLogSink(std::move(mock_sink));
+  ht::log(log_entry);
+  sink_ptr->wait();
+  {
+    std::stringstream ss;
+    ss << "num=" << num;
+    EXPECT_TRUE(sink_ptr->getLog().find(ss.str()) != std::string::npos);
+  }
+}
+
+}  // namespace hephtelemetry::tests


### PR DESCRIPTION
# Description

In succession of #201 this is my first try to implement the log interface like
```cpp
heph::log(heph::Level::WARN, "message", {"num", 123}, {"test", "lala"});
```
I tried doing the variadic interface but struggled to get the template deduction guides working that are needed to combine the variadic interface with source_location  with direct intitialization via {}.

Any ideas?

another way would be to have a class
```cpp
struct MessageWithLocation {
  std::string value;
  std::source_location loc;

  MessageWithLocation(std::string s,
                     std::source_location l = std::source_location::current())
      : value(s), loc(l) {}

};
```
that would be used instead of std::string for message input type. However I am not sure if then implicit conversion from string would be possible (`heph::log(heph::Level::WARN, "message")` vs `heph::log(heph::Level::WARN, {"message"})`
## Type of change
- New feature (non-breaking change which adds functionality)
