### PR TITLE
Fix/Fix nondetermenistic test for logging

### DIFF
--- a/modules/telemetry/telemetry/tests/log_tests.cpp
+++ b/modules/telemetry/telemetry/tests/log_tests.cpp
@@ -1,13 +1,10 @@
 //=================================================================================================
 // Copyright (C) 2023-2024 HEPHAESTUS Contributors
 
-#include <chrono>
 #include <format>
 #include <iomanip>
 #include <iostream>
 #include <memory>
-// #include <mutex>
-#include <source_location>
 #include <sstream>
 #include <string>
 #include <utility>


### PR DESCRIPTION
# Description

With using several sink, the asynchronous global sink became non deterministic, since it only held the last log.
Now it supports having several logs. and blocks until they are available. 
Tried to do it elegantly, with condition variable, but failed and did it with a sleeping loop.
@filippobrizzi can you get the condition variable to work? I always ended up in a deadlock...

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
