### PR TITLE
remove dep to concurrency

### DIFF
--- a/modules/telemetry/telemetry/BUILD
+++ b/modules/telemetry/telemetry/BUILD
@@ -17,7 +17,7 @@ heph_cc_library(
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
-        "//modules/concurrency",
+        "//modules/containers",
         "//modules/random",
         "//modules/serdes",
         "@abseil-cpp//absl/log:absl_log",

--- a/modules/telemetry/telemetry/CMakeLists.txt
+++ b/modules/telemetry/telemetry/CMakeLists.txt
@@ -32,7 +32,7 @@ set(SOURCES
 define_module_library(
   NAME telemetry
   PUBLIC_LINK_LIBS
-    hephaestus::concurrency
+    hephaestus::containers
     hephaestus::random
     hephaestus::serdes
     hephaestus::utils

--- a/modules/telemetry/telemetry/src/log.cpp
+++ b/modules/telemetry/telemetry/src/log.cpp
@@ -58,12 +58,12 @@ Logger::Logger() : entries_{ std::nullopt } {
     while (true) {
       auto message = entries_.waitAndPop();
       if (!message.has_value()) {
-        emptyQueue();
-        return;
+        break;
       }
 
       processEntry(message.value());
     }
+    emptyQueue();
   });
 }
 

--- a/modules/telemetry/telemetry/src/log.cpp
+++ b/modules/telemetry/telemetry/src/log.cpp
@@ -6,7 +6,6 @@
 
 #include <exception>
 #include <future>
-#include <iostream>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -14,6 +13,7 @@
 
 #include <absl/base/thread_annotations.h>
 #include <absl/synchronization/mutex.h>
+#include <fmt/base.h>
 
 #include "hephaestus/containers/blocking_queue.h"
 #include "hephaestus/telemetry/log_sink.h"

--- a/modules/telemetry/telemetry/src/log.cpp
+++ b/modules/telemetry/telemetry/src/log.cpp
@@ -72,7 +72,7 @@ Logger::~Logger() {
     entries_.stop();
     message_process_future_.get();
   } catch (const std::exception& ex) {
-    std::cerr << "While emptying log queue, exception happened: " << ex.what() << "\n";
+    fmt::println(stderr, "While emptying log queue, exception happened: {}", ex.what());
   }
 }
 

--- a/modules/telemetry/telemetry/src/log.cpp
+++ b/modules/telemetry/telemetry/src/log.cpp
@@ -5,6 +5,7 @@
 #include "hephaestus/telemetry/log.h"
 
 #include <exception>
+#include <future>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -14,9 +15,10 @@
 #include <absl/base/thread_annotations.h>
 #include <absl/synchronization/mutex.h>
 
-#include "hephaestus/concurrency/message_queue_consumer.h"
+#include "hephaestus/containers/blocking_queue.h"
 #include "hephaestus/telemetry/log_sink.h"
 
+namespace heph::telemetry {
 namespace {
 class Logger final {
 public:
@@ -28,9 +30,9 @@ public:
   auto operator=(const Logger&) -> Logger& = delete;
   auto operator=(Logger&&) -> Logger& = delete;
 
-  static void registerSink(std::unique_ptr<heph::telemetry::ILogSink> sink);
+  static void registerSink(std::unique_ptr<ILogSink> sink);
 
-  static void log(heph::telemetry::LogEntry&& log_entry);
+  static void log(LogEntry&& log_entry);
 
 private:
   [[nodiscard]] static auto instance() -> Logger&;
@@ -38,26 +40,39 @@ private:
   /// @brief Do the actual logging. Take in LogEntry and send it to all sinks
   /// @param LogEntry, class that takes in the structured logs and formats them.
   /// @return void
-  void processLogEntries(const heph::telemetry::LogEntry& entry);
+  void processEntry(const LogEntry& entry);
+
+  /// @brief Empty the queue so that remaining messages get processed
+  void emptyQueue();
 
 private:
   absl::Mutex sink_mutex_;
   // This is used as registry for the log sinks
-  std::vector<std::unique_ptr<heph::telemetry::ILogSink>> sinks_ ABSL_GUARDED_BY(sink_mutex_);
-  heph::concurrency::MessageQueueConsumer<heph::telemetry::LogEntry> log_entries_consumer_;
+  std::vector<std::unique_ptr<ILogSink>> sinks_ ABSL_GUARDED_BY(sink_mutex_);
+  heph::containers::BlockingQueue<LogEntry> entries_;
+  std::future<void> stop_signal_;
 };
 
-Logger::Logger()
-  : log_entries_consumer_([this](const heph::telemetry::LogEntry& entry) { processLogEntries(entry); },
-                          std::nullopt) {
-  log_entries_consumer_.start();
+Logger::Logger() : entries_{ std::nullopt } {
+  stop_signal_ = std::async(std::launch::async, [this]() {
+    while (true) {
+      auto message = entries_.waitAndPop();
+      if (!message.has_value()) {
+        emptyQueue();
+        return;
+      }
+
+      processEntry(message.value());
+    }
+  });
 }
 
 Logger::~Logger() {
   try {
-    log_entries_consumer_.stop().get();
+    entries_.stop();
+    stop_signal_.get();
   } catch (const std::exception& ex) {
-    std::cerr << "While emptying message consumer, exception happened: " << ex.what() << "\n";
+    std::cerr << "While emptying log queue, exception happened: " << ex.what() << "\n";
   }
 }
 
@@ -66,30 +81,42 @@ auto Logger::instance() -> Logger& {
   return telemetry;
 }
 
-void Logger::registerSink(std::unique_ptr<heph::telemetry::ILogSink> sink) {
+void Logger::registerSink(std::unique_ptr<ILogSink> sink) {
   // Add the custom log sink
   auto& telemetry = instance();
   const absl::MutexLock lock{ &telemetry.sink_mutex_ };
   telemetry.sinks_.emplace_back(std::move(sink));
 }
 
-void Logger::log(heph::telemetry::LogEntry&& log_entry) {
+void Logger::log(LogEntry&& log_entry) {
   auto& telemetry = instance();
-  telemetry.log_entries_consumer_.queue().forcePush(std::move(log_entry));
+  telemetry.entries_.forcePush(std::move(log_entry));
 }
 
-void Logger::processLogEntries(const heph::telemetry::LogEntry& entry) {
+void Logger::processEntry(const LogEntry& entry) {
   const absl::MutexLock lock{ &sink_mutex_ };
   for (auto& sink : sinks_) {
     sink->send(entry);
   }
 }
+
+void Logger::emptyQueue() {
+  while (!entries_.empty()) {
+    auto message = entries_.tryPop();
+    if (!message.has_value()) {
+      return;
+    }
+
+    processEntry(message.value());
+  }
+}
 }  // namespace
 
-void heph::telemetry::internal::log(heph::telemetry::LogEntry&& log_entry) {
+void internal::log(LogEntry&& log_entry) {
   Logger::log(std::move(log_entry));
 }
 
-void heph::telemetry::registerLogSink(std::unique_ptr<heph::telemetry::ILogSink> sink) {
+void registerLogSink(std::unique_ptr<ILogSink> sink) {
   Logger::registerSink(std::move(sink));
 }
+}  // namespace heph::telemetry

--- a/modules/telemetry/telemetry/src/log_sink.cpp
+++ b/modules/telemetry/telemetry/src/log_sink.cpp
@@ -3,14 +3,8 @@
 //=================================================================================================
 #include "hephaestus/telemetry/log_sink.h"
 
-// #include <filesystem>
-// #include <string>
-// #include <string_view>
 #include <thread>
 #include <utility>
-
-// #include <fmt/base.h>
-// #include <fmt/format.h>
 
 #include "hephaestus/utils/utils.h"
 

--- a/modules/telemetry/telemetry/src/metric_record.cpp
+++ b/modules/telemetry/telemetry/src/metric_record.cpp
@@ -131,12 +131,12 @@ MetricRecorder::MetricRecorder() : entries_{ std::nullopt } {
     while (true) {
       auto message = entries_.waitAndPop();
       if (!message.has_value()) {
-        emptyQueue();
-        return;
+        break;
       }
 
       processEntry(message.value());
     }
+    emptyQueue();
   });
 }
 

--- a/modules/telemetry/telemetry/src/metric_record.cpp
+++ b/modules/telemetry/telemetry/src/metric_record.cpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <exception>
+#include <future>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -21,7 +22,7 @@
 #include <fmt/format.h>
 #include <nlohmann/json_fwd.hpp>
 
-#include "hephaestus/concurrency/message_queue_consumer.h"
+#include "hephaestus/containers/blocking_queue.h"
 #include "hephaestus/telemetry/metric_sink.h"
 
 namespace heph::telemetry {
@@ -105,12 +106,16 @@ public:
 
 private:
   [[nodiscard]] static auto instance() -> MetricRecorder&;
-  void processEntries(const Metric& entry);
+  void processEntry(const Metric& entry);
+
+  /// @brief Empty the queue so that remaining messages get processed
+  void emptyQueue();
 
 private:
   absl::Mutex sink_mutex_;
   std::vector<std::unique_ptr<IMetricSink>> sinks_ ABSL_GUARDED_BY(sink_mutex_);
-  concurrency::MessageQueueConsumer<Metric> entries_consumer_;
+  containers::BlockingQueue<Metric> entries_;
+  std::future<void> stop_signal_;
 };
 
 void registerMetricSink(std::unique_ptr<IMetricSink> sink) {
@@ -121,14 +126,24 @@ void record(const Metric& metric) {
   MetricRecorder::record(metric);
 }
 
-MetricRecorder::MetricRecorder()
-  : entries_consumer_([this](const Metric& entry) { processEntries(entry); }, std::nullopt) {
-  entries_consumer_.start();
+MetricRecorder::MetricRecorder() : entries_{ std::nullopt } {
+  stop_signal_ = std::async(std::launch::async, [this]() {
+    while (true) {
+      auto message = entries_.waitAndPop();
+      if (!message.has_value()) {
+        emptyQueue();
+        return;
+      }
+
+      processEntry(message.value());
+    }
+  });
 }
 
 MetricRecorder::~MetricRecorder() {
   try {
-    entries_consumer_.stop().get();
+    entries_.stop();
+    stop_signal_.get();
   } catch (const std::exception& ex) {
     LOG(FATAL) << "While emptying message consumer, exception happened: " << ex.what();
   }
@@ -147,13 +162,24 @@ void MetricRecorder::registerSink(std::unique_ptr<IMetricSink> sink) {
 
 void MetricRecorder::record(const Metric& metric) {
   auto& telemetry = instance();
-  telemetry.entries_consumer_.queue().forcePush(metric);
+  telemetry.entries_.forcePush(metric);
 }
 
-void MetricRecorder::processEntries(const Metric& entry) {
+void MetricRecorder::processEntry(const Metric& entry) {
   const absl::MutexLock lock{ &sink_mutex_ };
   for (auto& sink : sinks_) {
     sink->send(entry);
+  }
+}
+
+void MetricRecorder::emptyQueue() {
+  while (!entries_.empty()) {
+    auto message = entries_.tryPop();
+    if (!message.has_value()) {
+      return;
+    }
+
+    processEntry(message.value());
   }
 }
 


### PR DESCRIPTION
# Description

The spinner inside of the consumer module needs logging. 
However up to now we used message_consumer to consume metrics and logs -> cyclic dep
We resovle this by adding the trivial behaviour of the Logger and MetricRecord singletons by hand and remove dep to concurrency.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] If this is a new component I have added examples.