### PR TITLE
[StopWatch] add `elapsed` function

### DIFF
--- a/bazel/hephaestus.bzl
+++ b/bazel/hephaestus.bzl
@@ -113,6 +113,7 @@ def heph_cc_test(
         linkopts = [],
         deps = [],
         tags = [],
+        size = "small",
         **kwargs):
     cc_test(
         copts = heph_copts() + copts,
@@ -122,6 +123,7 @@ def heph_cc_test(
             "@googletest//:gtest_main",
         ],
         tags = tags + ["no-clang-tidy"],  # NOTE: we need this to avoid all googletest issues
+        size = size,
         **kwargs
     )
 

--- a/modules/ipc/BUILD
+++ b/modules/ipc/BUILD
@@ -83,7 +83,6 @@ heph_cc_test(
     srcs = [
         "tests/action_server_tests.cpp",
     ],
-    flaky = True,
     deps = IPC_TEST_DEPS,
 )
 

--- a/modules/ipc/BUILD
+++ b/modules/ipc/BUILD
@@ -83,6 +83,7 @@ heph_cc_test(
     srcs = [
         "tests/action_server_tests.cpp",
     ],
+    flaky = True,
     deps = IPC_TEST_DEPS,
 )
 

--- a/modules/ipc/tests/action_server_tests.cpp
+++ b/modules/ipc/tests/action_server_tests.cpp
@@ -153,13 +153,14 @@ TEST(ActionServer, ActionServerRejectedAlreadyRunning) {
         return request;
       });
 
+  auto client_session = createSession({});
   auto request = types::DummyType::random(mt);
   auto reply_future = callActionServer<types::DummyType, types::DummyPrimitivesType, types::DummyType>(
-      action_server_data.session, action_server_data.topic_config, request,
-      [](const types::DummyPrimitivesType&) {}, SERVICE_CALL_TIMEOUT);
+      client_session, action_server_data.topic_config, request, [](const types::DummyPrimitivesType&) {},
+      SERVICE_CALL_TIMEOUT);
 
   auto other_reply = callActionServer<types::DummyType, types::DummyPrimitivesType, types::DummyType>(
-                         action_server_data.session, action_server_data.topic_config, request,
+                         client_session, action_server_data.topic_config, request,
                          [](const types::DummyPrimitivesType&) {}, SERVICE_CALL_TIMEOUT)
                          .get();
   EXPECT_EQ(other_reply.status, RequestStatus::REJECTED_ALREADY_RUNNING);

--- a/modules/utils/include/hephaestus/utils/timing/stop_watch.h
+++ b/modules/utils/include/hephaestus/utils/timing/stop_watch.h
@@ -27,13 +27,17 @@ public:
   [[nodiscard]] auto stop() -> TargetDurationT;
 
   /// \return Currently running lap time:
-  /// - time elapsed from max[most recent start(), most recent lap()] to now.
+  /// - time elapsed from max[most recent start(), most recent lapse()] to now.
   /// - Cast to desired duration.
   /// - Doesn't stop the watch.
   template <typename TargetDurationT = StopWatch::DurationT>
   [[nodiscard]] auto lapse() -> TargetDurationT;
 
-  /// Stop and reset accumlated information.
+  /// \return Elapsed time since the last start() cast to the desired duration.
+  template <typename TargetDurationT = StopWatch::DurationT>
+  [[nodiscard]] auto elapsed() -> TargetDurationT;
+
+  /// Stop and reset accumulated information.
   void reset();
 
   /// \return Time accumulated across all laps since last reset().
@@ -48,6 +52,7 @@ public:
 private:
   [[nodiscard]] auto lapseImpl() -> DurationT;
   [[nodiscard]] auto stopImpl() -> DurationT;
+  [[nodiscard]] auto elapsedImpl() -> DurationT;
 
 private:
   std::optional<ClockT::time_point> lap_start_timestamp_;      //!< Timestamp at start().
@@ -67,6 +72,11 @@ auto StopWatch::lapse() -> TargetDurationT {
 template <typename TargetDurationT>
 auto StopWatch::stop() -> TargetDurationT {
   return std::chrono::duration_cast<TargetDurationT>(stopImpl());
+}
+
+template <typename TargetDurationT>
+auto StopWatch::elapsed() -> TargetDurationT {
+  return std::chrono::duration_cast<TargetDurationT>(elapsedImpl());
 }
 
 }  // namespace heph::utils::timing

--- a/modules/utils/include/hephaestus/utils/timing/stop_watch.h
+++ b/modules/utils/include/hephaestus/utils/timing/stop_watch.h
@@ -10,6 +10,14 @@
 
 namespace heph::utils::timing {
 
+/// StopWatch provides functionalities to measure elapsed time in different intervals.
+///
+/// start                stop   start        stop
+///   |  lapse  |  lapse  |       |   lapse   |
+///   |   elapsed   |
+///   |___________________|       |___________|
+///             accumulatedLapsDuration
+///
 class StopWatch {
 public:
   using ClockT = std::chrono::steady_clock;
@@ -26,7 +34,8 @@ public:
   template <typename TargetDurationT = StopWatch::DurationT>
   [[nodiscard]] auto stop() -> TargetDurationT;
 
-  /// \return Currently running lap time:
+  /// \return Currently running lap time, measured from the last call to lapse.
+  /// The first lap is measured from the last start timestamp:
   /// - time elapsed from max[most recent start(), most recent lapse()] to now.
   /// - Cast to desired duration.
   /// - Doesn't stop the watch.

--- a/modules/utils/src/timing/stop_watch.cpp
+++ b/modules/utils/src/timing/stop_watch.cpp
@@ -78,4 +78,12 @@ auto StopWatch::stopImpl() -> ClockT::duration {
   return lap_time;
 }
 
+auto StopWatch::elapsedImpl() -> ClockT::duration {
+  if (!lap_start_timestamp_.has_value()) {
+    return {};
+  }
+
+  return ClockT::now() - lap_start_timestamp_.value();
+}
+
 }  // namespace heph::utils::timing

--- a/modules/utils/tests/stop_watch_tests.cpp
+++ b/modules/utils/tests/stop_watch_tests.cpp
@@ -95,9 +95,12 @@ TEST(StopWatch, Lapse) {
   std::this_thread::sleep_for(PERIOD);
   const auto l1 = swatch.lapse();
   const auto l2 = swatch.lapse();
-  const auto d = swatch.stop();
   EXPECT_GT(l1, l2);
+  const auto e = swatch.elapsed();
+  EXPECT_GT(e, l1 + l2);
+  const auto d = swatch.stop();
   EXPECT_GT(d, l2);
+  EXPECT_GT(d, e);
 }
 
 TEST(StopWatch, DurationCast) {


### PR DESCRIPTION
# Description
Add `elapsed` function ot `StopWatch`. The function allows to return the time elapsed from first call to `start()` 

