### PR TITLE
[IPC] Fix: command line options for zenoh session missing commad

### DIFF
--- a/modules/examples/examples/zenoh_pub.cpp
+++ b/modules/examples/examples/zenoh_pub.cpp
@@ -19,6 +19,8 @@
 #include "hephaestus/ipc/zenoh/program_options.h"
 #include "hephaestus/ipc/zenoh/publisher.h"
 #include "hephaestus/ipc/zenoh/session.h"
+#include "hephaestus/telemetry/log.h"
+#include "hephaestus/telemetry/log_sinks/absl_sink.h"
 #include "hephaestus/utils/exception.h"
 #include "hephaestus/utils/signal_handler.h"
 #include "hephaestus/utils/stack_trace.h"
@@ -28,6 +30,8 @@ auto main(int argc, const char* argv[]) -> int {
   const heph::utils::StackTrace stack_trace;
 
   try {
+    heph::telemetry::registerLogSink(std::make_unique<heph::telemetry::AbslLogSink>());
+
     auto desc = heph::cli::ProgramDescription("Periodic publisher example");
     heph::ipc::zenoh::appendProgramOption(desc, getDefaultTopic(ExampleType::PUBSUB));
     const auto args = std::move(desc).parse(argc, argv);

--- a/modules/ipc/src/zenoh/program_options.cpp
+++ b/modules/ipc/src/zenoh/program_options.cpp
@@ -24,9 +24,8 @@ void appendProgramOption(cli::ProgramDescription& program_description,
       .defineOption<std::string>("mode", "Running mode: options: peer, client", "peer")
       .defineOption<std::string>("router", "Router endpoint", "")
       .defineOption<std::string>("protocol", "Protocol to use, options: udp, tcp, any", "any")
-      .defineOption<std::string>("multicast_scouting_interface"
-                                 "Interface to use for multicast, options: auto, <INTERFACE_NAME>",
-                                 "auto")
+      .defineOption<std::string>("multicast_scouting_interface",
+                                 "Interface to use for multicast, options: auto, <INTERFACE_NAME>", "auto")
       .defineFlag("shared_memory", "Enable shared memory")
       .defineFlag("multicast_scouting_enabled", "Enable multicast scouting")
       .defineFlag("qos", "Enable QoS")


### PR DESCRIPTION
# Description
Fix a bug in command line options utility for zenoh session.
