### PR TITLE
[Service] fix type check for string type

### DIFF
--- a/modules/ipc/include/hephaestus/ipc/zenoh/service.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/service.h
@@ -180,8 +180,6 @@ template <typename RequestT, typename ReplyT>
   ::zenoh::Session::GetOptions options{};
   options.timeout_ms = static_cast<uint64_t>(timeout.count());
 
-  std::unordered_map<std::string, std::string> attachments;
-
   if constexpr (std::is_same_v<RequestT, std::string>) {
     options.encoding = ::zenoh::Encoding::Predefined::zenoh_string();
     options.payload = ::zenoh::ext::serialize(request);
@@ -190,6 +188,7 @@ template <typename RequestT, typename ReplyT>
     options.payload = toZenohBytes(serdes::serialize(request));
   }
 
+  std::unordered_map<std::string, std::string> attachments;
   attachments[SERVICE_ATTACHMENT_REQUEST_TYPE_INFO] = getSerializedTypeName<RequestT>();
   attachments[SERVICE_ATTACHMENT_REPLY_TYPE_INFO] = getSerializedTypeName<ReplyT>();
   options.attachment = ::zenoh::ext::serialize(attachments);


### PR DESCRIPTION
# Description
The result of `getTypeName<std::string>` depends on the compiler and can return either:
```
std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > 
std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, 
```

however, the two types are identical from a serialization point of view so the Service should not complain.

To fix this, we manually set the type to `std::string`