### PR TITLE
Expose proto serdes functionalities

### DIFF
--- a/modules/serdes/include/hephaestus/serdes/protobuf/buffers.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/buffers.h
@@ -22,7 +22,7 @@ public:
     proto.SerializeToArray(buffer_.data(), static_cast<int>(buffer_.size()));
   }
 
-  [[nodiscard]] auto exctractSerializedData() && -> std::vector<std::byte>&& {
+  [[nodiscard]] auto extractSerializedData() && -> std::vector<std::byte>&& {
     return std::move(buffer_);
   }
 

--- a/modules/serdes/include/hephaestus/serdes/protobuf/protobuf_internal.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/protobuf_internal.h
@@ -15,10 +15,9 @@
 
 namespace heph::serdes::protobuf::internal {
 
-template <class T>
+template <class T, class ProtoT>
 void toProtobuf(SerializerBuffer& buffer, const T& data) {
-  using Proto = ProtoAssociation<T>::Type;
-  Proto proto;
+  ProtoT proto;
   toProto(proto, data);
   buffer.serialize(proto);
 }

--- a/modules/serdes/include/hephaestus/serdes/protobuf/protobuf_internal.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/protobuf_internal.h
@@ -4,12 +4,18 @@
 
 #pragma once
 
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <fmt/format.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>
 
 #include "hephaestus/serdes/protobuf/buffers.h"
 #include "hephaestus/serdes/protobuf/concepts.h"
+#include "hephaestus/serdes/type_info.h"
 #include "hephaestus/utils/exception.h"
 #include "hephaestus/utils/utils.h"
 
@@ -20,6 +26,13 @@ void toProtobuf(SerializerBuffer& buffer, const T& data) {
   ProtoT proto;
   toProto(proto, data);
   buffer.serialize(proto);
+}
+
+template <class T, class ProtoT>
+[[nodiscard]] auto serialize(const T& data) -> std::vector<std::byte> {
+  SerializerBuffer buffer{};
+  internal::toProtobuf<T, ProtoT>(buffer, data);
+  return std::move(buffer).extractSerializedData();
 }
 
 template <class T>
@@ -37,5 +50,21 @@ void fromProtobuf(DeserializerBuffer& buffer, T& data) {
 /// channel schema. The descriptor can be obtained via `ProtoType::descriptor()`.
 auto buildFileDescriptorSet(const google::protobuf::Descriptor* toplevel_descriptor)
     -> google::protobuf::FileDescriptorSet;
+
+template <class ProtoT>
+[[nodiscard]] auto getProtoTypeInfo(std::string original_type) -> TypeInfo {
+  auto proto_descriptor = ProtoT::descriptor();
+  auto file_descriptor = buildFileDescriptorSet(proto_descriptor).SerializeAsString();
+
+  std::vector<std::byte> schema(file_descriptor.size());
+  std::transform(file_descriptor.begin(), file_descriptor.end(), schema.begin(),
+                 [](char c) { return static_cast<std::byte>(c); });
+
+  auto original_type_tmp = std::move(original_type);  // NOTE: this is need otherwise clang-tidy will complain
+  return { .name = proto_descriptor->full_name(),
+           .schema = schema,
+           .serialization = TypeInfo::Serialization::PROTOBUF,
+           .original_type = std::move(original_type_tmp) };
+}
 
 }  // namespace heph::serdes::protobuf::internal

--- a/modules/serdes/tests/tests.cpp
+++ b/modules/serdes/tests/tests.cpp
@@ -84,7 +84,7 @@ TEST(Protobuf, SerializerBuffers) {
 
   buffer.serialize(proto);
 
-  const auto data = std::move(buffer).exctractSerializedData();
+  const auto data = std::move(buffer).extractSerializedData();
   EXPECT_THAT(data, SizeIs(NUMBER));
 }
 


### PR DESCRIPTION
# Description
We expose some protobuf serdes functionalities to avoid having to rely on `ProtoAssociation`. This functionalities are in `internal` namespace and should be used only in rare cases. 
The use case is that we have one type that can match to two different proto types. This forces as to manually specify the association in one of the two cases.

> Note: nothing change on the public interface

Some minor changes:
* Fix a type
* Improved one error message
