### PR TITLE
support clock supported in heph::utils::format and std::chrono::duration

### DIFF
--- a/modules/format/include/hephaestus/format/generic_formatter.h
+++ b/modules/format/include/hephaestus/format/generic_formatter.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <chrono>
+#include <format>
 #include <ostream>
 #include <string>
 #include <string_view>
@@ -16,6 +17,7 @@
 #include <rfl/yaml.hpp>  // NOLINT(misc-include-cleaner)
 
 #include "hephaestus/utils/concepts.h"
+#include "hephaestus/utils/format/format.h"
 
 namespace heph::format {
 
@@ -35,14 +37,23 @@ namespace rfl {
 /// \brief Specialization of the Reflector for chrono based Timestamp type. See
 /// https://github.com/getml/reflect-cpp/blob/main/docs/custom_parser.md
 /// For implementation of Reflector::to see commit b1a4eda
-using SystemClockType = std::chrono::system_clock;
-template <>
-struct Reflector<std::chrono::time_point<SystemClockType>> {  // NOLINT(misc-include-cleaner)
+template <typename Clock>
+  requires(heph::ChronoSteadyClockType<Clock> || heph::ChronoSystemClockType<Clock>)
+struct Reflector<std::chrono::time_point<Clock>> {  // NOLINT(misc-include-cleaner)
   using ReflType = std::string;
 
-  static auto from(const std::chrono::time_point<SystemClockType>& x) noexcept -> ReflType {
-    return fmt::format("{:%Y-%m-%d %H:%M:%S}",
-                       std::chrono::time_point_cast<std::chrono::microseconds, SystemClockType>(x));
+  static auto from(const std::chrono::time_point<Clock>& x) noexcept -> ReflType {
+    return heph::utils::format::toString(x);
+  }
+};
+
+/// \brief Specialization of the Reflector for chrono based Duration type.
+template <typename Rep, typename Period>
+struct Reflector<std::chrono::duration<Rep, Period>> {  // NOLINT(misc-include-cleaner)
+  using ReflType = std::string;
+
+  static auto from(const std::chrono::duration<Rep, Period>& x) noexcept -> ReflType {
+    return std::format("{}", x);
   }
 };
 

--- a/modules/format/include/hephaestus/format/generic_formatter.h
+++ b/modules/format/include/hephaestus/format/generic_formatter.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <chrono>
-#include <format>
 #include <ostream>
 #include <string>
 #include <string_view>
@@ -53,7 +52,7 @@ struct Reflector<std::chrono::duration<Rep, Period>> {  // NOLINT(misc-include-c
   using ReflType = std::string;
 
   static auto from(const std::chrono::duration<Rep, Period>& x) noexcept -> ReflType {
-    return std::format("{}", x);
+    return fmt::format("{:.3f}s", std::chrono::duration_cast<std::chrono::duration<float>>(x).count());
   }
 };
 

--- a/modules/format/tests/generic_formatter_tests.cpp
+++ b/modules/format/tests/generic_formatter_tests.cpp
@@ -68,7 +68,7 @@ TEST(GenericFormatterTests, TestFormatKnownObjectWithChronoDuration) {
   struct TestStruct {
     std::string a = "test_value";
     std::chrono::duration<double> b = 42min;
-    std::chrono::duration<double> c = 42ms;
+    std::chrono::milliseconds c = 42ms;
   };
   const TestStruct x{};
   const std::string formatted = toString(x);

--- a/modules/format/tests/generic_formatter_tests.cpp
+++ b/modules/format/tests/generic_formatter_tests.cpp
@@ -49,10 +49,26 @@ TEST(GenericFormatterTests, TestFormatKnownObjectWithRflTimestamp) {
   EXPECT_NE(formatted.find("test_value"), std::string::npos);
 }
 
-TEST(GenericFormatterTests, TestFormatKnownObjectWithChrono) {
+TEST(GenericFormatterTests, TestFormatKnownObjectWithChronoTimePoint) {
   struct TestStruct {
     std::string a = "test_value";
     std::chrono::time_point<std::chrono::system_clock> b = std::chrono::system_clock::now();
+  };
+  const TestStruct x{};
+  const std::string formatted = toString(x);
+  EXPECT_NE(formatted.find("test_value"), std::string::npos);
+
+  // Dummy test if general printers can be compiled
+  std::cout << "cout: " << x << "\n" << std::flush;
+  fmt::println("fmt: {}", x);
+}
+
+TEST(GenericFormatterTests, TestFormatKnownObjectWithChronoDuration) {
+  using namespace std::literals::chrono_literals;
+  struct TestStruct {
+    std::string a = "test_value";
+    std::chrono::duration<double> b = 42min;
+    std::chrono::duration<double> c = 42ms;
   };
   const TestStruct x{};
   const std::string formatted = toString(x);


### PR DESCRIPTION
# Description

support clock supported in heph::utils::format (i.e. chrono::system_clock and chrono::steady_clock) and std::chrono::duration
## Type of change
Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
