### PR TITLE
Feat/add test for stringstream

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 )
 
 bazel_dep(name = "rules_foreign_cc", version = "0.12.0")
-bazel_dep(name = "rules_cc", version = "0.1.0")
+bazel_dep(name = "rules_cc", version = "0.0.15")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "aspect_rules_lint", version = "1.0.3")
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")

--- a/modules/format/include/hephaestus/format/generic_formatter.h
+++ b/modules/format/include/hephaestus/format/generic_formatter.h
@@ -76,8 +76,10 @@ struct fmt::formatter<T> : fmt::formatter<std::string_view> {
   }
 };
 
+namespace std {
 template <typename T>
-  requires(!std::is_arithmetic_v<T> && !heph::StringLike<T>)
-auto operator<<(std::ostream& os, const T& data) -> std::ostream& {
+  requires(!is_arithmetic_v<T> && !heph::StringLike<T>)
+auto operator<<(ostream& os, const T& data) -> ostream& {
   return os << heph::format::toString(data);
 }
+}  // namespace std

--- a/modules/format/include/hephaestus/format/generic_formatter.h
+++ b/modules/format/include/hephaestus/format/generic_formatter.h
@@ -19,8 +19,7 @@
 #include "hephaestus/utils/format/format.h"
 
 namespace heph::format {
-
-// @brief Custom formatter for various data types using reflect-cpp
+/// @brief Custom formatter for various data types using reflect-cpp
 ///
 /// @tparam T The type of data to format.
 /// @param data The data to format.
@@ -29,7 +28,6 @@ template <typename T>
 auto toString(const T& data) -> std::string {
   return rfl::yaml::write(data);
 }
-
 }  // namespace heph::format
 
 namespace rfl {
@@ -56,6 +54,7 @@ struct Reflector<std::chrono::duration<Rep, Period>> {  // NOLINT(misc-include-c
   }
 };
 
+/// \brief Specialization of the Reflector for custom format that is defined as described by Formattable<T>.
 template <heph::Formattable T>
 struct Reflector<T> {  // NOLINT(misc-include-cleaner)
   using ReflType = std::string;
@@ -66,17 +65,21 @@ struct Reflector<T> {  // NOLINT(misc-include-cleaner)
 };
 }  // namespace rfl
 
+namespace fmt {
+/// \brief Generic fmt::formatter for all types that are not handled by fmt library.
 template <typename T>
-  requires(!std::is_arithmetic_v<T> && !heph::StringLike<T> && !fmt::detail::has_to_string_view<T>::value &&
+  requires(!std::is_arithmetic_v<T> && !heph::StringLike<T> && !detail::has_to_string_view<T>::value &&
            !heph::TimeType<T>)
-struct fmt::formatter<T> : fmt::formatter<std::string_view> {
+struct formatter<T> : formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const T& data, FormatContext& ctx) const {
     return fmt::format_to(ctx.out(), "{}", heph::format::toString(data));
   }
 };
+}  // namespace fmt
 
 namespace std {
+/// \brief Generic operator<< for all types that are not handled by the standard.
 template <typename T>
   requires(!is_arithmetic_v<T> && !heph::StringLike<T>)
 auto operator<<(ostream& os, const T& data) -> ostream& {

--- a/modules/format/tests/generic_formatter_tests.cpp
+++ b/modules/format/tests/generic_formatter_tests.cpp
@@ -3,6 +3,7 @@
 //=================================================================================================
 
 #include <chrono>
+#include <sstream>
 
 #include <fmt/base.h>
 #include <fmt/chrono.h>  // NOLINT(misc-include-cleaner)
@@ -73,6 +74,10 @@ TEST(GenericFormatterTests, TestFormatKnownObjectWithChronoDuration) {
   const TestStruct x{};
   const std::string formatted = toString(x);
   EXPECT_NE(formatted.find("test_value"), std::string::npos);
+
+  std::stringstream ss;
+  ss << x;
+  EXPECT_EQ(formatted, ss.str());
 
   // Dummy test if general printers can be compiled
   std::cout << "cout: " << x << "\n" << std::flush;


### PR DESCRIPTION
# Description

In order to be able to use the operator<< outside of the module it seems we need to add it to namespace std

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
