### PR TITLE
add SFINAE to avoid conflict with already existing operator<<

### DIFF
--- a/modules/format/BUILD
+++ b/modules/format/BUILD
@@ -33,5 +33,6 @@ heph_cc_test(
     deps = [
         ":format",
         "//modules/types",
+        "//modules/types_proto",
     ],
 )

--- a/modules/format/include/hephaestus/format/generic_formatter.h
+++ b/modules/format/include/hephaestus/format/generic_formatter.h
@@ -19,6 +19,7 @@
 #include "hephaestus/utils/format/format.h"
 
 namespace heph::format {
+
 /// @brief Custom formatter for various data types using reflect-cpp
 ///
 /// @tparam T The type of data to format.
@@ -79,8 +80,10 @@ struct formatter<T> : formatter<std::string_view> {
 }  // namespace fmt
 
 namespace std {
-/// \brief Generic operator<< for all types that are not handled by the standard.
-template <typename T>
+/// \brief Generic operator<< for all types that are not handled by the standard. Note that here we actually
+/// need SFINAE, since concept Streamable would fall in infinite recursion.
+// NOLINTNEXTLINE(modernize-use-constraints)
+template <typename T, typename = std::enable_if_t<!heph::has_stream_operator<T>::value>>
   requires(!is_arithmetic_v<T> && !heph::StringLike<T>)
 auto operator<<(ostream& os, const T& data) -> ostream& {
   return os << heph::format::toString(data);

--- a/modules/format/tests/generic_formatter_tests.cpp
+++ b/modules/format/tests/generic_formatter_tests.cpp
@@ -13,6 +13,8 @@
 
 #include "hephaestus/format/generic_formatter.h"
 #include "hephaestus/types/bounds.h"
+// This is part of the test, since if operator<< is defined this will not compile due to conflicts
+#include "hephaestus/types_proto/dummy_type.h"  // NOLINT(misc-include-cleaner)
 
 // NOLINTNEXTLINE(google-build-using-namespace)
 using namespace ::testing;

--- a/modules/utils/include/hephaestus/utils/concepts.h
+++ b/modules/utils/include/hephaestus/utils/concepts.h
@@ -10,11 +10,13 @@
 #include <ctime>
 #include <future>
 #include <optional>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <string_view>
 #include <type_traits>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace heph {

--- a/modules/utils/include/hephaestus/utils/concepts.h
+++ b/modules/utils/include/hephaestus/utils/concepts.h
@@ -63,6 +63,19 @@ concept IsIterableImpl = requires(T& t) {
 template <typename T>
 concept Iterable = internal::IsIterableImpl<T>;
 
+// We want a SFINAE variant of this in order to be able to use it in the generic operator<< without falling
+// into infinite recursion
+template <typename T, typename = void>
+struct has_stream_operator : std::false_type {};  // NOLINT(readability-identifier-naming)
+
+template <typename T>
+struct has_stream_operator<T, std::void_t<decltype(std::declval<std::ostream&>() << std::declval<T>())>>
+  : std::true_type {};
+
+// Concept based on the SFINAE detection
+template <typename T>
+concept Streamable = has_stream_operator<T>::value;
+
 template <typename T>
 concept NonBooleanIntegralType = std::integral<T> && !BooleanType<T>;
 


### PR DESCRIPTION
# Description

Using concepts, we dump into an infinite loop when checking for streamable in the generic operator<<.
We can get around it with SFINAE, since the compiler will not even see that part of the code if operator<< is already defined.

Hence we should not have conflict with porotbuf, thread::id ,... anymore.
## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

