### PR TITLE
[IPC] Service: add post reply callback

### DIFF
--- a/modules/ipc/include/hephaestus/ipc/zenoh/action_server/action_server.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/action_server/action_server.h
@@ -13,7 +13,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <thread>
 #include <utility>
 
 #include <fmt/format.h>

--- a/modules/ipc/include/hephaestus/ipc/zenoh/action_server/action_server.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/action_server/action_server.h
@@ -261,19 +261,6 @@ auto callActionServer(SessionPtr session, const TopicConfig& topic_config, const
                                                                                 std::move(status_update_cb) };
 
         auto response = client_helper.getResponse().get();
-
-        // TODO(@fbrizzi): fix this properly
-        // This is a temporary fix to avoid the client to return before the server has finished.
-        // If we return immediately what can happen is that we destroy the `response_service_` Service inside
-        // ClientHelper, before it has finished sending the response to the caller (the ActionServer).
-        // This causes Zenoh to panic and the process to segfault.
-        // Ideally, we could have a way for the server to tell us when is idle, but not sure if this is
-        // available.
-        // Also, 100milliseconds it a completely arbitrary value, we will need to increase it if we still have
-        // issues.
-        // static constexpr auto WAIT_TIME = std::chrono::milliseconds{ 100 };
-        // std::this_thread::sleep_for(WAIT_TIME);
-
         return response;
       });
 }

--- a/modules/ipc/include/hephaestus/ipc/zenoh/action_server/action_server.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/action_server/action_server.h
@@ -271,8 +271,8 @@ auto callActionServer(SessionPtr session, const TopicConfig& topic_config, const
         // available.
         // Also, 100milliseconds it a completely arbitrary value, we will need to increase it if we still have
         // issues.
-        static constexpr auto WAIT_TIME = std::chrono::milliseconds{ 100 };
-        std::this_thread::sleep_for(WAIT_TIME);
+        // static constexpr auto WAIT_TIME = std::chrono::milliseconds{ 100 };
+        // std::this_thread::sleep_for(WAIT_TIME);
 
         return response;
       });

--- a/modules/ipc/include/hephaestus/ipc/zenoh/action_server/client_helper.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/action_server/client_helper.h
@@ -87,7 +87,6 @@ auto ClientHelper<RequestT, StatusT, ReplyT>::getResponse() -> std::future<Respo
 template <typename RequestT, typename StatusT, typename ReplyT>
 auto ClientHelper<RequestT, StatusT, ReplyT>::serviceCallback(const Response<ReplyT>& reply)
     -> RequestResponse {
-  // reply_promise_.set_value(reply);
   reply_ = reply;
   return { .status = RequestStatus::SUCCESSFUL };
 }

--- a/modules/ipc/include/hephaestus/ipc/zenoh/action_server/client_helper.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/action_server/client_helper.h
@@ -49,6 +49,7 @@ public:
 private:
   [[nodiscard]] auto serviceCallback(const Response<ReplyT>& reply) -> RequestResponse;
   void onFailure();
+  void postReplyServiceCallback();
 
 private:
   SessionPtr session_;
@@ -57,6 +58,7 @@ private:
   std::unique_ptr<Subscriber<StatusT>> status_subscriber_;
   std::unique_ptr<Service<Response<ReplyT>, RequestResponse>> response_service_;
 
+  Response<ReplyT> reply_;
   std::promise<Response<ReplyT>> reply_promise_;
 };
 
@@ -73,8 +75,8 @@ ClientHelper<RequestT, StatusT, ReplyT>::ClientHelper(SessionPtr session, TopicC
         }))
   , response_service_(std::make_unique<Service<Response<ReplyT>, RequestResponse>>(
         session_, internal::getResponseServiceTopic(topic_config_),
-        [this](const Response<ReplyT>& reply) { return serviceCallback(reply); },
-        [this]() { onFailure(); })) {
+        [this](const Response<ReplyT>& reply) { return serviceCallback(reply); }, [this]() { onFailure(); },
+        [this]() { postReplyServiceCallback(); })) {
 }
 
 template <typename RequestT, typename StatusT, typename ReplyT>
@@ -85,13 +87,19 @@ auto ClientHelper<RequestT, StatusT, ReplyT>::getResponse() -> std::future<Respo
 template <typename RequestT, typename StatusT, typename ReplyT>
 auto ClientHelper<RequestT, StatusT, ReplyT>::serviceCallback(const Response<ReplyT>& reply)
     -> RequestResponse {
-  reply_promise_.set_value(reply);
+  // reply_promise_.set_value(reply);
+  reply_ = reply;
   return { .status = RequestStatus::SUCCESSFUL };
 }
 
 template <typename RequestT, typename StatusT, typename ReplyT>
 void ClientHelper<RequestT, StatusT, ReplyT>::onFailure() {
   reply_promise_.set_value({ .value = {}, .status = RequestStatus::INVALID });
+}
+
+template <typename RequestT, typename StatusT, typename ReplyT>
+void ClientHelper<RequestT, StatusT, ReplyT>::postReplyServiceCallback() {
+  reply_promise_.set_value(std::move(reply_));
 }
 
 }  // namespace heph::ipc::zenoh::action_server::internal

--- a/modules/ipc/include/hephaestus/ipc/zenoh/service.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/service.h
@@ -45,6 +45,11 @@ public:
   using Callback = std::function<ReplyT(const RequestT&)>;
   using FailureCallback = std::function<void()>;
   using PostReplyCallback = std::function<void()>;
+  /// Create a new service that listen for request on `topic_config`.
+  /// - The `callback` will be called with the request and should return the reply.
+  /// - The `failure_callback` will be called if the service fails to process the request.
+  /// - The `post_reply_callback` will be called after the reply has been sent.
+  ///   - This can be used to perform cleanup operations.
   Service(
       SessionPtr session, TopicConfig topic_config, Callback&& callback,
       FailureCallback&& failure_callback = []() {}, PostReplyCallback&& post_reply_callback = []() {});


### PR DESCRIPTION
# Description
In the `Service`, add the option to specify a callback to be called after the reply has been sent back.

One use case is the caller to an `ActionServer` that uses it to be notified when the process has terminated and can destroy the temporary Service used to receive the response back from the Server.
