### PR TITLE
docs> reflect-cpp does not work for structs with private members

### DIFF
--- a/modules/format/include/hephaestus/format/generic_formatter.h
+++ b/modules/format/include/hephaestus/format/generic_formatter.h
@@ -35,6 +35,7 @@ namespace rfl {
 /// \brief Specialization of the Reflector for chrono based Timestamp type. See
 /// https://github.com/getml/reflect-cpp/blob/main/docs/custom_parser.md
 /// For implementation of Reflector::to see commit b1a4eda
+/// Limitation: Reflect-cpp does not work on any type that has private members.
 template <typename Clock>
   requires(heph::ChronoSteadyClockType<Clock> || heph::ChronoSystemClockType<Clock>)
 struct Reflector<std::chrono::time_point<Clock>> {  // NOLINT(misc-include-cleaner)

--- a/modules/format/tests/generic_formatter_tests.cpp
+++ b/modules/format/tests/generic_formatter_tests.cpp
@@ -115,4 +115,23 @@ TEST(GenericFormatterTests, TestFormatStructWithBounds) {
   std::cout << "cout: " << x << "\n" << std::flush;
 }
 
+TEST(GenericFormatterTests, TestFormatStructArray) {
+  class TestStruct {
+  public:
+    std::array<int, 2> a_{ 1, 2 };
+    // Reflect-cpp will not work if the class as private or protected members, methods do not have an effect
+  public:
+    [[maybe_unused]] int b_ = 3;
+  };
+  const TestStruct x{};
+  const std::string formatted = toString(x);
+
+  EXPECT_NE(formatted.find("1"), std::string::npos);
+  EXPECT_NE(formatted.find("2"), std::string::npos);
+
+  // Dummy test if the custom formatters can be compiled
+  fmt::println("test: {}", x);
+  std::cout << "cout: " << x << "\n" << std::flush;
+}
+
 }  // namespace heph::format::tests


### PR DESCRIPTION
# Description

Apparently relfect/cpp does not serialize if struct/class has private attributes.
Document that.

## Type of change
- Docs