### PR TITLE
Fix/make generic formatter concepts cleaner

### DIFF
--- a/modules/format/include/hephaestus/format/generic_formatter.h
+++ b/modules/format/include/hephaestus/format/generic_formatter.h
@@ -28,7 +28,7 @@ concept IsReflectable = std::is_aggregate_v<T> || rfl::internal::has_write_refle
 /// @tparam T The type of data to format.
 /// @param data The data to format.
 /// @return A formatted string representation of the data.
-template <IsReflectable T>
+template <typename T>
 auto toString(const T& data) -> std::string {
   return rfl::yaml::write(data);
 }

--- a/modules/format/include/hephaestus/format/generic_formatter.h
+++ b/modules/format/include/hephaestus/format/generic_formatter.h
@@ -35,6 +35,7 @@ namespace rfl {
 /// \brief Specialization of the Reflector for chrono based Timestamp type. See
 /// https://github.com/getml/reflect-cpp/blob/main/docs/custom_parser.md
 /// For implementation of Reflector::to see commit b1a4eda
+/// Limitation: Reflect-cpp does not work on any type that has private members.
 template <typename Clock>
   requires(heph::ChronoSteadyClockType<Clock> || heph::ChronoSystemClockType<Clock>)
 struct Reflector<std::chrono::time_point<Clock>> {  // NOLINT(misc-include-cleaner)

--- a/modules/format/include/hephaestus/format/generic_formatter.h
+++ b/modules/format/include/hephaestus/format/generic_formatter.h
@@ -20,12 +20,15 @@
 
 namespace heph::format {
 
+template <typename T>
+concept IsReflectable = std::is_aggregate_v<T> || rfl::internal::has_write_reflector<T>;
+
 /// @brief Custom formatter for various data types using reflect-cpp
 ///
 /// @tparam T The type of data to format.
 /// @param data The data to format.
 /// @return A formatted string representation of the data.
-template <typename T>
+template <IsReflectable T>
 auto toString(const T& data) -> std::string {
   return rfl::yaml::write(data);
 }
@@ -35,7 +38,6 @@ namespace rfl {
 /// \brief Specialization of the Reflector for chrono based Timestamp type. See
 /// https://github.com/getml/reflect-cpp/blob/main/docs/custom_parser.md
 /// For implementation of Reflector::to see commit b1a4eda
-/// Limitation: Reflect-cpp does not work on any type that has private members.
 template <typename Clock>
   requires(heph::ChronoSteadyClockType<Clock> || heph::ChronoSystemClockType<Clock>)
 struct Reflector<std::chrono::time_point<Clock>> {  // NOLINT(misc-include-cleaner)
@@ -72,7 +74,7 @@ namespace fmt {
 ///        Note that we need to have the typename Char here in order to have the formatters in fmt/std.h be
 ///        more specific than this one, to avoid collisions.
 template <typename T, typename Char>
-  requires(!std::is_arithmetic_v<T> && !heph::StringLike<T> && !detail::has_to_string_view<T>::value)
+  requires(heph::format::IsReflectable<T> && !heph::StringLike<T> && !detail::has_to_string_view<T>::value)
 struct formatter<T, Char> : formatter<std::string_view, Char> {
   template <typename FormatContext>
   auto format(const T& data, FormatContext& ctx) const {
@@ -82,11 +84,9 @@ struct formatter<T, Char> : formatter<std::string_view, Char> {
 }  // namespace fmt
 
 namespace std {
-/// \brief Generic operator<< for all types that are not handled by the standard. Note that here we actually
-/// need SFINAE, since concept Streamable would fall in infinite recursion.
-// NOLINTNEXTLINE(modernize-use-constraints)
-template <typename T, typename = std::enable_if_t<!heph::has_stream_operator<T>::value>>
-  requires(!is_arithmetic_v<T> && !heph::StringLike<T>)
+/// \brief Generic operator<< for all types that are not handled by the standard.
+template <typename T>
+  requires(heph::format::IsReflectable<T> && !heph::StringLike<T>)
 auto operator<<(ostream& os, const T& data) -> ostream& {
   return os << heph::format::toString(data);
 }

--- a/modules/format/include/hephaestus/format/generic_formatter.h
+++ b/modules/format/include/hephaestus/format/generic_formatter.h
@@ -12,7 +12,8 @@
 #include <fmt/base.h>
 #include <fmt/chrono.h>  // NOLINT(misc-include-cleaner)
 #include <fmt/format.h>
-#include <rfl.hpp>       // NOLINT(misc-include-cleaner)
+#include <rfl.hpp>  // NOLINT(misc-include-cleaner)
+#include <rfl/internal/has_reflector.hpp>
 #include <rfl/yaml.hpp>  // NOLINT(misc-include-cleaner)
 
 #include "hephaestus/utils/concepts.h"

--- a/modules/format/tests/generic_formatter_tests.cpp
+++ b/modules/format/tests/generic_formatter_tests.cpp
@@ -115,4 +115,23 @@ TEST(GenericFormatterTests, TestFormatStructWithBounds) {
   std::cout << "cout: " << x << "\n" << std::flush;
 }
 
+TEST(GenericFormatterTests, TestFormatStructArray) {
+  class TestStruct {
+  public:
+    std::array<int, 2> a_{ 1, 2 };
+    // Reflect-cpp will not work if the class as private or protected members, methods do not have an effect
+  public:
+    [[maybe_unused]] int b_ = 3;
+  };
+  const TestStruct x{};
+  const std::string formatted = toString(x);
+
+  EXPECT_NE(formatted.find("1"), std::string::npos);
+  EXPECT_NE(formatted.find("2"), std::string::npos);
+
+  // Dummy test if the custom formatters can be compiled
+  fmt::println("test: {}", x);
+  std::cout << "cout: " << x << "\n" << std::flush;
+}
+
 }  // namespace heph::format::tests

--- a/modules/format/tests/generic_formatter_tests.cpp
+++ b/modules/format/tests/generic_formatter_tests.cpp
@@ -117,10 +117,11 @@ TEST(GenericFormatterTests, TestFormatStructWithBounds) {
 
 TEST(GenericFormatterTests, TestFormatStructArray) {
   class TestStruct {
+    // Reflect-cpp will only work on aggregate types (so no private members, no custom constructor)
   public:
+    // TestStruct() = default;
     std::array<int, 2> a_{ 1, 2 };
-    // Reflect-cpp will not work if the class as private or protected members, methods do not have an effect
-  public:
+    // private:
     [[maybe_unused]] int b_ = 3;
   };
   const TestStruct x{};


### PR DESCRIPTION
# Description

Fix the concepts in generic_formatter to solve issues with gtest operator<< and make them more general.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
