### PR TITLE
Added a heph::Overloads struct to be used with std::visit

### DIFF
--- a/modules/utils/BUILD
+++ b/modules/utils/BUILD
@@ -80,3 +80,9 @@ heph_cc_test(
     srcs = ["tests/stop_watch_tests.cpp"],
     deps = [":utils"],
 )
+
+heph_cc_test(
+    name = "variant_tests",
+    srcs = ["tests/variant_tests.cpp"],
+    deps = [":utils"],
+)

--- a/modules/utils/include/hephaestus/utils/variant.h
+++ b/modules/utils/include/hephaestus/utils/variant.h
@@ -8,7 +8,7 @@ namespace heph {
 
 /// A helper struct which allows you to easily branch on the type of alternative held by a variant:
 ///
-///  std::visit( heph::Overloads {
+///  std::visit(heph::Overloads {
 ///    [](const &FirstAlternative& value) {
 ///      // Code to be run if variant holds a value of type FirstAlternative.
 ///    },

--- a/modules/utils/include/hephaestus/utils/variant.h
+++ b/modules/utils/include/hephaestus/utils/variant.h
@@ -1,0 +1,25 @@
+//=================================================================================================
+// Copyright (C) 2025 HEPHAESTUS Contributors
+//=================================================================================================
+
+#pragma once
+
+namespace heph {
+
+/// A helper struct which allows you to easily branch on the type of alternative held by a variant:
+///
+///  std::visit( heph::Overloads {
+///    [](const &FirstAlternative& value) {
+///      // Code to be run if variant holds a value of type FirstAlternative.
+///    },
+///    [](const &SecondAlternative& value) {
+///      // Code to be run if variant holds a value of type SecondAlternative.
+///    },
+///  }, variant);
+///
+template <class... Ts>
+struct Overloads : Ts... {
+  using Ts::operator()...;
+};
+
+}  // namespace heph

--- a/modules/utils/tests/CMakeLists.txt
+++ b/modules/utils/tests/CMakeLists.txt
@@ -57,3 +57,10 @@ define_module_test(
   PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   PUBLIC_LINK_LIBS ""
 )
+
+define_module_test(
+  NAME variant_tests
+  SOURCES variant_tests.cpp
+  PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  PUBLIC_LINK_LIBS ""
+)

--- a/modules/utils/tests/variant_tests.cpp
+++ b/modules/utils/tests/variant_tests.cpp
@@ -1,0 +1,31 @@
+//=================================================================================================
+// Copyright (C) 2025 HEPHAESTUS Contributors
+//=================================================================================================
+#include <exception>
+#include <variant>
+
+#include <fmt/format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "hephaestus/utils/variant.h"
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace ::testing;
+
+namespace heph::tests {
+TEST(Variant, VariantOverloads) {
+  using Variant = std::variant<std::string, int, float>;
+
+  auto overloads = Overloads{
+    [](const std::string& value) { return fmt::format("Holds string \"{}\"", value); },
+    [](const int value) { return fmt::format("Holds int {}", value); },
+    [](const float value) { return fmt::format("Holds float {}", value); },
+  };
+
+  EXPECT_EQ(std::visit(overloads, Variant("foo")), "Holds string \"foo\"");
+  EXPECT_EQ(std::visit(overloads, Variant(2)), "Holds int 2");
+  EXPECT_EQ(std::visit(overloads, Variant(3.0f)), "Holds float 3");
+}
+
+}  // namespace heph::tests


### PR DESCRIPTION
This change allows you to handle the various alternatives like this:

```
std::visit(heph::Overloads {
    [](const FirstAlternative& val) {
    },
    [](const SecondAlternative& val) {
    },
  },
  val);
```

# Description


## Type of change
Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
