### PR TITLE
Push fork changes to upstream

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -127,7 +127,7 @@ add_cmake_dependency(
 
 # --------------------------------------------------------------------------------------------------
 # magic_enum
-set(MAGIC_ENUM_VERSION 0.9.5)
+set(MAGIC_ENUM_VERSION 0.9.6)
 set(MAGIC_ENUM_TAG v${MAGIC_ENUM_VERSION})
 set(MAGIC_ENUM_CMAKE_ARGS -DMAGIC_ENUM_OPT_BUILD_EXAMPLES=OFF -DMAGIC_ENUM_OPT_BUILD_TESTS=OFF
                           -DMAGIC_ENUM_OPT_INSTALL=ON

--- a/modules/bag/include/hephaestus/bag/writer.h
+++ b/modules/bag/include/hephaestus/bag/writer.h
@@ -10,6 +10,8 @@
 #include <span>
 #include <string>
 
+#include <mcap/writer.hpp>
+
 #include "hephaestus/ipc/zenoh/raw_subscriber.h"
 #include "hephaestus/serdes/type_info.h"
 
@@ -26,6 +28,7 @@ public:
 
 struct McapWriterParams {
   std::filesystem::path output_file;
+  mcap::McapWriterOptions mcap_writer_options = mcap::McapWriterOptions("");
 };
 
 [[nodiscard]] auto createMcapWriter(McapWriterParams params) -> std::unique_ptr<IBagWriter>;

--- a/modules/bag/src/writer.cpp
+++ b/modules/bag/src/writer.cpp
@@ -12,7 +12,9 @@
 #include <unordered_map>
 #include <utility>
 
+#include <absl/log/log.h>
 #include <absl/strings/ascii.h>
+#include <fmt/core.h>
 #include <fmt/format.h>
 #include <magic_enum.hpp>
 #include <mcap/types.hpp>
@@ -34,6 +36,7 @@ namespace {
 class McapWriter final : public IBagWriter {
 public:
   explicit McapWriter(McapWriterParams params);
+
   ~McapWriter() override = default;
 
   void writeRecord(const ipc::zenoh::MessageMetadata& metadata, std::span<const std::byte> data) override;
@@ -50,7 +53,7 @@ private:
 };
 
 McapWriter::McapWriter(McapWriterParams params) : params_(std::move(params)) {
-  auto options = mcap::McapWriterOptions("");
+  auto options = params_.mcap_writer_options;
   const auto status = writer_.open(params_.output_file.string(), options);
   throwExceptionIf<InvalidParameterException>(
       !status.ok(), fmt::format("failed to create Mcap writer for file {}, with error: {}",

--- a/modules/examples/examples/mcap_writer.cpp
+++ b/modules/examples/examples/mcap_writer.cpp
@@ -7,7 +7,6 @@
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
-#include <utility>
 
 #include <fmt/base.h>
 
@@ -25,9 +24,9 @@ auto main(int argc, const char* argv[]) -> int {
                    argv[0]);  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       std::exit(1);
     }
-    std::filesystem::path output{ argv[1] };  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    const std::filesystem::path output{ argv[1] };  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 
-    auto bag_writer = heph::bag::createMcapWriter({ std::move(output) });
+    auto bag_writer = heph::bag::createMcapWriter({ .output_file = output });
 
     auto type_info = heph::serdes::getSerializedTypeInfo<heph::examples::types::Pose>();
     bag_writer->registerSchema(type_info);

--- a/modules/format/tests/CMakeLists.txt
+++ b/modules/format/tests/CMakeLists.txt
@@ -5,5 +5,5 @@
 define_module_test(
   NAME generic_formatter_tests
   SOURCES generic_formatter_tests.cpp
-  PUBLIC_LINK_LIBS types
+  PUBLIC_LINK_LIBS hephaestus::types hephaestus::types_proto
 )

--- a/modules/ipc/include/hephaestus/ipc/zenoh/publisher.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/publisher.h
@@ -13,8 +13,13 @@
 
 namespace heph::ipc::zenoh {
 
+class PublisherBase {
+public:
+  virtual ~PublisherBase() = default;
+};
+
 template <class T>
-class Publisher {
+class Publisher : public PublisherBase {
 public:
   Publisher(SessionPtr session, TopicConfig topic_config, RawPublisher::MatchCallback&& match_cb = nullptr)
     : publisher_(std::move(session), std::move(topic_config), serdes::getSerializedTypeInfo<T>(),

--- a/modules/ipc/include/hephaestus/ipc/zenoh/service.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/service.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <zenoh.h>
 #include <zenoh/api/base.hxx>
 #include <zenoh/api/channels.hxx>
@@ -39,8 +40,12 @@
 
 namespace heph::ipc::zenoh {
 
+class ServiceBase {
+public:
+  virtual ~ServiceBase() = default;
+};
 template <typename RequestT, typename ReplyT>
-class Service {
+class Service : public ServiceBase {
 public:
   using Callback = std::function<ReplyT(const RequestT&)>;
   using FailureCallback = std::function<void()>;

--- a/modules/ipc/include/hephaestus/ipc/zenoh/service.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/service.h
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include <fmt/ranges.h>
 #include <zenoh.h>
 #include <zenoh/api/base.hxx>
 #include <zenoh/api/channels.hxx>

--- a/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
@@ -22,8 +22,13 @@
 
 namespace heph::ipc::zenoh {
 
+class SubscriberBase {
+public:
+  virtual ~SubscriberBase() = default;
+};
+
 template <typename T>
-class Subscriber {
+class Subscriber : public SubscriberBase {
 public:
   using DataCallback = std::function<void(const MessageMetadata&, const std::shared_ptr<T>&)>;
   Subscriber(zenoh::SessionPtr session, TopicConfig topic_config, DataCallback&& callback,

--- a/modules/serdes/include/hephaestus/serdes/protobuf/concepts.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/concepts.h
@@ -9,7 +9,7 @@
 namespace heph::serdes::protobuf {
 
 template <class T>
-struct ProtoAssociation {};
+struct ProtoAssociation;
 
 template <typename T>
 concept ProtobufMessage = requires(T proto, void* out_data, const void* in_data, int size) {

--- a/modules/serdes/include/hephaestus/serdes/protobuf/protobuf.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/protobuf.h
@@ -10,7 +10,6 @@
 #include <string_view>
 #include <vector>
 
-#include <google/protobuf/json/json.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/json_util.h>
 

--- a/modules/serdes/include/hephaestus/serdes/protobuf/protobuf.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/protobuf.h
@@ -10,6 +10,7 @@
 #include <string_view>
 #include <vector>
 
+#include <google/protobuf/json/json.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/json_util.h>
 

--- a/modules/utils/include/hephaestus/utils/exception.h
+++ b/modules/utils/include/hephaestus/utils/exception.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <type_traits>
 
+#include <absl/log/check.h>
+
 #ifdef DISABLE_EXCEPTIONS
 #include <absl/log/absl_check.h>
 #include <fmt/format.h>

--- a/modules/utils/include/hephaestus/utils/exception.h
+++ b/modules/utils/include/hephaestus/utils/exception.h
@@ -10,9 +10,8 @@
 #include <string>
 #include <type_traits>
 
-#include <absl/log/check.h>
-
 #ifdef DISABLE_EXCEPTIONS
+#include <absl/log/check.h>
 #include <fmt/format.h>
 #endif
 

--- a/modules/utils/include/hephaestus/utils/exception.h
+++ b/modules/utils/include/hephaestus/utils/exception.h
@@ -44,7 +44,7 @@ constexpr void throwException(const std::string& message,
 #else
   auto e = T{ message, location };
   CHECK(false) << fmt::format("[ERROR {}] {} at {}:{}", e.what(), message, location.file_name(),
-                                   location.line());
+                              location.line());
 #endif
 }
 
@@ -65,7 +65,7 @@ constexpr void throwExceptionIf(bool condition, const std::string& message,
 #else
   auto e = T{ message, location };
   CHECK(!condition) << fmt::format("[ERROR {}] {} at {}:{}", e.what(), message, location.file_name(),
-                                        location.line());
+                                   location.line());
 #endif
 }
 

--- a/modules/utils/include/hephaestus/utils/exception.h
+++ b/modules/utils/include/hephaestus/utils/exception.h
@@ -13,7 +13,6 @@
 #include <absl/log/check.h>
 
 #ifdef DISABLE_EXCEPTIONS
-#include <absl/log/absl_check.h>
 #include <fmt/format.h>
 #endif
 
@@ -44,7 +43,7 @@ constexpr void throwException(const std::string& message,
   throw T{ message, location };
 #else
   auto e = T{ message, location };
-  ABSL_CHECK(false) << fmt::format("[ERROR {}] {} at {}:{}", e.what(), message, location.file_name(),
+  CHECK(false) << fmt::format("[ERROR {}] {} at {}:{}", e.what(), message, location.file_name(),
                                    location.line());
 #endif
 }
@@ -65,7 +64,7 @@ constexpr void throwExceptionIf(bool condition, const std::string& message,
   }
 #else
   auto e = T{ message, location };
-  ABSL_CHECK(!condition) << fmt::format("[ERROR {}] {} at {}:{}", e.what(), message, location.file_name(),
+  CHECK(!condition) << fmt::format("[ERROR {}] {} at {}:{}", e.what(), message, location.file_name(),
                                         location.line());
 #endif
 }

--- a/modules/utils/include/hephaestus/utils/format/format.h
+++ b/modules/utils/include/hephaestus/utils/format/format.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
-#include <ranges>
 #include <sstream>
 #include <string>
 #include <string_view>

--- a/modules/utils/include/hephaestus/utils/format/format.h
+++ b/modules/utils/include/hephaestus/utils/format/format.h
@@ -14,7 +14,6 @@
 #include <fmt/chrono.h>  // NOLINT(misc-include-cleaner)
 #include <fmt/format.h>
 #include <magic_enum.hpp>
-#include <range/v3/view/zip.hpp>
 
 #include "hephaestus/utils/concepts.h"
 
@@ -30,11 +29,10 @@ template <ArrayOrVectorType T>
 [[nodiscard]] inline auto toString(const T& vec) -> std::string {
   std::stringstream ss;
 
-  const auto indices = std::views::iota(0);
-  const auto indexed_vec = ranges::views::zip(indices, vec);
-
-  for (const auto& [index, value] : indexed_vec) {
-    const std::string str = fmt::format("  Index: {}, Value: {}\n", index, value);
+  std::size_t idx = 0;
+  for (const auto& value : vec) {
+    const std::string str = fmt::format("  Index: {}, Value: {}\n", idx, value);
+    ++idx;
     ss << str;
   }
 


### PR DESCRIPTION
# Description

We did a bit of a cleanup of the voliro specific changes to reduce the differences to upstream.
Here are some things I thought might make sense to push upstream.

It is mainly:
 - adding options to the mcap writer
 - updating cmake-build magic enum version
 - undo an unnecessary change I pushed earlier
 -  some minor clang related compilation things
 - fix cmake --preset gcc -> ninja check
 - clang-tidy 

## Type of change
- Bug fix (non-breaking change which fixes an issue)