### PR TITLE
[Fix] StopWatch: remove clock template

### DIFF
--- a/modules/ipc/src/zenoh/liveliness.cpp
+++ b/modules/ipc/src/zenoh/liveliness.cpp
@@ -104,7 +104,6 @@ auto parseLivelinessToken(std::string_view keyexpr, ::zenoh::SampleKind kind) ->
   static constexpr auto TYPE_IDX = 2;
   // Expected keyexpr: <topic/name/whatever>/<session_id>/<actor_type>
   const std::vector<std::string> items = absl::StrSplit(keyexpr, '|');
-  fmt::println("items:\n - {}", fmt::join(items, "\n - "));
   if (items.size() != 3) {
     heph::log(heph::ERROR, "invalid liveliness keyexpr, too few items", "keyexpr", keyexpr, "items_count",
               items.size());

--- a/modules/utils/include/hephaestus/utils/timing/mock_clock.h
+++ b/modules/utils/include/hephaestus/utils/timing/mock_clock.h
@@ -13,7 +13,7 @@ public:
   using duration = std::chrono::steady_clock::duration;
   using rep = std::chrono::steady_clock::rep;
   using period = std::chrono::steady_clock::period;
-  using time_point = std::chrono::time_point<MockClock>;
+  using time_point = std::chrono::time_point<std::chrono::steady_clock>;
 
   ~MockClock() = default;
   MockClock(const MockClock&) = delete;

--- a/modules/utils/src/timing/stop_watch.cpp
+++ b/modules/utils/src/timing/stop_watch.cpp
@@ -5,3 +5,80 @@
 //=================================================================================================
 
 #include "hephaestus/utils/timing/stop_watch.h"
+
+namespace heph::utils::timing {
+
+StopWatch::StopWatch(NowFunctionPtr now_fn) : now_fn_(now_fn) {
+  reset();
+}
+
+void StopWatch::start() {
+  if (lap_start_timestamp_.has_value()) {
+    return;
+  }
+
+  lap_start_timestamp_ = now_fn_();
+  if (!initial_start_timestamp_.has_value()) {
+    initial_start_timestamp_ = lap_start_timestamp_.value();
+  }
+}
+
+void StopWatch::reset() {
+  lap_start_timestamp_ = std::nullopt;
+  initial_start_timestamp_ = std::nullopt;
+  lapse_timestamp_ = std::nullopt;
+  accumulated_time_ = {};
+  lap_counter_ = 0;
+}
+
+auto StopWatch::accumulatedLapsDuration() const -> ClockT::duration {
+  return (lap_start_timestamp_.has_value() ?
+              (accumulated_time_ + (now_fn_() - lap_start_timestamp_.value())) :
+              accumulated_time_);
+}
+
+auto StopWatch::initialStartTimestamp() const -> std::optional<typename ClockT::time_point> {
+  return initial_start_timestamp_;
+}
+
+auto StopWatch::lapsCount() const -> std::size_t {
+  return lap_counter_;
+}
+
+auto StopWatch::lapseImpl() -> ClockT::duration {
+  if (!lap_start_timestamp_.has_value()) {
+    return {};
+  }
+
+  auto lapse_start_timestamp =
+      lapse_timestamp_.has_value() ? lapse_timestamp_.value() : lap_start_timestamp_.value();
+
+  lapse_timestamp_ = now_fn_();
+
+  return lapse_timestamp_.value() - lapse_start_timestamp;
+}
+
+auto StopWatch::stopImpl() -> ClockT::duration {
+  if (!lap_start_timestamp_.has_value()) {
+    return {};
+  }
+
+  auto stop_timestamp = now_fn_();
+  const auto lap_time = stop_timestamp - lap_start_timestamp_.value();
+
+  lap_start_timestamp_ = std::nullopt;
+  lapse_timestamp_ = std::nullopt;
+  accumulated_time_ += lap_time;
+  ++lap_counter_;
+
+  return lap_time;
+}
+
+auto StopWatch::elapsedImpl() -> ClockT::duration {
+  if (!lap_start_timestamp_.has_value()) {
+    return {};
+  }
+
+  return now_fn_() - lap_start_timestamp_.value();
+}
+}  // namespace heph::utils::timing

--- a/modules/utils/src/timing/stop_watch.cpp
+++ b/modules/utils/src/timing/stop_watch.cpp
@@ -6,6 +6,10 @@
 
 #include "hephaestus/utils/timing/stop_watch.h"
 
+#include <chrono>
+#include <cstddef>
+#include <optional>
+
 namespace heph::utils::timing {
 
 StopWatch::StopWatch(NowFunctionPtr now_fn) : now_fn_(now_fn) {

--- a/modules/utils/tests/stop_watch_tests.cpp
+++ b/modules/utils/tests/stop_watch_tests.cpp
@@ -15,7 +15,7 @@ TEST(StopWatch, AccumulateTime) {
   using namespace std::chrono_literals;
   constexpr auto PERIOD = 100ms;
 
-  StopWatch<MockClock> swatch;
+  StopWatch swatch{ MockClock::now };
   swatch.start();
   const auto t1 = swatch.accumulatedLapsDuration();
   EXPECT_EQ(t1.count(), 0);
@@ -28,7 +28,7 @@ TEST(StopWatch, Stoppable) {
   using namespace std::chrono_literals;
   static constexpr auto PERIOD = 10ms;
 
-  StopWatch<MockClock> swatch;
+  StopWatch swatch{ MockClock::now };
   swatch.start();
 
   MockClock::advance(PERIOD);
@@ -48,7 +48,7 @@ TEST(StopWatch, ResumeCounting) {
   using namespace std::chrono_literals;
   constexpr auto PERIOD = 10ms;
 
-  StopWatch<MockClock> swatch;
+  StopWatch swatch{ MockClock::now };
 
   // start and let it run for period
   swatch.start();
@@ -74,7 +74,7 @@ TEST(StopWatch, Reset) {
   using namespace std::chrono_literals;
   constexpr auto PERIOD = 10ms;
 
-  StopWatch<MockClock> swatch;
+  StopWatch swatch{ MockClock::now };
   swatch.start();
   MockClock::advance(PERIOD);
   std::ignore = swatch.stop();
@@ -90,7 +90,7 @@ TEST(StopWatch, Lapse) {
   using namespace std::chrono_literals;
   constexpr auto PERIOD = 10ms;
 
-  StopWatch<MockClock> swatch;
+  StopWatch swatch{ MockClock::now };
   swatch.start();
   MockClock::advance(PERIOD);
   const auto l1 = swatch.lapse();
@@ -107,7 +107,7 @@ TEST(StopWatch, Lapse) {
 TEST(StopWatch, DurationCast) {
   using namespace std::chrono_literals;
   using DurationT = std::chrono::duration<double>;
-  StopWatch<MockClock> swatch;
+  StopWatch swatch{ MockClock::now };
   swatch.start();
   auto elapsed = swatch.lapse<DurationT>();
   static_assert(std::is_same_v<decltype(elapsed), DurationT>);


### PR DESCRIPTION
# Description
Pass the clock as an input to the constructor to avoid the templated class
