### PR TITLE
Fix/action server hangs

### DIFF
--- a/modules/ipc/include/hephaestus/ipc/zenoh/action_server/client_helper.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/action_server/client_helper.h
@@ -56,11 +56,14 @@ private:
   SessionPtr session_;
   TopicConfig topic_config_;
 
-  std::unique_ptr<Subscriber<StatusT>> status_subscriber_;
-  std::unique_ptr<Service<Response<ReplyT>, RequestResponse>> response_service_;
-
+  // The reply and reply promise need to initialized before the response service
+  // otherwise, a data race between initialization and the response callbacks might
+  // occur
   Response<ReplyT> reply_;
   std::promise<Response<ReplyT>> reply_promise_;
+
+  std::unique_ptr<Subscriber<StatusT>> status_subscriber_;
+  std::unique_ptr<Service<Response<ReplyT>, RequestResponse>> response_service_;
 };
 
 template <typename RequestT, typename StatusT, typename ReplyT>


### PR DESCRIPTION
# Description

- fix: action server test stabilization

     - Removing `std::future::wait_for`: The tests checking if a future
       is ready after a specific time are flakey since `std::future::wait_for`
       might be woken up spuriously
     - Adding a loop around `std::atomic_flag::wait` as it might get woken
       up spuriously
     - Properly synchronizing rejection test by waiting until request is
       pending

- fix: Proper order of members

    To avoid a race between initialization and setting the reply
    through the callback, the reply and reply_promise need to be
    ordered *before* the response service

## Type of change
Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
