### PR TITLE
Feat: Adding possibility to pass and use a Zenoh configuration file

### DIFF
--- a/modules/bag/apps/bag_player.cpp
+++ b/modules/bag/apps/bag_player.cpp
@@ -53,7 +53,7 @@ auto main(int argc, const char* argv[]) -> int {
       std::exit(1);
     }
 
-    heph::bag::ZenohPlayerParams params{ .session = heph::ipc::zenoh::createSession(std::move(config)),
+    heph::bag::ZenohPlayerParams params{ .session = heph::ipc::zenoh::createSession(config),
                                          .bag_reader = std::move(bag_reader),
                                          .wait_for_readers_to_connect = wait_for_readers_to_connect };
     auto zenoh_player = heph::bag::ZenohPlayer::create(std::move(params));

--- a/modules/bag/apps/bag_recorder.cpp
+++ b/modules/bag/apps/bag_recorder.cpp
@@ -33,7 +33,7 @@ auto main(int argc, const char* argv[]) -> int {
     auto output_file = args.getOption<std::string>("output_bag");
 
     heph::bag::ZenohRecorderParams params{
-      .session = heph::ipc::zenoh::createSession(std::move(config)),
+      .session = heph::ipc::zenoh::createSession(config),
       .bag_writer = heph::bag::createMcapWriter({ .output_file = std::move(output_file) }),
       .topics_filter_params = heph::ipc::TopicFilterParams{ .include_topics_only = {},
                                                             .prefix = topic.name,

--- a/modules/examples/examples/zenoh_action_server.cpp
+++ b/modules/examples/examples/zenoh_action_server.cpp
@@ -83,8 +83,8 @@ auto main(int argc, const char* argv[]) -> int {
     auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
 
     auto stop_session_config = session_config;
-    auto session = heph::ipc::zenoh::createSession(std::move(session_config));
-    auto stop_session = heph::ipc::zenoh::createSession(std::move(stop_session_config));
+    auto session = heph::ipc::zenoh::createSession(session_config);
+    auto stop_session = heph::ipc::zenoh::createSession(stop_session_config);
 
     auto request_callback = [](const heph::examples::types::SampleRequest& sample) {
       return request(sample);

--- a/modules/examples/examples/zenoh_action_server_client.cpp
+++ b/modules/examples/examples/zenoh_action_server_client.cpp
@@ -37,7 +37,7 @@ auto main(int argc, const char* argv[]) -> int {
     const auto args = std::move(desc).parse(argc, argv);
     auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
 
-    auto session = heph::ipc::zenoh::createSession(std::move(session_config));
+    auto session = heph::ipc::zenoh::createSession(session_config);
 
     heph::utils::TerminationBlocker::registerInterruptCallback([session = std::ref(*session), &topic_config] {
       std::ignore =

--- a/modules/examples/examples/zenoh_pub.cpp
+++ b/modules/examples/examples/zenoh_pub.cpp
@@ -38,7 +38,7 @@ auto main(int argc, const char* argv[]) -> int {
     const auto args = std::move(desc).parse(argc, argv);
 
     auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
-    auto session = heph::ipc::zenoh::createSession(std::move(session_config));
+    auto session = heph::ipc::zenoh::createSession(session_config);
 
     heph::ipc::zenoh::Publisher<heph::examples::types::Pose> publisher{ session, topic_config,
                                                                         [](const auto& status) {

--- a/modules/examples/examples/zenoh_service_client.cpp
+++ b/modules/examples/examples/zenoh_service_client.cpp
@@ -38,7 +38,7 @@ auto main(int argc, const char* argv[]) -> int {
     const auto args = std::move(desc).parse(argc, argv);
     auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
 
-    auto session = heph::ipc::zenoh::createSession(std::move(session_config));
+    auto session = heph::ipc::zenoh::createSession(session_config);
 
     static constexpr auto K_TIMEOUT = std::chrono::seconds(10);
     const auto query =

--- a/modules/examples/examples/zenoh_service_server.cpp
+++ b/modules/examples/examples/zenoh_service_server.cpp
@@ -34,7 +34,7 @@ auto main(int argc, const char* argv[]) -> int {
     heph::ipc::zenoh::appendProgramOption(desc, getDefaultTopic(ExampleType::SERVICE_SERVER));
     const auto args = std::move(desc).parse(argc, argv);
     auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
-    auto session = heph::ipc::zenoh::createSession(std::move(session_config));
+    auto session = heph::ipc::zenoh::createSession(session_config);
 
     auto callback = [](const heph::examples::types::Pose& sample) {
       fmt::println("received query: pose = {}", sample);

--- a/modules/examples/examples/zenoh_string_service_client.cpp
+++ b/modules/examples/examples/zenoh_string_service_client.cpp
@@ -36,7 +36,7 @@ auto main(int argc, const char* argv[]) -> int {
     const auto args = std::move(desc).parse(argc, argv);
     auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
 
-    auto session = heph::ipc::zenoh::createSession(std::move(session_config));
+    auto session = heph::ipc::zenoh::createSession(session_config);
 
     static constexpr auto K_TIMEOUT = std::chrono::seconds(10);
     const std::string query = "Marco";

--- a/modules/examples/examples/zenoh_string_service_server.cpp
+++ b/modules/examples/examples/zenoh_string_service_server.cpp
@@ -33,7 +33,7 @@ auto main(int argc, const char* argv[]) -> int {
     const auto args = std::move(desc).parse(argc, argv);
     auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
 
-    auto session = heph::ipc::zenoh::createSession(std::move(session_config));
+    auto session = heph::ipc::zenoh::createSession(session_config);
 
     auto callback = [](const std::string& sample) {
       heph::log(heph::DEBUG, "received query", "query", sample);

--- a/modules/examples/examples/zenoh_sub.cpp
+++ b/modules/examples/examples/zenoh_sub.cpp
@@ -39,7 +39,7 @@ auto main(int argc, const char* argv[]) -> int {
 
     heph::log(heph::DEBUG, "opening session", "subscriber_name", topic_config.name);
 
-    auto session = heph::ipc::zenoh::createSession(std::move(session_config));
+    auto session = heph::ipc::zenoh::createSession(session_config);
 
     auto cb = [topic = topic_config.name](const heph::ipc::zenoh::MessageMetadata& metadata,
                                           const std::shared_ptr<heph::examples::types::Pose>& pose) {

--- a/modules/ipc/BUILD
+++ b/modules/ipc/BUILD
@@ -127,6 +127,14 @@ heph_cc_test(
 )
 
 heph_cc_test(
+    name = "config_tests",
+    srcs = [
+        "tests/config_tests.cpp",
+    ],
+    deps = IPC_TEST_DEPS,
+)
+
+heph_cc_test(
     name = "session_tests",
     srcs = [
         "tests/session_tests.cpp",

--- a/modules/ipc/apps/zenoh_string_service_client.cpp
+++ b/modules/ipc/apps/zenoh_string_service_client.cpp
@@ -37,7 +37,7 @@ auto main(int argc, const char* argv[]) -> int {
     const auto value = args.getOption<std::string>("value");
 
     auto [config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
-    auto session = heph::ipc::zenoh::createSession(std::move(config));
+    auto session = heph::ipc::zenoh::createSession(config);
     heph::log(heph::DEBUG, "opening session", "id",
               heph::ipc::zenoh::toString(session->zenoh_session.get_zid()));
 

--- a/modules/ipc/apps/zenoh_topic_echo.cpp
+++ b/modules/ipc/apps/zenoh_topic_echo.cpp
@@ -135,7 +135,7 @@ auto main(int argc, const char* argv[]) -> int {
 
     fmt::println("Opening session...");
 
-    auto session = heph::ipc::zenoh::createSession(std::move(session_config));
+    auto session = heph::ipc::zenoh::createSession(session_config);
 
     heph::ipc::zenoh::apps::TopicEcho topic_echo{ std::move(session), topic_config, noarr, max_array_length };
     topic_echo.start().wait();

--- a/modules/ipc/apps/zenoh_topic_list.cpp
+++ b/modules/ipc/apps/zenoh_topic_list.cpp
@@ -50,7 +50,7 @@ auto main(int argc, const char* argv[]) -> int {
     auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
 
     fmt::println("Opening session...");
-    auto session = heph::ipc::zenoh::createSession(std::move(session_config));
+    auto session = heph::ipc::zenoh::createSession(session_config);
 
     if (!args.getOption<bool>("live")) {
       getListOfZenohEndpoints(*session, topic_config.name);

--- a/modules/ipc/include/hephaestus/ipc/zenoh/session.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/session.h
@@ -60,7 +60,6 @@ struct Config {
   Mode mode = Mode::PEER;
   // NOLINTNEXTLINE(readability-redundant-string-init) otherwise we need to specify in constructor
   std::string router = "";  //! If specified connect to the given router endpoint.
-  std::size_t cache_size = 0;
   bool qos = false;
   bool real_time = false;
   Protocol protocol{ Protocol::ANY };

--- a/modules/ipc/include/hephaestus/ipc/zenoh/session.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/session.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include <zenoh/api/queryable.hxx>
 #include <zenoh/api/session.hxx>
@@ -18,9 +19,40 @@ namespace heph::ipc::zenoh {
 enum class Mode : uint8_t { PEER = 0, CLIENT, ROUTER };
 enum class Protocol : uint8_t { ANY = 0, UDP, TCP };
 
+/// There are a lot of options to configure a zenoh session,
+/// See  for more information https://zenoh.io/docs/manual/configuration/#configuration-files
+struct ZenohConfig {
+  ZenohConfig() {
+    zconfig.insert_json5(Z_CONFIG_ADD_TIMESTAMP_KEY, "true");
+  }
+  explicit ZenohConfig(std::string const& path) : zconfig(::zenoh::Config::from_file(path)) {
+  }
+
+  ~ZenohConfig() noexcept = default;
+  ZenohConfig(const ZenohConfig&) = delete;
+  auto operator=(const ZenohConfig&) -> ZenohConfig& = delete;
+  ZenohConfig(ZenohConfig&&) noexcept = default;
+  auto operator=(ZenohConfig&&) noexcept -> ZenohConfig& = default;
+
+  ::zenoh::Config zconfig{ ::zenoh::Config::create_default() };
+  std::size_t cache_size{ 0 };
+};
+
+void setSessionId(ZenohConfig& config, std::string_view id);
+void setSessionIdFromBinary(ZenohConfig& config);
+void setSharedMemory(ZenohConfig& config, bool);
+void setMode(ZenohConfig& config, Mode mode);
+void connectToEndpoints(ZenohConfig& config, const std::vector<std::string>& endpoints);
+void listenToEndpoints(ZenohConfig& config, const std::vector<std::string>& endpoints);
+void setQos(ZenohConfig& config, bool);
+void setRealTime(ZenohConfig& config, bool);
+void setMulticastScouting(ZenohConfig& config, bool);
+void setMulticastScoutingInterface(ZenohConfig& config, std::string_view interface);
+
 struct Config {
   bool use_binary_name_as_session_id = false;
   std::optional<std::string> id{ std::nullopt };
+  std::string zenoh_config_path;
   bool enable_shared_memory = false;  //! NOTE: With shared-memory enabled, the publisher still uses the
                                       //! network transport layer to notify subscribers of the shared-memory
                                       //! segment to read. Therefore, for very small messages, shared -
@@ -39,7 +71,7 @@ struct Config {
 
 struct Session {
   ::zenoh::Session zenoh_session;
-  Config config;
+  std::size_t cache_size;
 };
 
 /// Create configuration for a session that doesn't connect to any other session.
@@ -48,5 +80,6 @@ struct Session {
 
 using SessionPtr = std::shared_ptr<Session>;
 [[nodiscard]] auto createSession(Config config) -> SessionPtr;
+[[nodiscard]] auto createSession(ZenohConfig config) -> SessionPtr;
 
 }  // namespace heph::ipc::zenoh

--- a/modules/ipc/include/hephaestus/ipc/zenoh/session.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/session.h
@@ -25,8 +25,7 @@ enum class Protocol : uint8_t { ANY = 0, UDP, TCP };
 /// See  for more information https://zenoh.io/docs/manual/configuration/#configuration-files
 struct ZenohConfig {
   ZenohConfig();
-  explicit ZenohConfig(std::filesystem::path const& path) : zconfig(::zenoh::Config::from_file(path)) {
-  }
+  explicit ZenohConfig(std::filesystem::path const& path);
 
   ~ZenohConfig() noexcept = default;
   ZenohConfig(const ZenohConfig&) = delete;
@@ -34,7 +33,7 @@ struct ZenohConfig {
   ZenohConfig(ZenohConfig&&) noexcept = default;
   auto operator=(ZenohConfig&&) noexcept -> ZenohConfig& = default;
 
-  ::zenoh::Config zconfig{ ::zenoh::Config::create_default() };
+  ::zenoh::Config zconfig{ ::zenoh::Config::create_default() };  // NOLINT(misc-include-cleaner)
 };
 
 void setSessionId(ZenohConfig& config, std::string_view id);

--- a/modules/ipc/src/zenoh/program_options.cpp
+++ b/modules/ipc/src/zenoh/program_options.cpp
@@ -22,6 +22,10 @@ void appendProgramOption(cli::ProgramDescription& program_description,
   program_description.defineOption<std::string>("topic", "Key expression", default_topic)
       .defineFlag("use_binary_name_as_session_id", "Use the binary name as the session id")
       .defineOption<std::string>("session_id", "the session id", "")
+      .defineOption<std::string>("zenoh_config",
+                                 "path to a zenoh configuration file (either in yaml or json5 format). "
+                                 "Options set in here will get overriden by explicit command line options.",
+                                 "")
       .defineOption<std::size_t>("cache", "Cache size", 0)
       .defineOption<std::string>("mode", "Running mode: options: peer, client", "peer")
       .defineOption<std::string>("router", "Router endpoint", "")
@@ -43,6 +47,8 @@ auto parseProgramOptions(const heph::cli::ProgramOptions& args) -> std::pair<Con
   } else if (auto session_id = args.getOption<std::string>("session_id"); !session_id.empty()) {
     config.id = std::move(session_id);
   }
+
+  config.zenoh_config_path = args.getOption<std::string>("zenoh_config");
 
   config.cache_size = args.getOption<std::size_t>("cache");
 

--- a/modules/ipc/src/zenoh/program_options.cpp
+++ b/modules/ipc/src/zenoh/program_options.cpp
@@ -50,8 +50,6 @@ auto parseProgramOptions(const heph::cli::ProgramOptions& args) -> std::pair<Con
 
   config.zenoh_config_path = args.getOption<std::string>("zenoh_config");
 
-  config.cache_size = args.getOption<std::size_t>("cache");
-
   auto mode = args.getOption<std::string>("mode");
   if (mode == "peer") {
     config.mode = Mode::PEER;

--- a/modules/ipc/src/zenoh/raw_subscriber.cpp
+++ b/modules/ipc/src/zenoh/raw_subscriber.cpp
@@ -77,10 +77,10 @@ RawSubscriber::RawSubscriber(SessionPtr session, TopicConfig topic_config, DataC
   }
 
   auto sub_options = ::zenoh::ext::SessionExt::AdvancedSubscriberOptions::create_default();
-  if (session_->cache_size > 0) {
+  if (config.cache_size.has_value() && *config.cache_size > 0) {
     sub_options.history =
         ::zenoh::ext::SessionExt::AdvancedSubscriberOptions::HistoryOptions::create_default();
-    sub_options.history->max_samples = session_->cache_size;
+    sub_options.history->max_samples = *config.cache_size;
   }
 
   ::zenoh::ZResult result{};

--- a/modules/ipc/src/zenoh/raw_subscriber.cpp
+++ b/modules/ipc/src/zenoh/raw_subscriber.cpp
@@ -77,10 +77,10 @@ RawSubscriber::RawSubscriber(SessionPtr session, TopicConfig topic_config, DataC
   }
 
   auto sub_options = ::zenoh::ext::SessionExt::AdvancedSubscriberOptions::create_default();
-  if (session_->config.cache_size > 0) {
+  if (session_->cache_size > 0) {
     sub_options.history =
         ::zenoh::ext::SessionExt::AdvancedSubscriberOptions::HistoryOptions::create_default();
-    sub_options.history->max_samples = session_->config.cache_size;
+    sub_options.history->max_samples = session_->cache_size;
   }
 
   ::zenoh::ZResult result{};

--- a/modules/ipc/src/zenoh/scout.cpp
+++ b/modules/ipc/src/zenoh/scout.cpp
@@ -68,8 +68,8 @@ private:
 };
 
 [[nodiscard]] auto getRouterInfoJson(const std::string& router_id) -> std::string {
-  heph::ipc::zenoh::Config config;
-  auto session = heph::ipc::zenoh::createSession(std::move(config));
+  const heph::ipc::zenoh::Config config;
+  auto session = heph::ipc::zenoh::createSession(config);
 
   static constexpr auto ROUTER_TOPIC = "@/router/{}";
   const auto query_topic = TopicConfig{ fmt::format(ROUTER_TOPIC, router_id) };

--- a/modules/ipc/src/zenoh/session.cpp
+++ b/modules/ipc/src/zenoh/session.cpp
@@ -67,8 +67,8 @@ auto createZenohConfig(const Config& config) -> ::zenoh::Config {
                                               "cannot specify both protocol and the router endpoint");
 
   auto zconfig = [&] {
-    if (!config.zenoh_config_path.empty()) {
-      return ZenohConfig{ config.zenoh_config_path };
+    if (config.zenoh_config_path.has_value()) {
+      return ZenohConfig{ *config.zenoh_config_path };
     }
     return ZenohConfig{};
   }();
@@ -114,6 +114,10 @@ auto toJsonArray(const std::vector<std::string>& values) -> std::string {
                                        ","));
 }
 }  // namespace
+
+ZenohConfig::ZenohConfig() {
+  zconfig.insert_json5(Z_CONFIG_ADD_TIMESTAMP_KEY, "true");
+}
 
 void setSessionId(ZenohConfig& config, std::string_view id) {
   config.zconfig.insert_json5("id", fmt::format(R"("{}")", createSessionId(id)));
@@ -179,13 +183,12 @@ auto createLocalConfig() -> Config {
   return config;
 }
 
-auto createSession(Config config) -> SessionPtr {
+auto createSession(const Config& config) -> SessionPtr {
   auto zconfig = createZenohConfig(config);
-  return std::make_shared<Session>(::zenoh::Session::open(std::move(zconfig)), config.cache_size);
+  return std::make_shared<Session>(::zenoh::Session::open(std::move(zconfig)));
 }
 
 auto createSession(ZenohConfig config) -> SessionPtr {
-  return std::make_shared<Session>(::zenoh::Session::open(std::move(config.zconfig)), config.cache_size);
+  return std::make_shared<Session>(::zenoh::Session::open(std::move(config.zconfig)));
 }
-
 }  // namespace heph::ipc::zenoh

--- a/modules/ipc/src/zenoh/session.cpp
+++ b/modules/ipc/src/zenoh/session.cpp
@@ -107,6 +107,7 @@ auto createZenohConfig(const Config& config) -> ::zenoh::Config {
 
   return std::move(zconfig.zconfig);
 }
+
 auto toJsonArray(const std::vector<std::string>& values) -> std::string {
   return fmt::format("[{}]", fmt::join(values | std::views::transform([](const std::string& value) {
                                          return fmt::format(R"("{}")", value);

--- a/modules/ipc/src/zenoh/session.cpp
+++ b/modules/ipc/src/zenoh/session.cpp
@@ -5,13 +5,16 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdlib>
 #include <memory>
 #include <ranges>
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <unistd.h>
 #include <zenoh/api/config.hxx>
 #include <zenoh/api/session.hxx>
@@ -117,7 +120,10 @@ auto toJsonArray(const std::vector<std::string>& values) -> std::string {
 }  // namespace
 
 ZenohConfig::ZenohConfig() {
-  zconfig.insert_json5(Z_CONFIG_ADD_TIMESTAMP_KEY, "true");
+  zconfig.insert_json5(Z_CONFIG_ADD_TIMESTAMP_KEY, "true");  // NOLINT(misc-include-cleaner)
+}
+
+ZenohConfig::ZenohConfig(std::filesystem::path const& path) : zconfig(::zenoh::Config::from_file(path)) {
 }
 
 void setSessionId(ZenohConfig& config, std::string_view id) {
@@ -135,13 +141,13 @@ void setSharedMemory(ZenohConfig& config, bool value) {
 void setMode(ZenohConfig& config, Mode mode) {
   switch (mode) {
     case Mode::PEER:
-      config.zconfig.insert_json5(Z_CONFIG_MODE_KEY, R"("peer")");
+      config.zconfig.insert_json5(Z_CONFIG_MODE_KEY, R"("peer")");  // NOLINT(misc-include-cleaner)
       break;
     case Mode::CLIENT:
-      config.zconfig.insert_json5(Z_CONFIG_MODE_KEY, R"("client")");
+      config.zconfig.insert_json5(Z_CONFIG_MODE_KEY, R"("client")");  // NOLINT(misc-include-cleaner)
       break;
     case Mode::ROUTER:
-      config.zconfig.insert_json5(Z_CONFIG_MODE_KEY, R"("router")");
+      config.zconfig.insert_json5(Z_CONFIG_MODE_KEY, R"("router")");  // NOLINT(misc-include-cleaner)
       break;
     default:
       std::abort();
@@ -149,11 +155,11 @@ void setMode(ZenohConfig& config, Mode mode) {
 }
 
 void connectToEndpoints(ZenohConfig& config, const std::vector<std::string>& endpoints) {
-  config.zconfig.insert_json5(Z_CONFIG_CONNECT_KEY, toJsonArray(endpoints));
+  config.zconfig.insert_json5(Z_CONFIG_CONNECT_KEY, toJsonArray(endpoints));  // NOLINT(misc-include-cleaner)
 }
 
 void listenToEndpoints(ZenohConfig& config, const std::vector<std::string>& endpoints) {
-  config.zconfig.insert_json5(Z_CONFIG_LISTEN_KEY, toJsonArray(endpoints));
+  config.zconfig.insert_json5(Z_CONFIG_LISTEN_KEY, toJsonArray(endpoints));  // NOLINT(misc-include-cleaner)
 }
 
 void setQos(ZenohConfig& config, bool value) {

--- a/modules/ipc/tests/config_tests.cpp
+++ b/modules/ipc/tests/config_tests.cpp
@@ -1,0 +1,131 @@
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include "hephaestus/ipc/zenoh/session.h"
+
+TEST(ZenohTests, ConfigSetSessionId) {
+  heph::ipc::zenoh::ZenohConfig config;
+
+  nlohmann::json default_config = config.zconfig.to_string();
+
+  heph::ipc::zenoh::setSessionId(config, "blubb");
+
+  nlohmann::json new_config1 = config.zconfig.to_string();
+
+  heph::ipc::zenoh::setSessionIdFromBinary(config);
+
+  nlohmann::json new_config2 = config.zconfig.to_string();
+
+  ASSERT_NE(default_config, new_config1);
+  ASSERT_NE(default_config, new_config2);
+  ASSERT_NE(new_config1, new_config2);
+}
+
+TEST(ZenohTests, ConfigSetSharedMemory) {
+  heph::ipc::zenoh::ZenohConfig config;
+
+  nlohmann::json default_config = config.zconfig.to_string();
+
+  heph::ipc::zenoh::setSharedMemory(config, false);
+
+  nlohmann::json new_config = config.zconfig.to_string();
+
+  ASSERT_NE(default_config, new_config);
+}
+
+TEST(ZenohTests, ConfigSetMode) {
+  heph::ipc::zenoh::ZenohConfig config;
+
+  nlohmann::json default_config = config.zconfig.to_string();
+
+  heph::ipc::zenoh::setMode(config, heph::ipc::zenoh::Mode::CLIENT);
+  nlohmann::json new_config1 = config.zconfig.to_string();
+
+  heph::ipc::zenoh::setMode(config, heph::ipc::zenoh::Mode::ROUTER);
+  nlohmann::json new_config2 = config.zconfig.to_string();
+
+  heph::ipc::zenoh::setMode(config, heph::ipc::zenoh::Mode::PEER);
+  nlohmann::json new_config3 = config.zconfig.to_string();
+
+  ASSERT_NE(default_config, new_config1);
+  ASSERT_NE(default_config, new_config2);
+  ASSERT_NE(default_config, new_config3);
+  ASSERT_NE(new_config1, new_config2);
+  ASSERT_NE(new_config1, new_config3);
+}
+
+TEST(ZenohTests, ConnectToEndpoints) {
+  heph::ipc::zenoh::ZenohConfig config;
+
+  nlohmann::json default_config = config.zconfig.to_string();
+
+  heph::ipc::zenoh::connectToEndpoints(config, { "tcp/0.0.0.0:7447", "udp/localhost:7448" });
+
+  nlohmann::json new_config = config.zconfig.to_string();
+
+  ASSERT_NE(default_config, new_config);
+
+  // fmt::println("{}", fmt::join(new_config[Z_CONFIG_CONNECT_KEY]);
+}
+
+TEST(ZenohTests, ListenToEndpoints) {
+  heph::ipc::zenoh::ZenohConfig config;
+
+  nlohmann::json default_config = config.zconfig.to_string();
+
+  heph::ipc::zenoh::listenToEndpoints(config, { "tcp/0.0.0.0:7447", "udp/localhost:7448" });
+
+  nlohmann::json new_config = config.zconfig.to_string();
+
+  ASSERT_NE(default_config, new_config);
+}
+
+TEST(ZenohTests, ConfigSetQos) {
+  heph::ipc::zenoh::ZenohConfig config;
+
+  nlohmann::json default_config = config.zconfig.to_string();
+
+  heph::ipc::zenoh::setQos(config, false);
+
+  nlohmann::json new_config = config.zconfig.to_string();
+
+  ASSERT_NE(default_config, new_config);
+}
+
+TEST(ZenohTests, ConfigSetRealTime) {
+  heph::ipc::zenoh::ZenohConfig config;
+
+  nlohmann::json default_config = config.zconfig.to_string();
+
+  heph::ipc::zenoh::setRealTime(config, true);
+
+  nlohmann::json new_config = config.zconfig.to_string();
+
+  ASSERT_NE(default_config, new_config);
+}
+
+TEST(ZenohTests, ConfigSetMulticastScouting) {
+  heph::ipc::zenoh::ZenohConfig config;
+
+  nlohmann::json default_config = config.zconfig.to_string();
+
+  heph::ipc::zenoh::setMulticastScouting(config, true);
+
+  nlohmann::json new_config = config.zconfig.to_string();
+
+  ASSERT_NE(default_config, new_config);
+}
+
+TEST(ZenohTests, ConfigSetMulticastScoutingInterface) {
+  heph::ipc::zenoh::ZenohConfig config;
+
+  nlohmann::json default_config = config.zconfig.to_string();
+
+  heph::ipc::zenoh::setMulticastScoutingInterface(config, "lilo");
+
+  nlohmann::json new_config = config.zconfig.to_string();
+
+  ASSERT_NE(default_config, new_config);
+}

--- a/modules/ipc/tests/config_tests.cpp
+++ b/modules/ipc/tests/config_tests.cpp
@@ -66,8 +66,6 @@ TEST(ZenohTests, ConnectToEndpoints) {
   nlohmann::json new_config = config.zconfig.to_string();
 
   ASSERT_NE(default_config, new_config);
-
-  // fmt::println("{}", fmt::join(new_config[Z_CONFIG_CONNECT_KEY]);
 }
 
 TEST(ZenohTests, ListenToEndpoints) {

--- a/modules/ipc/tests/dynamic_subscriber_tests.cpp
+++ b/modules/ipc/tests/dynamic_subscriber_tests.cpp
@@ -16,7 +16,7 @@ namespace heph::ipc::zenoh::tests {
 
 TEST(DynamicSubscriber, StartStop) {
   auto params = DynamicSubscriberParams{
-    .session = zenoh::createSession({}),
+    .session = zenoh::createSession(zenoh::createLocalConfig()),
     .topics_filter_params = {},
     .init_subscriber_cb = [](const auto&, const auto&) {},
     .subscriber_cb = [](const auto&, const auto&, const auto&) {},


### PR DESCRIPTION
 - Adding command line option `--zenoh_config` to allow to pass a zenoh configuration file
 - Adding helper functions to set options for the zenoh config

Order of precedence:
 - Config file
 - Command line options

## Type of change
Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
