### PR TITLE
fix zenoh config default

### DIFF
--- a/modules/bag/src/zenoh_player.cpp
+++ b/modules/bag/src/zenoh_player.cpp
@@ -128,7 +128,7 @@ void ZenohPlayer::Impl::createPublisher(const mcap::Channel& channel) {
         }
       });
 
-  heph::log(heph::DEBUG, "created publisher for topic", "name", channel.topic);
+  heph::log(heph::INFO, "created publisher for topic", "name", channel.topic);
 }
 
 void ZenohPlayer::Impl::run() {

--- a/modules/ipc/src/zenoh/program_options.cpp
+++ b/modules/ipc/src/zenoh/program_options.cpp
@@ -33,7 +33,7 @@ void appendProgramOption(cli::ProgramDescription& program_description,
       .defineOption<std::string>("multicast_scouting_interface",
                                  "Interface to use for multicast, options: auto, <INTERFACE_NAME>", "auto")
       .defineFlag("shared_memory", "Enable shared memory")
-      .defineFlag("multicast_scouting_enabled", "Enable multicast scouting")
+      .defineFlag("disable_multicast_scouting", "Disable multicast scouting")
       .defineFlag("qos", "Enable QoS")
       .defineFlag("realtime", "Enable real-time communication");
 }
@@ -76,7 +76,7 @@ auto parseProgramOptions(const heph::cli::ProgramOptions& args) -> std::pair<Con
 
   config.router = args.getOption<std::string>("router");
   config.enable_shared_memory = args.getOption<bool>("shared_memory");
-  config.multicast_scouting_enabled = args.getOption<bool>("multicast_scouting_enabled");
+  config.multicast_scouting_enabled = !args.getOption<bool>("disable_multicast_scouting");
   config.multicast_scouting_interface = args.getOption<std::string>("multicast_scouting_interface");
   config.qos = args.getOption<bool>("qos");
   config.real_time = args.getOption<bool>("realtime");


### PR DESCRIPTION
# Description
multicast is now enable by default when using CLI options

## Type of change
Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
