### PR TITLE
Fix/sensor spinner improve state machine transition logic

### DIFF
--- a/modules/concurrency/BUILD
+++ b/modules/concurrency/BUILD
@@ -52,6 +52,12 @@ heph_cc_test(
 )
 
 heph_cc_test(
+    name = "spinner_state_machine_tests",
+    srcs = ["tests/spinner_state_machine_tests.cpp"],
+    deps = CONCURRENCY_TEST_DEPS,
+)
+
+heph_cc_test(
     name = "spinner_tests",
     srcs = ["tests/spinner_tests.cpp"],
     deps = CONCURRENCY_TEST_DEPS,

--- a/modules/concurrency/include/hephaestus/concurrency/spinner.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner.h
@@ -12,6 +12,8 @@
 #include <limits>
 #include <mutex>
 
+#include "hephaestus/concurrency/spinner_state_machine.h"
+
 namespace heph::concurrency {
 
 /// A spinner is a class that spins in a loop calling a user-defined function.

--- a/modules/concurrency/include/hephaestus/concurrency/spinner.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner.h
@@ -27,25 +27,9 @@ public:
   /// @brief Wrap the user provided callback in a callback that never stops.
   [[nodiscard]] static auto createNeverStoppingCallback(Callback&& callback) -> StoppableCallback;
 
-  struct StateMachineCallbacks {
-    using TransitionCallback = std::function<void()>;
-    using PolicyCallback = std::function<bool()>;
-
-    TransitionCallback init_cb = []() {};       //!< Handles initialization.
-    TransitionCallback spin_once_cb = []() {};  //!< Handles execution.
-
-    PolicyCallback shall_stop_spinning_cb = []() {
-      return false;
-    };  //!< This callback is called after successful execution. It decides if spinning shall continue or
-        //!< conclude. Default: spin indefinitely.
-    PolicyCallback shall_restart_cb = []() {
-      return false;
-    };  //!< This callback is called after failure. It decides if operation shall restart, or the spinner
-        //!< shall conclude. Default: do not restart.
-  };
-
   /// @brief Create a callback for the spinner which internally handles the state machine.
-  [[nodiscard]] static auto createCallbackWithStateMachine(StateMachineCallbacks&& callbacks)
+  [[nodiscard]] static auto
+  createCallbackWithStateMachine(spinner_state_machine::StateMachineCallbackT&& state_machine_callback)
       -> StoppableCallback;
 
   /// @brief Create a spinner with a stoppable callback. A stoppable callback is a function that returns

--- a/modules/concurrency/include/hephaestus/concurrency/spinner_state_machine.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner_state_machine.h
@@ -9,9 +9,9 @@
 
 namespace heph::concurrency::spinner_state_machine {
 
-enum class State : uint8_t { NOT_INITIALIZED, FAILED, READY_TO_SPIN, SPIN_SUCCESSFUL, EXIT };
-enum class CallbackResult : uint8_t { SUCCESS, FAILURE };
-enum class ExecutionDirective : uint8_t { TRUE, FALSE, REPEAT };
+enum class State : std::uint8_t { NOT_INITIALIZED, FAILED, READY_TO_SPIN, SPIN_SUCCESSFUL, EXIT };
+enum class CallbackResult : std::uint8_t { SUCCESS, FAILURE };
+enum class ExecutionDirective : std::uint8_t { TRUE, FALSE, REPEAT };
 
 using StateMachineCallbackT = std::function<State()>;
 using OperationCallbackT = std::function<CallbackResult()>;

--- a/modules/concurrency/include/hephaestus/concurrency/spinner_state_machine.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner_state_machine.h
@@ -1,0 +1,44 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+namespace heph::concurrency::spinner_state_machine {
+
+enum class State : uint8_t { NOT_INITIALIZED, FAILED, READY_TO_SPIN, SPIN_SUCCESSFUL, EXIT };
+enum class CallbackResult : uint8_t { SUCCESS, FAILURE };
+enum class ExecutionDirective : uint8_t { TRUE, FALSE, REPEAT };
+
+using StateMachineCallbackT = std::function<State()>;
+using OperationCallbackT = std::function<CallbackResult()>;
+using BinaryCheckCallbackT = std::function<ExecutionDirective()>;
+
+struct Callbacks {
+  OperationCallbackT init_cb = []() -> CallbackResult {
+    return CallbackResult::SUCCESS;
+  };  //!< Handles initialization.
+
+  OperationCallbackT spin_once_cb = []() -> CallbackResult {
+    return CallbackResult::SUCCESS;
+  };  //!< Handles execution.
+
+  BinaryCheckCallbackT shall_stop_spinning_cb = []() -> ExecutionDirective {
+    return ExecutionDirective::FALSE;
+  };  //!< This callback is called after successful execution. It decides if spinning shall continue or
+      //!< conclude. Default: spin indefinitely.
+
+  BinaryCheckCallbackT shall_restart_cb = []() -> ExecutionDirective {
+    return ExecutionDirective::FALSE;
+  };  //!< This callback is called after failure. It decides if operation shall restart, or the spinner
+      //!< shall conclude. Default: do not restart.
+};
+
+/// @brief Create a callback for the spinner which internally handles the state machine. The current state is
+/// stored and a copy is returned to the caller.
+[[nodiscard]] auto createStateMachineCallback(Callbacks&& callbacks) -> StateMachineCallbackT;
+
+}  // namespace heph::concurrency::spinner_state_machine

--- a/modules/concurrency/include/hephaestus/concurrency/spinner_state_machine.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner_state_machine.h
@@ -10,29 +10,19 @@
 namespace heph::concurrency::spinner_state_machine {
 
 enum class State : std::uint8_t { NOT_INITIALIZED, FAILED, READY_TO_SPIN, SPIN_SUCCESSFUL, EXIT };
-enum class CallbackResult : std::uint8_t { SUCCESS, FAILURE };
-enum class ExecutionDirective : std::uint8_t { TRUE, FALSE, REPEAT };
+enum class Result : std::uint8_t { SUCCESS, FAILURE, REPEAT };
 
+using OperationCallbackT = std::function<Result()>;
+using CheckCallbackT = std::function<bool()>;
 using StateMachineCallbackT = std::function<State()>;
-using OperationCallbackT = std::function<CallbackResult()>;
-using BinaryCheckCallbackT = std::function<ExecutionDirective()>;
 
 struct Callbacks {
-  OperationCallbackT init_cb = []() -> CallbackResult {
-    return CallbackResult::SUCCESS;
-  };  //!< Handles initialization.
+  OperationCallbackT init_cb = []() -> Result { return Result::SUCCESS; };  //!< Handles initialization.
 
-  OperationCallbackT spin_once_cb = []() -> CallbackResult {
-    return CallbackResult::SUCCESS;
-  };  //!< Handles execution.
+  OperationCallbackT spin_once_cb = []() -> Result { return Result::SUCCESS; };  //!< Handles execution.
 
-  BinaryCheckCallbackT shall_stop_spinning_cb = []() -> ExecutionDirective {
-    return ExecutionDirective::FALSE;
-  };  //!< This callback is called after successful execution. It decides if spinning shall continue or
-      //!< conclude. Default: spin indefinitely.
-
-  BinaryCheckCallbackT shall_restart_cb = []() -> ExecutionDirective {
-    return ExecutionDirective::FALSE;
+  CheckCallbackT shall_restart_cb = []() -> bool {
+    return false;
   };  //!< This callback is called after failure. It decides if operation shall restart, or the spinner
       //!< shall conclude. Default: do not restart.
 };

--- a/modules/concurrency/include/hephaestus/concurrency/spinner_state_machine.h
+++ b/modules/concurrency/include/hephaestus/concurrency/spinner_state_machine.h
@@ -10,16 +10,18 @@
 namespace heph::concurrency::spinner_state_machine {
 
 enum class State : std::uint8_t { NOT_INITIALIZED, FAILED, READY_TO_SPIN, SPIN_SUCCESSFUL, EXIT };
-enum class Result : std::uint8_t { SUCCESS, FAILURE, REPEAT };
+enum class Result : std::uint8_t { PROCEED, FAILURE, REPEAT };
 
 using OperationCallbackT = std::function<Result()>;
 using CheckCallbackT = std::function<bool()>;
 using StateMachineCallbackT = std::function<State()>;
 
+// In each spin iteration, the state machine will call exactly one operation. Checks are called after the
+// operation and do not take up a spin cycle.
 struct Callbacks {
-  OperationCallbackT init_cb = []() -> Result { return Result::SUCCESS; };  //!< Handles initialization.
+  OperationCallbackT init_cb = []() -> Result { return Result::PROCEED; };  //!< Handles initialization.
 
-  OperationCallbackT spin_once_cb = []() -> Result { return Result::SUCCESS; };  //!< Handles execution.
+  OperationCallbackT spin_once_cb = []() -> Result { return Result::PROCEED; };  //!< Handles execution.
 
   CheckCallbackT shall_restart_cb = []() -> bool {
     return false;

--- a/modules/concurrency/src/spinner.cpp
+++ b/modules/concurrency/src/spinner.cpp
@@ -49,7 +49,7 @@ auto Spinner::createCallbackWithStateMachine(
     const auto state = state_machine_callback();
 
     // If the state machine reaches the exit state, the spinner should stop, else continue spinning.
-    if (state == State::EXIT) {
+    if (state == spinner_state_machine::State::EXIT) {
       return SpinResult::STOP;
     }
 

--- a/modules/concurrency/src/spinner.cpp
+++ b/modules/concurrency/src/spinner.cpp
@@ -93,6 +93,7 @@ void Spinner::spin() {
                                         start_timestamp, std::chrono::system_clock::now(), spin_period_));
       }
     } catch (std::exception& e) {
+      heph::log(heph::ERROR, "Spinner caught an exception, terminating", "error", e.what());
       terminate();
       throw;
     }

--- a/modules/concurrency/src/spinner.cpp
+++ b/modules/concurrency/src/spinner.cpp
@@ -13,11 +13,9 @@
 #include <future>
 #include <limits>
 #include <mutex>
-#include <type_traits>
 #include <utility>
 
-#include <magic_enum.hpp>
-
+#include "hephaestus/concurrency/spinner_state_machine.h"
 #include "hephaestus/telemetry/log.h"
 #include "hephaestus/utils/exception.h"
 

--- a/modules/concurrency/src/spinner.cpp
+++ b/modules/concurrency/src/spinner.cpp
@@ -34,48 +34,6 @@ namespace {
 
   return std::chrono::microseconds{ period_microseconds };
 }
-
-enum class State : uint8_t { NOT_INITIALIZED, FAILED, READY_TO_SPIN, SPIN_SUCCESSFUL, EXIT };
-
-template <typename CallbackT>
-struct BinaryTransitionParams {
-  State input_state;
-  CallbackT& operation;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
-  State success_state;
-  State failure_state;
-};
-
-template <typename T>
-struct IsPolicyCallback : std::false_type {};
-
-template <>
-struct IsPolicyCallback<Spinner::StateMachineCallbacks::PolicyCallback> : std::true_type {};
-
-template <typename CallbackT>
-[[nodiscard]] auto attemptBinaryTransition(State current_state,
-                                           const BinaryTransitionParams<CallbackT>& params) -> State {
-  if (current_state != params.input_state) {
-    return current_state;
-  }
-
-  try {
-    if constexpr (IsPolicyCallback<CallbackT>::value) {
-      // policy callbacks have a return value which is returned to the caller
-      return params.operation() ? params.success_state : params.failure_state;
-    }
-
-    params.operation();
-  } catch (const std::exception& exception_message) {
-    heph::log(heph::ERROR, "spinner state transition failed", "current_state",
-              magic_enum::enum_name(params.input_state), "expected_transition_state",
-              magic_enum::enum_name(params.success_state), "actual_transition_state",
-              magic_enum::enum_name(params.failure_state), "exception", exception_message.what());
-
-    return params.failure_state;
-  }
-
-  return params.success_state;
-}
 }  // namespace
 
 auto Spinner::createNeverStoppingCallback(Callback&& callback) -> StoppableCallback {
@@ -85,28 +43,10 @@ auto Spinner::createNeverStoppingCallback(Callback&& callback) -> StoppableCallb
   };
 }
 
-auto Spinner::createCallbackWithStateMachine(StateMachineCallbacks&& callbacks) -> StoppableCallback {
-  return [callbacks = std::move(callbacks), state = State::NOT_INITIALIZED]() mutable -> SpinResult {
-    state = attemptBinaryTransition(state, BinaryTransitionParams{ .input_state = State::NOT_INITIALIZED,
-                                                                   .operation = callbacks.init_cb,
-                                                                   .success_state = State::READY_TO_SPIN,
-                                                                   .failure_state = State::FAILED });
-
-    state = attemptBinaryTransition(state, BinaryTransitionParams{ .input_state = State::READY_TO_SPIN,
-                                                                   .operation = callbacks.spin_once_cb,
-                                                                   .success_state = State::SPIN_SUCCESSFUL,
-                                                                   .failure_state = State::FAILED });
-
-    state = attemptBinaryTransition(state, BinaryTransitionParams{ .input_state = State::FAILED,
-                                                                   .operation = callbacks.shall_restart_cb,
-                                                                   .success_state = State::NOT_INITIALIZED,
-                                                                   .failure_state = State::EXIT });
-
-    state =
-        attemptBinaryTransition(state, BinaryTransitionParams{ .input_state = State::SPIN_SUCCESSFUL,
-                                                               .operation = callbacks.shall_stop_spinning_cb,
-                                                               .success_state = State::EXIT,
-                                                               .failure_state = State::READY_TO_SPIN });
+auto Spinner::createCallbackWithStateMachine(
+    spinner_state_machine::StateMachineCallbackT&& state_machine_callback) -> StoppableCallback {
+  return [state_machine_callback = std::move(state_machine_callback)]() mutable -> SpinResult {
+    const auto state = state_machine_callback();
 
     // If the state machine reaches the exit state, the spinner should stop, else continue spinning.
     if (state == State::EXIT) {

--- a/modules/concurrency/src/spinner_state_machine.cpp
+++ b/modules/concurrency/src/spinner_state_machine.cpp
@@ -4,6 +4,8 @@
 
 #include "hephaestus/concurrency/spinner_state_machine.h"
 
+#include <utility>
+
 #include "hephaestus/utils/exception.h"
 
 namespace heph::concurrency::spinner_state_machine {

--- a/modules/concurrency/src/spinner_state_machine.cpp
+++ b/modules/concurrency/src/spinner_state_machine.cpp
@@ -15,67 +15,40 @@ struct OperationParams {
   State failure_state;
 };
 
-[[nodiscard]] auto executeOperation(const OperationParams& params) -> State {
+[[nodiscard]] auto executeOperation(State current_state, const OperationParams& params) -> State {
   const auto result = params.operation();
 
   switch (result) {
-    case CallbackResult::SUCCESS:
+    case Result::SUCCESS:
       return params.success_state;
-    case CallbackResult::FAILURE:
+    case Result::FAILURE:
       return params.failure_state;
-  }
-}
-
-struct BinaryCheckParams {
-  BinaryCheckCallbackT& check;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
-  State true_state;
-  State false_state;
-  State repeat_state;
-};
-
-[[nodiscard]] auto executeBinaryCheck(const BinaryCheckParams& params) -> State {
-  const auto result = params.check();
-  switch (result) {
-    case ExecutionDirective::TRUE:
-      return params.true_state;
-    case ExecutionDirective::FALSE:
-      return params.false_state;
-    case ExecutionDirective::REPEAT:
-      return params.repeat_state;
+    case Result::REPEAT:
+      return current_state;
   }
 }
 }  // namespace
 
 auto createStateMachineCallback(Callbacks&& callbacks) -> StateMachineCallbackT {
-  return [callbacks = std::move(callbacks), state = State::NOT_INITIALIZED]() mutable -> State {
+  auto execute_state_transition = [callbacks = std::move(callbacks)](State state) -> State {
     switch (state) {
       case State::NOT_INITIALIZED:
-        state = executeOperation(OperationParams{ .operation = callbacks.init_cb,
-                                                  .success_state = State::READY_TO_SPIN,
-                                                  .failure_state = State::FAILED });
-        break;
+        return executeOperation(state, OperationParams{ .operation = callbacks.init_cb,
+                                                        .success_state = State::READY_TO_SPIN,
+                                                        .failure_state = State::FAILED });
       case State::READY_TO_SPIN:
-        state = executeOperation(OperationParams{ .operation = callbacks.spin_once_cb,
-                                                  .success_state = State::SPIN_SUCCESSFUL,
-                                                  .failure_state = State::FAILED });
-        break;
+        return executeOperation(state, OperationParams{ .operation = callbacks.spin_once_cb,
+                                                        .success_state = State::SPIN_SUCCESSFUL,
+                                                        .failure_state = State::FAILED });
       case State::FAILED:
-        state = executeBinaryCheck(BinaryCheckParams{ .check = callbacks.shall_restart_cb,
-                                                      .true_state = State::NOT_INITIALIZED,
-                                                      .false_state = State::EXIT,
-                                                      .repeat_state = State::FAILED });
-        break;
-      case State::SPIN_SUCCESSFUL:
-        state = executeBinaryCheck(BinaryCheckParams{ .check = callbacks.shall_stop_spinning_cb,
-                                                      .true_state = State::EXIT,
-                                                      .false_state = State::READY_TO_SPIN,
-                                                      .repeat_state = State::SPIN_SUCCESSFUL });
-        break;
+        return callbacks.shall_restart_cb() ? State::NOT_INITIALIZED : State::EXIT;
       default:
-        state = State::EXIT;
-        break;
+        return state;
     }
+  };
 
+  return [&execute_state_transition, state = State::NOT_INITIALIZED]() mutable -> State {
+    state = execute_state_transition(state);
     return state;
   };
 }

--- a/modules/concurrency/src/spinner_state_machine.cpp
+++ b/modules/concurrency/src/spinner_state_machine.cpp
@@ -6,8 +6,6 @@
 
 #include <utility>
 
-#include "hephaestus/utils/exception.h"
-
 namespace heph::concurrency::spinner_state_machine {
 
 namespace {
@@ -26,8 +24,6 @@ struct OperationParams {
     case CallbackResult::FAILURE:
       return params.failure_state;
   }
-
-  heph::throwException<heph::InvalidParameterException>("Invalid callback result");
 }
 
 struct BinaryCheckParams {
@@ -47,8 +43,6 @@ struct BinaryCheckParams {
     case ExecutionDirective::REPEAT:
       return params.repeat_state;
   }
-
-  heph::throwException<heph::InvalidParameterException>("Invalid callback result");
 }
 }  // namespace
 

--- a/modules/concurrency/src/spinner_state_machine.cpp
+++ b/modules/concurrency/src/spinner_state_machine.cpp
@@ -1,0 +1,86 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#include "hephaestus/concurrency/spinner_state_machine.h"
+
+#include <utility>
+
+#include "hephaestus/utils/exception.h"
+
+namespace heph::concurrency::spinner_state_machine {
+
+namespace {
+struct OperationParams {
+  OperationCallbackT& operation;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+  State success_state;
+  State failure_state;
+};
+
+[[nodiscard]] auto executeOperation(const OperationParams& params) -> State {
+  switch (params.operation()) {
+    case CallbackResult::SUCCESS:
+      return params.success_state;
+    case CallbackResult::FAILURE:
+      return params.failure_state;
+  }
+
+  heph::throwException<heph::InvalidParameterException>("Invalid callback result");
+  std::unreachable();
+}
+
+struct BinaryCheckParams {
+  BinaryCheckCallbackT operation;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+  State true_state;
+  State false_state;
+  State repeat_state;
+};
+
+[[nodiscard]] auto executeBinaryCheck(const BinaryCheckParams& params) -> State {
+  switch (params.operation()) {
+    case ExecutionDirective::TRUE:
+      return params.true_state;
+    case ExecutionDirective::FALSE:
+      return params.false_state;
+    case ExecutionDirective::REPEAT:
+      return params.repeat_state;
+  }
+
+  heph::throwException<heph::InvalidParameterException>("Invalid callback result");
+  std::unreachable();
+}
+
+}  // namespace
+
+auto createCallbackWithStateMachine(Callbacks&& callbacks) -> StateMachineCallbackT {
+  return [callbacks = std::move(callbacks), state = State::NOT_INITIALIZED]() mutable -> State {
+    switch (state) {
+      case State::NOT_INITIALIZED:
+        state = executeOperation({ .operation = callbacks.init_cb(),
+                                   .success_state = State::READY_TO_SPIN,
+                                   .failure_state = State::FAILED });
+        break;
+      case State::READY_TO_SPIN:
+        state = executeOperation({ .operation = callbacks.spin_once_cb(),
+                                   .success_state = State::SPIN_SUCCESSFUL,
+                                   .failure_state = State::FAILED });
+        break;
+      case State::FAILED:
+        state = executeBinaryCheck({ .operation = callbacks.shall_restart_cb(),
+                                     .true_state = State::NOT_INITIALIZED,
+                                     .false_state = State::EXIT,
+                                     .repeat_state = State::FAILED });
+        break;
+      case State::SPIN_SUCCESSFUL:
+        state = executeBinaryCheck({ .operation = callbacks.shall_stop_spinning_cb(),
+                                     .true_state = State::EXIT,
+                                     .false_state = State::READY_TO_SPIN,
+                                     .repeat_state = State::SPIN_SUCCESSFUL });
+        break;
+    }
+
+    return state;
+  };
+}
+
+}  // namespace heph::concurrency::spinner_state_machine

--- a/modules/concurrency/src/spinner_state_machine.cpp
+++ b/modules/concurrency/src/spinner_state_machine.cpp
@@ -6,8 +6,6 @@
 
 #include <utility>
 
-#include <sys/stat.h>
-
 namespace heph::concurrency::spinner_state_machine {
 
 namespace {

--- a/modules/concurrency/src/spinner_state_machine.cpp
+++ b/modules/concurrency/src/spinner_state_machine.cpp
@@ -6,12 +6,14 @@
 
 #include <utility>
 
+#include <sys/stat.h>
+
 namespace heph::concurrency::spinner_state_machine {
 
 namespace {
 struct OperationParams {
   OperationCallbackT& operation;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
-  State success_state;
+  State proceed_state;
   State failure_state;
 };
 
@@ -19,8 +21,8 @@ struct OperationParams {
   const auto result = params.operation();
 
   switch (result) {
-    case Result::SUCCESS:
-      return params.success_state;
+    case Result::PROCEED:
+      return params.proceed_state;
     case Result::FAILURE:
       return params.failure_state;
     case Result::REPEAT:
@@ -30,25 +32,23 @@ struct OperationParams {
 }  // namespace
 
 auto createStateMachineCallback(Callbacks&& callbacks) -> StateMachineCallbackT {
-  auto execute_state_transition = [callbacks = std::move(callbacks)](State state) -> State {
-    switch (state) {
-      case State::NOT_INITIALIZED:
-        return executeOperation(state, OperationParams{ .operation = callbacks.init_cb,
-                                                        .success_state = State::READY_TO_SPIN,
-                                                        .failure_state = State::FAILED });
-      case State::READY_TO_SPIN:
-        return executeOperation(state, OperationParams{ .operation = callbacks.spin_once_cb,
-                                                        .success_state = State::SPIN_SUCCESSFUL,
-                                                        .failure_state = State::FAILED });
-      case State::FAILED:
-        return callbacks.shall_restart_cb() ? State::NOT_INITIALIZED : State::EXIT;
-      default:
-        return state;
+  return [callbacks = std::move(callbacks), state = State::NOT_INITIALIZED]() mutable -> State {
+    // Ensure that either init or spin once is called in one spin iteration, but not both.
+    if (state == State::NOT_INITIALIZED) {
+      state = executeOperation(state, OperationParams{ .operation = callbacks.init_cb,
+                                                       .proceed_state = State::READY_TO_SPIN,
+                                                       .failure_state = State::FAILED });
+    } else if (state == State::READY_TO_SPIN) {
+      state = executeOperation(state, OperationParams{ .operation = callbacks.spin_once_cb,
+                                                       .proceed_state = State::EXIT,
+                                                       .failure_state = State::FAILED });
     }
-  };
 
-  return [&execute_state_transition, state = State::NOT_INITIALIZED]() mutable -> State {
-    state = execute_state_transition(state);
+    // Shall restart is called after failure, within the same spin iteration.
+    if (state == State::FAILED) {
+      state = callbacks.shall_restart_cb() ? State::NOT_INITIALIZED : State::EXIT;
+    }
+
     return state;
   };
 }

--- a/modules/concurrency/tests/CMakeLists.txt
+++ b/modules/concurrency/tests/CMakeLists.txt
@@ -1,24 +1,31 @@
-#=================================================================================================
+# =================================================================================================
 # Copyright (C) 2023-2024 HEPHAESTUS Contributors
-#=================================================================================================
+# =================================================================================================
 
 define_module_test(
-        NAME queue_consumer_tests
-        SOURCES queue_consumer_tests.cpp
-        PUBLIC_INCLUDE_PATHS
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-        PUBLIC_LINK_LIBS hephaestus::random)
+  NAME queue_consumer_tests
+  SOURCES queue_consumer_tests.cpp
+  PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  PUBLIC_LINK_LIBS hephaestus::random
+)
 
 define_module_test(
-        NAME spinner_tests
-        SOURCES spinner_tests.cpp
-        PUBLIC_INCLUDE_PATHS
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-        PUBLIC_LINK_LIBS "")
+  NAME spinner_state_machine_tests
+  SOURCES spinner_state_machine_tests.cpp
+  PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  PUBLIC_LINK_LIBS ""
+)
 
 define_module_test(
-        NAME spinners_manager_tests
-        SOURCES spinners_manager_tests.cpp
-        PUBLIC_INCLUDE_PATHS
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-        PUBLIC_LINK_LIBS "")
+  NAME spinner_tests
+  SOURCES spinner_tests.cpp
+  PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  PUBLIC_LINK_LIBS ""
+)
+
+define_module_test(
+  NAME spinners_manager_tests
+  SOURCES spinners_manager_tests.cpp
+  PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  PUBLIC_LINK_LIBS ""
+)

--- a/modules/concurrency/tests/spinner_state_machine_tests.cpp
+++ b/modules/concurrency/tests/spinner_state_machine_tests.cpp
@@ -2,6 +2,8 @@
 // Copyright (C) 2023-2024 HEPHAESTUS Contributors
 //=================================================================================================
 
+#include <cstddef>
+
 #include <gtest/gtest.h>
 
 #include "hephaestus/concurrency/spinner_state_machine.h"
@@ -12,9 +14,9 @@ TEST(SpinnerStateMachineTest, TestCallback) {
   static constexpr std::size_t MAX_ITERATION_COUNT = 10ul;
 
   std::size_t init_counter = 0;
-  std::size_t successful_spin_counter = 0;
-  std::size_t total_spin_counter = 0;
-  std::size_t shall_stop_spinning_repeat_counter = 0;
+  std::size_t init_repeat_counter = 0;
+  std::size_t spin_once_repeat_counter = 0;
+  std::size_t total_spin_once_counter = 0;
   std::size_t state_machine_counter = 0;
 
   // Create a spinner state machine. Policies:
@@ -23,41 +25,31 @@ TEST(SpinnerStateMachineTest, TestCallback) {
   // We thus expect to see three initializations and MAX_ITERATION_COUNT spins.
   // A state_machine_counter is used to verify that each callback is called once per iteration.
   auto callbacks =
-      Callbacks{ .init_cb = [&init_counter, &state_machine_counter]() -> CallbackResult {
+      Callbacks{ .init_cb = [&init_counter, &state_machine_counter, &init_repeat_counter]() -> Result {
                   ++state_machine_counter;
                   ++init_counter;
                   if (init_counter == 1) {
-                    return CallbackResult::FAILURE;
+                    return Result::FAILURE;
                   }
-                  return CallbackResult::SUCCESS;
+                  if (init_counter == 2) {
+                    ++init_repeat_counter;
+                    return Result::REPEAT;
+                  }
+                  return Result::PROCEED;
                 },
 
-                 .spin_once_cb = [&successful_spin_counter, &total_spin_counter,
-                                  &state_machine_counter]() -> CallbackResult {
+                 .spin_once_cb = [&spin_once_repeat_counter, &total_spin_once_counter,
+                                  &state_machine_counter]() -> Result {
                    ++state_machine_counter;
-                   ++total_spin_counter;
-                   if (total_spin_counter == 1) {
-                     return CallbackResult::FAILURE;
+                   ++total_spin_once_counter;
+                   if (total_spin_once_counter == 1) {
+                     return Result::FAILURE;
                    }
-                   ++successful_spin_counter;
-                   return CallbackResult::SUCCESS;
+                   ++spin_once_repeat_counter;
+                   return spin_once_repeat_counter < MAX_ITERATION_COUNT ? Result::REPEAT : Result::PROCEED;
                  },
 
-                 .shall_stop_spinning_cb = [&successful_spin_counter, &shall_stop_spinning_repeat_counter,
-                                            &state_machine_counter]() -> ExecutionDirective {
-                   ++state_machine_counter;
-                   if (shall_stop_spinning_repeat_counter < 1) {
-                     ++shall_stop_spinning_repeat_counter;
-                     return ExecutionDirective::REPEAT;
-                   }
-                   return successful_spin_counter < MAX_ITERATION_COUNT ? ExecutionDirective::FALSE :
-                                                                          ExecutionDirective::TRUE;
-                 },
-
-                 .shall_restart_cb = [&state_machine_counter]() -> ExecutionDirective {
-                   ++state_machine_counter;
-                   return ExecutionDirective::TRUE;
-                 } };
+                 .shall_restart_cb = []() -> bool { return true; } };
 
   auto callback = createStateMachineCallback(std::move(callbacks));
 
@@ -69,10 +61,10 @@ TEST(SpinnerStateMachineTest, TestCallback) {
   }
   EXPECT_EQ(state, State::EXIT);
 
-  EXPECT_EQ(init_counter, 3);  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-  EXPECT_EQ(shall_stop_spinning_repeat_counter, 1);
-  EXPECT_EQ(successful_spin_counter, MAX_ITERATION_COUNT);
-  EXPECT_EQ(total_spin_counter, MAX_ITERATION_COUNT + 1);
+  EXPECT_EQ(init_counter, 3 + init_repeat_counter);  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+  EXPECT_EQ(init_repeat_counter, 1);
+  EXPECT_EQ(spin_once_repeat_counter, MAX_ITERATION_COUNT);
+  EXPECT_EQ(total_spin_once_counter, spin_once_repeat_counter + 1);
   EXPECT_EQ(state_machine_counter, callback_counter);
 }
 

--- a/modules/concurrency/tests/spinner_state_machine_tests.cpp
+++ b/modules/concurrency/tests/spinner_state_machine_tests.cpp
@@ -1,0 +1,56 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#include <gtest/gtest.h>
+
+#include "hephaestus/concurrency/spinner.h"
+
+namespace heph::concurrency::tests {
+
+// TEST(SpinnerTest, StateMachine) {
+//   size_t init_counter = 0;
+//   size_t successful_spin_counter = 0;
+//   size_t total_spin_counter = 0;
+
+//   // Create a spinner with a state machine. Policies:
+//   // The spinner will restart indefinitely upon failure.
+//   // Both init and spin once will fail once, on the first iteration.
+//   // We thus expect to see three initializations and MAX_ITERATION_COUNT spins.
+//   auto callbacks = Spinner::StateMachineCallbacks{
+//     .init_cb =
+//         [&init_counter]() {
+//           {
+//             ++init_counter;
+//             if (init_counter == 1) [[unlikely]] {
+//               throw InvalidOperationException{ "Init failed.", std::source_location::current() };
+//             }
+//           }
+//         },
+//     .spin_once_cb =
+//         [&successful_spin_counter, &total_spin_counter]() {
+//           ++total_spin_counter;
+//           if (total_spin_counter == 1) [[unlikely]] {
+//             throw InvalidOperationException{ "Spin failed.", std::source_location::current() };
+//           }
+//           ++successful_spin_counter;
+//         },
+//     .shall_stop_spinning_cb =
+//         [&successful_spin_counter]() { return successful_spin_counter < MAX_ITERATION_COUNT ? false : true;
+//         },
+//     .shall_restart_cb = []() { return true; }
+//   };
+
+//   auto cb = Spinner::createCallbackWithStateMachine(std::move(callbacks));
+//   Spinner spinner(std::move(cb));
+
+//   spinner.start();
+//   spinner.wait();
+//   spinner.stop().get();
+
+//   EXPECT_EQ(init_counter, 3);  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+//   EXPECT_EQ(successful_spin_counter, MAX_ITERATION_COUNT);
+//   EXPECT_EQ(total_spin_counter, MAX_ITERATION_COUNT + 1);
+// }
+
+}  // namespace heph::concurrency::tests

--- a/modules/concurrency/tests/spinner_state_machine_tests.cpp
+++ b/modules/concurrency/tests/spinner_state_machine_tests.cpp
@@ -4,53 +4,76 @@
 
 #include <gtest/gtest.h>
 
-#include "hephaestus/concurrency/spinner.h"
+#include "hephaestus/concurrency/spinner_state_machine.h"
 
-namespace heph::concurrency::tests {
+namespace heph::concurrency::spinner_state_machine::tests {
 
-// TEST(SpinnerTest, StateMachine) {
-//   size_t init_counter = 0;
-//   size_t successful_spin_counter = 0;
-//   size_t total_spin_counter = 0;
+TEST(SpinnerStateMachineTest, TestCallback) {
+  static constexpr std::size_t MAX_ITERATION_COUNT = 10ul;
 
-//   // Create a spinner with a state machine. Policies:
-//   // The spinner will restart indefinitely upon failure.
-//   // Both init and spin once will fail once, on the first iteration.
-//   // We thus expect to see three initializations and MAX_ITERATION_COUNT spins.
-//   auto callbacks = Spinner::StateMachineCallbacks{
-//     .init_cb =
-//         [&init_counter]() {
-//           {
-//             ++init_counter;
-//             if (init_counter == 1) [[unlikely]] {
-//               throw InvalidOperationException{ "Init failed.", std::source_location::current() };
-//             }
-//           }
-//         },
-//     .spin_once_cb =
-//         [&successful_spin_counter, &total_spin_counter]() {
-//           ++total_spin_counter;
-//           if (total_spin_counter == 1) [[unlikely]] {
-//             throw InvalidOperationException{ "Spin failed.", std::source_location::current() };
-//           }
-//           ++successful_spin_counter;
-//         },
-//     .shall_stop_spinning_cb =
-//         [&successful_spin_counter]() { return successful_spin_counter < MAX_ITERATION_COUNT ? false : true;
-//         },
-//     .shall_restart_cb = []() { return true; }
-//   };
+  std::size_t init_counter = 0;
+  std::size_t successful_spin_counter = 0;
+  std::size_t total_spin_counter = 0;
+  std::size_t shall_stop_spinning_repeat_counter = 0;
+  std::size_t state_machine_counter = 0;
 
-//   auto cb = Spinner::createCallbackWithStateMachine(std::move(callbacks));
-//   Spinner spinner(std::move(cb));
+  // Create a spinner state machine. Policies:
+  // The state machine will restart indefinitely upon failure.
+  // Both init and spin once will fail once, on the first iteration.
+  // We thus expect to see three initializations and MAX_ITERATION_COUNT spins.
+  // A state_machine_counter is used to verify that each callback is called once per iteration.
+  auto callbacks =
+      Callbacks{ .init_cb = [&init_counter, &state_machine_counter]() -> CallbackResult {
+                  ++state_machine_counter;
+                  ++init_counter;
+                  if (init_counter == 1) {
+                    return CallbackResult::FAILURE;
+                  }
+                  return CallbackResult::SUCCESS;
+                },
 
-//   spinner.start();
-//   spinner.wait();
-//   spinner.stop().get();
+                 .spin_once_cb = [&successful_spin_counter, &total_spin_counter,
+                                  &state_machine_counter]() -> CallbackResult {
+                   ++state_machine_counter;
+                   ++total_spin_counter;
+                   if (total_spin_counter == 1) {
+                     return CallbackResult::FAILURE;
+                   }
+                   ++successful_spin_counter;
+                   return CallbackResult::SUCCESS;
+                 },
 
-//   EXPECT_EQ(init_counter, 3);  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-//   EXPECT_EQ(successful_spin_counter, MAX_ITERATION_COUNT);
-//   EXPECT_EQ(total_spin_counter, MAX_ITERATION_COUNT + 1);
-// }
+                 .shall_stop_spinning_cb = [&successful_spin_counter, &shall_stop_spinning_repeat_counter,
+                                            &state_machine_counter]() -> ExecutionDirective {
+                   ++state_machine_counter;
+                   if (shall_stop_spinning_repeat_counter < 1) {
+                     ++shall_stop_spinning_repeat_counter;
+                     return ExecutionDirective::REPEAT;
+                   }
+                   return successful_spin_counter < MAX_ITERATION_COUNT ? ExecutionDirective::FALSE :
+                                                                          ExecutionDirective::TRUE;
+                 },
 
-}  // namespace heph::concurrency::tests
+                 .shall_restart_cb = [&state_machine_counter]() -> ExecutionDirective {
+                   ++state_machine_counter;
+                   return ExecutionDirective::TRUE;
+                 } };
+
+  auto callback = createStateMachineCallback(std::move(callbacks));
+
+  auto state = State{};
+  static constexpr auto LOOP_BOUND = 10 * MAX_ITERATION_COUNT;
+  std::size_t callback_counter = 0;
+  for (; state != State::EXIT && callback_counter < LOOP_BOUND; ++callback_counter) {
+    state = callback();
+  }
+  EXPECT_EQ(state, State::EXIT);
+
+  EXPECT_EQ(init_counter, 3);  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+  EXPECT_EQ(shall_stop_spinning_repeat_counter, 1);
+  EXPECT_EQ(successful_spin_counter, MAX_ITERATION_COUNT);
+  EXPECT_EQ(total_spin_counter, MAX_ITERATION_COUNT + 1);
+  EXPECT_EQ(state_machine_counter, callback_counter);
+}
+
+}  // namespace heph::concurrency::spinner_state_machine::tests

--- a/modules/concurrency/tests/spinner_tests.cpp
+++ b/modules/concurrency/tests/spinner_tests.cpp
@@ -194,48 +194,4 @@ TEST(SpinnerTest, SpinStartAfterStop) {
   EXPECT_EQ(callback_called_counter, MAX_ITERATION_COUNT);
 }
 
-TEST(SpinnerTest, StateMachine) {
-  size_t init_counter = 0;
-  size_t successful_spin_counter = 0;
-  size_t total_spin_counter = 0;
-
-  // Create a spinner with a state machine. Policies:
-  // The spinner will restart indefinitely upon failure.
-  // Both init and spin once will fail once, on the first iteration.
-  // We thus expect to see three initializations and MAX_ITERATION_COUNT spins.
-  auto callbacks = Spinner::StateMachineCallbacks{
-    .init_cb =
-        [&init_counter]() {
-          {
-            ++init_counter;
-            if (init_counter == 1) [[unlikely]] {
-              throw InvalidOperationException{ "Init failed.", std::source_location::current() };
-            }
-          }
-        },
-    .spin_once_cb =
-        [&successful_spin_counter, &total_spin_counter]() {
-          ++total_spin_counter;
-          if (total_spin_counter == 1) [[unlikely]] {
-            throw InvalidOperationException{ "Spin failed.", std::source_location::current() };
-          }
-          ++successful_spin_counter;
-        },
-    .shall_stop_spinning_cb =
-        [&successful_spin_counter]() { return successful_spin_counter < MAX_ITERATION_COUNT ? false : true; },
-    .shall_restart_cb = []() { return true; }
-  };
-
-  auto cb = Spinner::createCallbackWithStateMachine(std::move(callbacks));
-  Spinner spinner(std::move(cb));
-
-  spinner.start();
-  spinner.wait();
-  spinner.stop().get();
-
-  EXPECT_EQ(init_counter, 3);  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-  EXPECT_EQ(successful_spin_counter, MAX_ITERATION_COUNT);
-  EXPECT_EQ(total_spin_counter, MAX_ITERATION_COUNT + 1);
-}
-
 }  // namespace heph::concurrency::tests


### PR DESCRIPTION
# Description
* Change transition logic in the spinner state machine to use states instead of exceptions.
* Move spinner state machine inside a standalone file, as the `Spinner` is independent of the state machine (but not the other way around)

## Type of change
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
