### PR TITLE
Make TypeInfo service creation a free function

### DIFF
--- a/modules/ipc/src/zenoh/service.cpp
+++ b/modules/ipc/src/zenoh/service.cpp
@@ -90,4 +90,30 @@ auto isEndpointTypeInfoServiceTopic(const std::string& topic) -> bool {
 
   return elements.front() == TOPIC_INFO_SERVICE_TOPIC_PREFIX;
 }
+
+auto createTypeInfoService(std::shared_ptr<Session>& session, const TopicConfig& topic_config,
+                           Service<std::string, std::string>::Callback&& callback)
+    -> std::unique_ptr<Service<std::string, std::string>> {
+  if (isEndpointTypeInfoServiceTopic(topic_config.name)) {
+    return nullptr;
+  }
+
+  auto failure_callback = [&topic_config]() {
+    heph::log(heph::ERROR, "Failed to process type info service", "service_topic", topic_config.name);
+  };
+
+  auto post_reply_callback = []() {
+    // Do nothing.
+  };
+
+  ServiceConfig service_config = {
+    .create_liveliness_token = false,
+    .create_type_info_service = false,
+  };
+
+  return std::make_unique<Service<std::string, std::string>>(
+      session, TopicConfig{ getEndpointTypeInfoServiceTopic(topic_config.name) }, std::move(callback),
+      failure_callback, post_reply_callback, service_config);
+}
+
 }  // namespace heph::ipc::zenoh


### PR DESCRIPTION
# Description

Last time we upgraded heph, we ran into this issue here on our side:

```
communication/ipc/ipc/include/ipc/impl/general.h:30:66: error: no type named 'Type' in 'proto_serialization::ProtoAssociation<std::string>'
   30 |   using Type = proto_serialization::ProtoAssociation<ProtoType>::Type;
```
IIRC it was an issue that originated from a unlucky combination of:
 - createTypeInfoService being defined in the header due to it being a member variable of a templated class (Service)
 - the include order of some serdes related header
 We fixed it by moving this function out of Service into a free function, as it doesn't need to be templated at all.

The change should be non-breaking.

As a side note: We also discussed that the proper way would likely be refactoring the Service<T1, T2> into RawService and Service<T1, T2> like it is done with Publisher/Subscriber -> RawPublisher / RawSubscriber. This would have also fixed it since type advertisement could be part of the RawService class. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
