### PR TITLE
[feat] add formatter for enum

### DIFF
--- a/modules/format/BUILD
+++ b/modules/format/BUILD
@@ -19,6 +19,7 @@ heph_cc_library(
     deps = [
         "//modules/utils",
         "@fmt",
+        "@magic_enum",
         "@reflect-cpp",
     ],
 )

--- a/modules/format/CMakeLists.txt
+++ b/modules/format/CMakeLists.txt
@@ -10,17 +10,17 @@ declare_module(
 
 find_package(fmt REQUIRED)
 find_package(reflectcpp REQUIRED)
+find_package(magic_enum REQUIRED)
 
 # library sources
-set(SOURCES src/generic_formatter.cpp README.md include/hephaestus/format/generic_formatter.h)
+set(SOURCES src/generic_formatter.cpp README.md include/hephaestus/format/generic_formatter.h
+            include/hephaestus/format/enum.h
+)
 
 # library target
 define_module_library(
   NAME format
-  PUBLIC_LINK_LIBS
-    fmt::fmt
-    hephaestus::utils
-    reflectcpp::reflectcpp
+  PUBLIC_LINK_LIBS fmt::fmt hephaestus::utils reflectcpp::reflectcpp magic_enum::magic_enum
   PRIVATE_LINK_LIBS ""
   SOURCES ${SOURCES}
   PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>

--- a/modules/format/include/hephaestus/format/enum.h
+++ b/modules/format/include/hephaestus/format/enum.h
@@ -1,0 +1,22 @@
+//=================================================================================================
+// Copyright (C) 2025 HEPHAESTUS Contributors
+//=================================================================================================
+#pragma once
+
+#include <string>
+#include <type_traits>
+
+#include <fmt/base.h>
+#include <magic_enum.hpp>
+
+template <typename T>
+concept EnumType = std::is_enum_v<T>;
+
+// Specialization of fmt::formatter for any enum type
+template <EnumType E>
+struct fmt::formatter<E> : fmt::formatter<std::string> {
+  template <typename FormatContext>
+  auto format(E value, FormatContext& ctx) const {
+    return fmt::format_to(ctx.out(), "{}", magic_enum::enum_name(value));
+  }
+};

--- a/modules/format/include/hephaestus/format/generic_formatter.h
+++ b/modules/format/include/hephaestus/format/generic_formatter.h
@@ -16,6 +16,7 @@
 #include <rfl/internal/has_reflector.hpp>
 #include <rfl/yaml.hpp>  // NOLINT(misc-include-cleaner)
 
+#include "hephaestus/format/enum.h"  // NOLINT(misc-include-cleaner)
 #include "hephaestus/utils/concepts.h"
 #include "hephaestus/utils/format/format.h"
 

--- a/modules/format/tests/generic_formatter_tests.cpp
+++ b/modules/format/tests/generic_formatter_tests.cpp
@@ -11,6 +11,7 @@
 #include <gtest/gtest.h>
 #include <rfl.hpp>  // NOLINT(misc-include-cleaner)
 
+#include "hephaestus/format/enum.h"
 #include "hephaestus/format/generic_formatter.h"
 #include "hephaestus/types/bounds.h"
 // This is part of the test, since if operator<< is defined this will not compile due to conflicts
@@ -115,6 +116,25 @@ TEST(GenericFormatterTests, TestFormatStructWithBounds) {
   // Dummy test if the custom formatters can be compiled
   fmt::println("test: {}", x);
   std::cout << "cout: " << x << "\n" << std::flush;
+}
+
+TEST(GenericFormatterTests, TestFormatStructEnums) {
+  enum class TestEnum : std::uint8_t { A, B, C };
+
+  const std::string formatted = fmt::format("test enum {}", TestEnum::A);
+  EXPECT_NE(formatted.find("A"), std::string::npos);
+
+  struct S {
+    std::string a = "test_value";
+    TestEnum b = TestEnum::B;
+  };
+
+  S x{};
+
+  const std::string formatted2 = fmt::format("{}", x);
+
+  EXPECT_NE(formatted2.find("B"), std::string::npos);
+  EXPECT_NE(formatted2.find("test_value"), std::string::npos);
 }
 
 TEST(GenericFormatterTests, TestFormatStructArray) {

--- a/modules/types/BUILD
+++ b/modules/types/BUILD
@@ -40,5 +40,7 @@ heph_cc_test(
 heph_cc_test(
     name = "tests",
     srcs = ["tests/tests.cpp"],
-    deps = TYPES_TEST_DEPS,
+    deps = TYPES_TEST_DEPS + [
+        "//modules/format",
+    ],
 )

--- a/modules/types/CMakeLists.txt
+++ b/modules/types/CMakeLists.txt
@@ -20,11 +20,7 @@ set(SOURCES src/bounds.cpp src/dummy_type.cpp README.md include/hephaestus/types
 # library target
 define_module_library(
   NAME types
-  PUBLIC_LINK_LIBS
-    fmt::fmt
-    hephaestus::random
-    magic_enum::magic_enum
-    range-v3::range-v3
+  PUBLIC_LINK_LIBS fmt::fmt hephaestus::random magic_enum::magic_enum range-v3::range-v3
   PRIVATE_LINK_LIBS ""
   SOURCES ${SOURCES}
   PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>

--- a/modules/types/include/hephaestus/types/dummy_type.h
+++ b/modules/types/include/hephaestus/types/dummy_type.h
@@ -6,13 +6,9 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
 #include <random>
 #include <string>
 #include <vector>
-
-#include <fmt/base.h>
-#include <fmt/ostream.h>
 
 namespace heph::types {
 
@@ -40,8 +36,6 @@ struct DummyPrimitivesType {
   double dummy_double{};
 };
 
-auto operator<<(std::ostream& os, const DummyPrimitivesType& dummy_primitives_type) -> std::ostream&;
-
 enum class ExternalDummyEnum : int8_t { A, B, C, D, E, F, G };
 
 /// @brief Collection of non-primitive types for testing purposes.
@@ -63,14 +57,4 @@ struct DummyType {
   std::vector<int32_t> dummy_vector;
 };
 
-auto operator<<(std::ostream& os, const DummyType& dummy_type) -> std::ostream&;
-
 }  // namespace heph::types
-
-namespace fmt {
-template <>
-struct formatter<heph::types::DummyPrimitivesType> : ostream_formatter {};
-
-template <>
-struct formatter<heph::types::DummyType> : ostream_formatter {};
-}  // namespace fmt

--- a/modules/types/src/dummy_type.cpp
+++ b/modules/types/src/dummy_type.cpp
@@ -5,11 +5,9 @@
 #include "hephaestus/types/dummy_type.h"
 
 #include <cstdint>
-#include <iostream>
 #include <random>
 
 #include "hephaestus/random/random_object_creator.h"
-#include "hephaestus/utils/format/format.h"
 
 namespace heph::types {
 
@@ -27,39 +25,12 @@ auto DummyPrimitivesType::random(std::mt19937_64& mt) -> DummyPrimitivesType {
            .dummy_double = random::random<double>(mt) };
 }
 
-auto operator<<(std::ostream& os, const DummyPrimitivesType& dummy_primitives_type) -> std::ostream& {
-  return os << "DummyPrimitivesType{"
-            << "\n"
-            << "  dummy_bool=" << dummy_primitives_type.dummy_bool << "\n"
-            << "  dummy_int8_t=" << static_cast<int>(dummy_primitives_type.dummy_int8_t) << "\n"
-            << "  dummy_int16_t=" << dummy_primitives_type.dummy_int16_t << "\n"
-            << "  dummy_int32_t=" << dummy_primitives_type.dummy_int32_t << "\n"
-            << "  dummy_int64_t=" << dummy_primitives_type.dummy_int64_t << "\n"
-            << "  dummy_uint8_t=" << static_cast<int>(dummy_primitives_type.dummy_uint8_t) << "\n"
-            << "  dummy_uint16_t=" << dummy_primitives_type.dummy_uint16_t << "\n"
-            << "  dummy_uint32_t=" << dummy_primitives_type.dummy_uint32_t << "\n"
-            << "  dummy_uint64_t=" << dummy_primitives_type.dummy_uint64_t << "\n"
-            << "  dummy_float=" << dummy_primitives_type.dummy_float << "\n"
-            << "  dummy_double=" << dummy_primitives_type.dummy_double << "\n"
-            << "}";
-}
-
 auto DummyType::random(std::mt19937_64& mt) -> DummyType {
   return { .dummy_primitives_type = random::random<decltype(dummy_primitives_type)>(mt),
            .internal_dummy_enum = random::random<decltype(internal_dummy_enum)>(mt),
            .external_dummy_enum = random::random<decltype(external_dummy_enum)>(mt),
            .dummy_string = random::random<decltype(dummy_string)>(mt),
            .dummy_vector = random::random<decltype(dummy_vector)>(mt) };
-}
-
-auto operator<<(std::ostream& os, const DummyType& dummy_type) -> std::ostream& {
-  return os << "DummyType{\n"
-            << "  dummy_primitives_type={" << dummy_type.dummy_primitives_type << "}\n"
-            << "  internal_dummy_enum=" << utils::format::toString(dummy_type.internal_dummy_enum) << "\n"
-            << "  external_dummy_enum=" << utils::format::toString(dummy_type.external_dummy_enum) << "\n"
-            << "  dummy_string=" << dummy_type.dummy_string << "\n"
-            << "  dummy_vector=" << utils::format::toString(dummy_type.dummy_vector) << "\n"
-            << "}";
 }
 
 }  // namespace heph::types

--- a/modules/types/tests/CMakeLists.txt
+++ b/modules/types/tests/CMakeLists.txt
@@ -2,12 +2,10 @@
 # Copyright (C) 2023-2024 HEPHAESTUS Contributors
 # =================================================================================================
 
-define_module_test(
-  NAME bounds_tests
-  SOURCES bounds_tests.cpp
-)
+define_module_test(NAME bounds_tests SOURCES bounds_tests.cpp)
 
 define_module_test(
   NAME tests
   SOURCES tests.cpp
+  PUBLIC_LINK_LIBS hephaestus::format
 )

--- a/modules/types/tests/tests.cpp
+++ b/modules/types/tests/tests.cpp
@@ -9,6 +9,7 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include "hephaestus/format/generic_formatter.h"  // NOLINT(misc-include-cleaner)
 #include "hephaestus/random/random_number_generator.h"
 #include "hephaestus/types/bounds.h"
 #include "hephaestus/types/dummy_type.h"


### PR DESCRIPTION
# Description

As per request of @lhruby I added a formatter for enum proxying magic enum.
Just add include it and you should be good to go.
Also works together with generic_formatter as can be seen in the tests.

## Type of change

- New feature (non-breaking change which adds functionality)


## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

