### PR TITLE
Split types unit tests dep on format module

### DIFF
--- a/modules/format/BUILD
+++ b/modules/format/BUILD
@@ -59,3 +59,12 @@ heph_cc_test(
         ":format",
     ],
 )
+
+heph_cc_test(
+    name = "types_formatter_tests",
+    srcs = ["tests/types_formatter_tests.cpp"],
+    deps = [
+        ":format",
+        "//modules/types",
+    ],
+)

--- a/modules/format/tests/CMakeLists.txt
+++ b/modules/format/tests/CMakeLists.txt
@@ -7,3 +7,15 @@ define_module_test(
   SOURCES generic_formatter_tests.cpp
   PUBLIC_LINK_LIBS hephaestus::types hephaestus::types_proto
 )
+
+define_module_test(
+  NAME formatter_collisions_tests
+  SOURCES formatter_collisions_tests.cpp
+  PUBLIC_LINK_LIBS ""
+)
+
+define_module_test(
+  NAME types_formatter_tests
+  SOURCES types_formatter_tests.cpp
+  PUBLIC_LINK_LIBS hephaestus::types
+)

--- a/modules/format/tests/types_formatter_tests.cpp
+++ b/modules/format/tests/types_formatter_tests.cpp
@@ -1,3 +1,5 @@
+
+
 //=================================================================================================
 // Copyright (C) 2023-2024 HEPHAESTUS Contributors
 //=================================================================================================
@@ -8,31 +10,39 @@
 
 #include <fmt/format.h>
 #include <gtest/gtest.h>
+#include <hephaestus/types/bounds.h>
+#include <hephaestus/types/dummy_type.h>
 
-#include "hephaestus/random/random_number_generator.h"
-#include "hephaestus/types/bounds.h"
-#include "hephaestus/types/dummy_type.h"
+#include "hephaestus/format/generic_formatter.h"  // NOLINT(misc-include-cleaner)
 
 // NOLINTNEXTLINE(google-build-using-namespace)
 using namespace ::testing;
 
 namespace heph::types::tests {
 
+template <class T>
+class TypeFormatTests : public ::testing::Test {};
+
 using IntegerBoundsT = Bounds<int32_t>;
 using FloatingPointBoundsT = Bounds<float>;
-
-/* --- Test all custom structs which support creation via a random member function --- */
-template <class T>
-class TypeTests : public ::testing::Test {};
 using TypeImplementations = ::testing::Types<IntegerBoundsT, FloatingPointBoundsT, DummyType>;
 
-TYPED_TEST_SUITE(TypeTests, TypeImplementations);
+TYPED_TEST_SUITE(TypeFormatTests, TypeImplementations);
 
-TYPED_TEST(TypeTests, RandomUnequalTest) {
-  auto [mt, mt_copy] = heph::random::createPairOfIdenticalRNGs();
+TYPED_TEST(TypeFormatTests, OstreamTest) {
+  const TypeParam type;
+  std::stringstream ss;
+  EXPECT_TRUE(ss.str().empty());
+  ss << type;
+  EXPECT_FALSE(ss.str().empty());
+}
 
-  EXPECT_EQ(TypeParam::random(mt), TypeParam::random(mt_copy));  // Ensure determinism
-  EXPECT_NE(TypeParam::random(mt), TypeParam::random(mt));       // Ensure randomness
+TYPED_TEST(TypeFormatTests, FmtFormatTest) {
+  TypeParam type;
+  std::string fmt_stream;
+  EXPECT_TRUE(fmt_stream.empty());
+  fmt_stream = fmt::format("{}", type);
+  EXPECT_FALSE(fmt_stream.empty());
 }
 
 }  // namespace heph::types::tests

--- a/modules/types/tests/CMakeLists.txt
+++ b/modules/types/tests/CMakeLists.txt
@@ -7,5 +7,5 @@ define_module_test(NAME bounds_tests SOURCES bounds_tests.cpp)
 define_module_test(
   NAME tests
   SOURCES tests.cpp
-  PUBLIC_LINK_LIBS hephaestus::format
+  PUBLIC_LINK_LIBS ""
 )


### PR DESCRIPTION
# Description

The new types unit test introduced an unwanted dependency between types and format.
This PR splits the unit test and also added a missing unit test to the CMakeLists.txt

## Type of change

- Bug fix (non-breaking change which fixes an issue)
