### PR TITLE
Pass service timout from ws client to ws bridge/ipc call

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -58,5 +58,5 @@ def foreign_cc_repositories():
         build_file = ":foreign_cc/ws_protocol.BUILD",
         urls = ["https://github.com/olympus-robotics/ws-protocol/archive/refs/tags/{tag}.zip".format(tag = WS_PROTOCOL_TAG)],
         strip_prefix = "ws-protocol-releases-cpp-v" + WS_PROTOCOL_VERSION,
-        sha256 = "86bd5743098825822b26b0459f4115b86694fdc86398ba7e84e296b6af4bdc23",
+        sha256 = "1c7d7b874f2e20d841cd04391d9d0be507ccb75b22f84b65a0fc61a30ac30651",
     )

--- a/modules/websocket_bridge/config/ws_bridge-config.yaml
+++ b/modules/websocket_bridge/config/ws_bridge-config.yaml
@@ -15,7 +15,7 @@ ws_server_config:
   certfile: ""
   keyfile: ""
   sessionId: websocket_bridge
-  numWorkerThreads: 10
+  numWorkerThreads: 20
   useCompression: true
   clientTopicWhitelistPatterns:
     - .*
@@ -37,9 +37,9 @@ zenoh_config:
   multicast_scouting_enabled: true
   multicast_scouting_interface: auto
 
-ipc_service_call_timeout_ms: 10000
-# Async service calls are currently not supported.
-ipc_service_service_request_async: true
+ipc_default_service_call_timeout_ms: 100
+
+ipc_service_service_request_async: false
 
 ipc_advertise_topics_based_on_subscribers: true
 

--- a/modules/websocket_bridge/examples/example_client__services.cpp
+++ b/modules/websocket_bridge/examples/example_client__services.cpp
@@ -34,11 +34,11 @@ using heph::ws::WsServiceFailure;
 using heph::ws::WsServiceRequest;
 using heph::ws::WsServiceResponse;
 
-constexpr int SERVICE_REQUEST_COUNT = 8;
+constexpr int SERVICE_REQUEST_COUNT = 20;
 constexpr int SPINNING_SLEEP_DURATION_MS = 1000;
 constexpr int LAUNCHING_SLEEP_DURATION_MS = 0;
 constexpr int RESPONSE_WAIT_DURATION_S = 1;
-
+constexpr int SERVCE_CALL_TIMEOUT_MS = 1000;
 namespace {
 
 std::atomic<bool> g_abort{ false };  // NOLINT
@@ -69,6 +69,8 @@ void handleBinaryMessage(const uint8_t* data, size_t length, WsAdvertisements& w
       heph::log(heph::ERROR, "Failed to deserialize service response", "exception", e.what());
       return;
     }
+
+    auto lock = state.scopedLock();
 
     // Check that we already have dispatched a service call with this ID.
     auto state_it = state.find(response.callId);
@@ -107,6 +109,8 @@ void handleJsonMessage(const std::string& json_msg, WsAdvertisements& ws_server_
     heph::log(heph::ERROR, "Service call failed with error.", "call_id", service_failure.call_id,
               "error_message", service_failure.error_message);
 
+    auto lock = state.scopedLock();
+
     auto state_it = state.find(service_failure.call_id);
     if (state_it == state.end()) {
       heph::log(heph::ERROR, "No record of a service call with this id.", "call_id", service_failure.call_id);
@@ -125,6 +129,7 @@ void sendTestServiceRequests(WsClientNoTls& client, const WsServiceAd& foxglove_
     WsServiceRequest request;
     request.callId = static_cast<uint32_t>(i);
     request.serviceId = foxglove_service_id;
+    request.timeoutMs = SERVCE_CALL_TIMEOUT_MS;
 
     if (!foxglove_service.request.has_value()) {
       fmt::println("Service '{}' has no request definition", foxglove_service.name);
@@ -154,8 +159,12 @@ void sendTestServiceRequests(WsClientNoTls& client, const WsServiceAd& foxglove_
     request.data.assign(message_buffer.begin(), message_buffer.end());
     request.encoding = "protobuf";
 
-    // Init the service call as dispatched.
-    state.emplace(request.callId, ServiceCallState(request.callId));
+    {
+      auto lock = state.scopedLock();
+
+      // Init the service call as dispatched.
+      state.emplace(request.callId, ServiceCallState(request.callId));
+    }
 
     // Dispatch the service request.
     client.sendServiceRequest(request);
@@ -238,16 +247,14 @@ auto main(int argc, char** argv) -> int try {
 
   sendTestServiceRequests(client, foxglove_service, ws_server_ads, state);
 
+  printServiceCallStateMap(state);
+
   while (!allServiceCallsFinished(state) && !g_abort) {
     fmt::println("Waiting for responses... [Ctrl-C to abort]");
     std::this_thread::sleep_for(std::chrono::seconds(RESPONSE_WAIT_DURATION_S));
 
     printServiceCallStateMap(state);
   }
-
-  // IF we wait between launching the requests (LAUNCHING_SLEEP_DURATION_MS), the above loop will not even
-  // execute, so we print here again.
-  printServiceCallStateMap(state);
 
   fmt::println("Closing client...");
   client.close();

--- a/modules/websocket_bridge/include/hephaestus/websocket_bridge/bridge_config.h
+++ b/modules/websocket_bridge/include/hephaestus/websocket_bridge/bridge_config.h
@@ -65,7 +65,7 @@ struct WebsocketBridgeConfig {
   heph::ipc::zenoh::Config zenoh_config;  // Default constructor is called here
 
   static constexpr int DEFAULT_IPC_SERVICE_CALL_TIMEOUT_MS = 5000;
-  int ipc_service_call_timeout_ms = DEFAULT_IPC_SERVICE_CALL_TIMEOUT_MS;
+  int ipc_default_service_call_timeout_ms = DEFAULT_IPC_SERVICE_CALL_TIMEOUT_MS;
   bool ipc_service_service_request_async = true;
 
   bool ipc_advertise_topics_based_on_subscribers = true;

--- a/modules/websocket_bridge/src/websocket_bridge/bridge.cpp
+++ b/modules/websocket_bridge/src/websocket_bridge/bridge.cpp
@@ -753,7 +753,11 @@ void WebsocketBridge::callback_Ws_ServiceRequest(const WsServiceRequest& request
 
   auto buffer = std::as_bytes(std::span(request.data.data(), request.data.size()));
 
-  const std::chrono::milliseconds timeout_ms = std::chrono::milliseconds(config_.ipc_service_call_timeout_ms);
+  std::chrono::milliseconds timeout_ms =
+      std::chrono::milliseconds(config_.ipc_default_service_call_timeout_ms);
+  if (request.timeoutMs > 0) {
+    timeout_ms = std::chrono::milliseconds(request.timeoutMs);
+  }
 
   if (config_.ipc_service_service_request_async) {
     ///////////
@@ -762,9 +766,11 @@ void WebsocketBridge::callback_Ws_ServiceRequest(const WsServiceRequest& request
 
     state_.addCallIdToClientMapping(call_id, client_handle, client_name);
 
-    auto response_callback = [this, service_id, call_id](const RawServiceResponses& responses) -> void {
+    auto response_callback = [this, service_id, call_id,
+                              timeout_ms](const RawServiceResponses& responses) -> void {
       heph::log(heph::INFO, "[WS Bridge] - Service response callback triggered for service [ASYNC]",
-                "num_responses", responses.size(), "service_id", service_id, "call_id", call_id);
+                "num_responses", responses.size(), "service_id", service_id, "call_id", call_id, "timeout_ms",
+                timeout_ms);
 
       callback_Ipc_ServiceResponsesReceived(service_id, call_id, responses);
     };
@@ -772,7 +778,8 @@ void WebsocketBridge::callback_Ws_ServiceRequest(const WsServiceRequest& request
     ipc_entity_manager_->callServiceAsync(call_id, topic_config, buffer, timeout_ms, response_callback);
 
     heph::log(heph::INFO, "[WS Bridge] - Client service request dispatched [ASYNC]", "client_name",
-              client_name, "service_name", service_name, "service_id", service_id, "call_id", call_id);
+              client_name, "service_name", service_name, "service_id", service_id, "call_id", call_id,
+              "timeout_ms", timeout_ms);
   } else {
     //////////
     // SYNC //

--- a/modules/websocket_bridge/src/websocket_bridge/utils/ws_client.cpp
+++ b/modules/websocket_bridge/src/websocket_bridge/utils/ws_client.cpp
@@ -119,6 +119,8 @@ auto horizontalLine(uint32_t cell_content_width, uint32_t columns) -> std::strin
 }
 
 void printServiceCallStateMap(ServiceCallStateMap& state) {
+  auto lock = state.scopedLock();
+
   constexpr uint32_t MAX_COLUMNS = 5;
   constexpr uint32_t CELL_CONTENT_WIDTH = 17;
 
@@ -270,6 +272,7 @@ void printClientChannelAds(const std::vector<WsClientChannelAd>& client_ads) {
 }
 
 auto allServiceCallsFinished(const ServiceCallStateMap& state) -> bool {
+  auto lock = state.scopedLock();
   return std::ranges::all_of(state, [](const auto& pair) { return pair.second.hasResponse(); });
 }
 


### PR DESCRIPTION
# Description

The ws bridge so far only had one global service call timeout setting. This makes little sense, as service calls might require a wide variety of different timeouts and having to set one on the ws client side + having to deal with an arbitrary one in the bridge makes things painful.

This change let's the client set a timeout.
The other changes are related to testing/improving the example cpp client.

## Caveat

This technically breaks the ws-protocol compatibility for service calls as the binary message definition for ServiceRequests deviates from the ws protocol definition.
That being said, Foxglove Studio anyways does not support protobuf service calls at the moment, so there is no consequence to this. IFF  we get to the point where we want (and actually can) extend foxglove studio to support service calls in protobuf, we might have to revisit this. It is a small change though.

## Type of change
Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality) -> At least non-breaking withing heph
