### PR TITLE
Update yaml-cpp cmake build to work with latest cmake version

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -58,5 +58,5 @@ def foreign_cc_repositories():
         build_file = ":foreign_cc/ws_protocol.BUILD",
         urls = ["https://github.com/olympus-robotics/ws-protocol/archive/refs/tags/{tag}.zip".format(tag = WS_PROTOCOL_TAG)],
         strip_prefix = "ws-protocol-releases-cpp-v" + WS_PROTOCOL_VERSION,
-        sha256 = "86bd5743098825822b26b0459f4115b86694fdc86398ba7e84e296b6af4bdc23",
+        sha256 = "1c7d7b874f2e20d841cd04391d9d0be507ccb75b22f84b65a0fc61a30ac30651",
     )

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -165,6 +165,7 @@ add_cmake_dependency(
   VERSION ${YAML_CPP_VERSION}
   GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
   GIT_TAG ${YAML_CPP_VERSION}
+  CMAKE_ARGS -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 )
 
 # --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fix this error:
```
yaml-cpp-configure
CMake Error at CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```