### PR TITLE
Add batch support to Loki log sink

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -165,6 +165,7 @@ add_cmake_dependency(
   VERSION ${YAML_CPP_VERSION}
   GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
   GIT_TAG ${YAML_CPP_VERSION}
+  CMAKE_ARGS -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 )
 
 # --------------------------------------------------------------------------------------------------

--- a/modules/telemetry/telemetry_loki_sink/BUILD
+++ b/modules/telemetry/telemetry_loki_sink/BUILD
@@ -17,6 +17,7 @@ heph_cc_library(
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
+        "//modules/concurrency",
         "//modules/telemetry/telemetry",
         "@cpr",
         "@fmt",

--- a/modules/telemetry/telemetry_loki_sink/CMakeLists.txt
+++ b/modules/telemetry/telemetry_loki_sink/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 declare_module(
   NAME telemetry_loki_sink
-  DEPENDS_ON_MODULES telemetry
+  DEPENDS_ON_MODULES concurrency telemetry
   DEPENDS_ON_EXTERNAL_PROJECTS cpr fmt reflectcpp
 )
 
@@ -18,7 +18,7 @@ set(SOURCES src/loki_log_sink.cpp include/hephaestus/telemetry/telemetry_loki_si
 # library target
 define_module_library(
   NAME telemetry_loki_sink
-  PUBLIC_LINK_LIBS fmt::fmt hephaestus::telemetry cpr::cpr reflectcpp::reflectcpp
+  PUBLIC_LINK_LIBS fmt::fmt hephaestus::concurrency hephaestus::telemetry cpr::cpr reflectcpp::reflectcpp
   PRIVATE_LINK_LIBS ""
   SOURCES ${SOURCES}
   PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>

--- a/modules/telemetry/telemetry_loki_sink/examples/loki_log_sink_example.cpp
+++ b/modules/telemetry/telemetry_loki_sink/examples/loki_log_sink_example.cpp
@@ -7,6 +7,7 @@
 
 #include "hephaestus/telemetry/log.h"
 #include "hephaestus/telemetry/telemetry_loki_sink/loki_log_sink.h"
+#include "hephaestus/utils/signal_handler.h"
 #include "hephaestus/utils/stack_trace.h"
 
 // To start a Grafana + Loki stack follow this instructions
@@ -31,6 +32,14 @@ auto main(int /*unused*/, const char* /*unused*/[]) -> int {
     heph::log(heph::TRACE, "debug loki trace log sink with fields", "num", num);
 
     heph::log(heph::ERROR, "debug loki error log sink with fields", "num", num);
+
+    std::size_t counter = 0;
+    while (!heph::utils::TerminationBlocker::stopRequested()) {
+      static constexpr auto PERIOD = std::chrono::milliseconds{ 200 };
+      heph::log(heph::INFO, "loki log sink with fields", "counter", counter);
+      heph::log(heph::ERROR, "debug loki error log sink with fields", "counter", counter++);
+      std::this_thread::sleep_for(PERIOD);
+    }
 
   } catch (std::exception& e) {
     return 1;

--- a/modules/telemetry/telemetry_loki_sink/include/hephaestus/telemetry/telemetry_loki_sink/loki_log_sink.h
+++ b/modules/telemetry/telemetry_loki_sink/include/hephaestus/telemetry/telemetry_loki_sink/loki_log_sink.h
@@ -48,7 +48,6 @@ private:
   std::map<std::string, std::string> stream_labels_;
 
   absl::Mutex mutex_;
-  // std::vector<LogEntry> log_entries_ ABSL_GUARDED_BY(mutex_);
   std::unordered_map<LogLevel, std::vector<LogEntry>> log_entries_ ABSL_GUARDED_BY(mutex_);
 
   concurrency::Spinner spinner_;

--- a/modules/telemetry/telemetry_loki_sink/include/hephaestus/telemetry/telemetry_loki_sink/loki_log_sink.h
+++ b/modules/telemetry/telemetry_loki_sink/include/hephaestus/telemetry/telemetry_loki_sink/loki_log_sink.h
@@ -8,8 +8,11 @@
 #include <map>
 #include <string>
 
+#include <absl/base/thread_annotations.h>
+#include <absl/synchronization/mutex.h>
 #include <cpr/session.h>
 
+#include "hephaestus/concurrency/spinner.h"
 #include "hephaestus/telemetry/log_sink.h"
 
 namespace heph::telemetry {
@@ -17,10 +20,12 @@ namespace heph::telemetry {
 struct LokiLogSinkConfig {
   static constexpr auto DEFAULT_LOKI_PORT = 3100;
   static constexpr auto DEFAULT_LOKI_HOST = "localhost";
+  static constexpr auto DEFAULT_FLUSH_RATE_HZ = 5;
   uint32_t loki_port = DEFAULT_LOKI_PORT;
   std::string loki_host = DEFAULT_LOKI_HOST;
   LogLevel log_level = LogLevel::TRACE;
   std::string domain;  /// Used to group logs from different binaries.
+  double flush_rate_hz = DEFAULT_FLUSH_RATE_HZ;
 };
 
 /// @brief A simple sink that passes the logs to ABSL.
@@ -28,8 +33,12 @@ struct LokiLogSinkConfig {
 class LokiLogSink final : public ILogSink {
 public:
   explicit LokiLogSink(const LokiLogSinkConfig& config);
+  ~LokiLogSink() override;
 
   void send(const LogEntry& entry) override;
+
+private:
+  void spinOnce();
 
 private:
   static constexpr auto LOKI_URL_FORMAT = "http://{}:{}/loki/api/v1/push";
@@ -37,6 +46,12 @@ private:
   cpr::Session cpr_session_;
 
   std::map<std::string, std::string> stream_labels_;
+
+  absl::Mutex mutex_;
+  // std::vector<LogEntry> log_entries_ ABSL_GUARDED_BY(mutex_);
+  std::unordered_map<LogLevel, std::vector<LogEntry>> log_entries_ ABSL_GUARDED_BY(mutex_);
+
+  concurrency::Spinner spinner_;
 };
 
 }  // namespace heph::telemetry


### PR DESCRIPTION
## Description

Instead of sending every log message directly to Loki we first batch them and send them periodically from a separate thread.