### PR TITLE
Spinner/change rate to period

### DIFF
--- a/modules/concurrency/examples/spinner_example.cpp
+++ b/modules/concurrency/examples/spinner_example.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2023-2024 HEPHAESTUS Contributors
 //=================================================================================================
 
+#include <chrono>
 #include <cstdlib>
 #include <exception>
 #include <future>
@@ -11,12 +12,12 @@
 #include "hephaestus/concurrency/spinner.h"
 #include "hephaestus/utils/signal_handler.h"
 
-static constexpr auto RATE_HZ = 10;
+static constexpr auto SPIN_PERIOD = std::chrono::duration<double>(0.1);
 
 class Worker {
 public:
   Worker()
-    : spinner_(heph::concurrency::Spinner::createNeverStoppingCallback([this] { doWork(); }), RATE_HZ) {
+    : spinner_(heph::concurrency::Spinner::createNeverStoppingCallback([this] { doWork(); }), SPIN_PERIOD) {
   }
 
   void start() {

--- a/modules/concurrency/src/spinner.cpp
+++ b/modules/concurrency/src/spinner.cpp
@@ -131,12 +131,13 @@ void Spinner::setTerminationCallback(Callback&& termination_callback) {
 namespace internal {
 auto computeNextSpinTimestamp(const std::chrono::system_clock::time_point& start_timestamp,
                               const std::chrono::system_clock::time_point& now,
-                              const std::chrono::microseconds& spin_period)
+                              std::chrono::duration<double> spin_period)
     -> std::chrono::system_clock::time_point {
-  const auto elapsed_time_since_start_micro_sec = static_cast<double>(
-      std::chrono::duration_cast<std::chrono::microseconds>(now - start_timestamp).count());
-  const auto spin_count = static_cast<std::size_t>(
-      std::ceil(elapsed_time_since_start_micro_sec / static_cast<double>(spin_period.count())));
+  const auto duration_since_start =
+      std::chrono::duration_cast<std::chrono::duration<double>>(now - start_timestamp);
+  const auto spin_count =
+      static_cast<std::size_t>(std::ceil(duration_since_start.count() / spin_period.count()));
+
   return start_timestamp + (spin_count * spin_period);
 }
 }  // namespace internal

--- a/modules/concurrency/src/spinner.cpp
+++ b/modules/concurrency/src/spinner.cpp
@@ -20,19 +20,6 @@
 #include "hephaestus/utils/exception.h"
 
 namespace heph::concurrency {
-namespace {
-[[nodiscard]] auto rateToPeriod(double rate_hz) -> std::chrono::microseconds {
-  // Explicit check to prevent floating point errors
-  if (rate_hz == std::numeric_limits<double>::infinity()) {
-    return std::chrono::microseconds{ 0 };
-  }
-
-  const double period_seconds = 1 / rate_hz;
-  const auto period_microseconds = static_cast<uint64_t>(period_seconds * 1e6);
-
-  return std::chrono::microseconds{ period_microseconds };
-}
-}  // namespace
 
 auto Spinner::createNeverStoppingCallback(Callback&& callback) -> StoppableCallback {
   return [callback = std::move(callback)]() -> SpinResult {
@@ -56,10 +43,8 @@ auto Spinner::createCallbackWithStateMachine(
 }
 
 Spinner::Spinner(StoppableCallback&& stoppable_callback,
-                 double rate_hz /*= std::numeric_limits<double>::infinity()*/)
-  : stoppable_callback_(std::move(stoppable_callback))
-  , stop_requested_(false)
-  , spin_period_(rateToPeriod(rate_hz)) {
+                 std::optional<std::chrono::duration<double>> spin_period /*= std::nullopt*/)
+  : stoppable_callback_(std::move(stoppable_callback)), stop_requested_(false), spin_period_(spin_period) {
 }
 
 Spinner::~Spinner() {
@@ -87,10 +72,11 @@ void Spinner::spin() {
         break;
       }
 
-      if (spin_period_.count() > 0) {  // Throttle spinner to a fixed rate if a valid rate_hz is provided.
+      if (spin_period_.has_value()) {  // Throttle spinner to a fixed period if spin_period_ is provided
         std::unique_lock<std::mutex> lock(mutex_);
-        condition_.wait_until(lock, internal::computeNextSpinTimestamp(
-                                        start_timestamp, std::chrono::system_clock::now(), spin_period_));
+        condition_.wait_until(lock, internal::computeNextSpinTimestamp(start_timestamp,
+                                                                       std::chrono::system_clock::now(),
+                                                                       spin_period_.value()));
       }
     } catch (std::exception& e) {
       heph::log(heph::ERROR, "Spinner caught an exception, terminating", "error", e.what());
@@ -138,7 +124,8 @@ auto computeNextSpinTimestamp(const std::chrono::system_clock::time_point& start
   const auto spin_count =
       static_cast<std::size_t>(std::ceil(duration_since_start.count() / spin_period.count()));
 
-  return start_timestamp + (spin_count * spin_period);
+  return start_timestamp +
+         std::chrono::duration_cast<std::chrono::system_clock::duration>(spin_count * spin_period);
 }
 }  // namespace internal
 }  // namespace heph::concurrency

--- a/modules/telemetry/telemetry_influxdb_sink/examples/influxdb_measure_example.cpp
+++ b/modules/telemetry/telemetry_influxdb_sink/examples/influxdb_measure_example.cpp
@@ -41,10 +41,12 @@ auto main(int argc, const char* argv[]) -> int {
   heph::telemetry::registerLogSink(std::make_unique<heph::telemetry::AbslLogSink>());
 
   try {
+    static constexpr auto PERIOD = std::chrono::duration<double>(1.0);
+
     auto influxdb_sink = heph::telemetry_sink::InfluxDBSink::create({ .url = "localhost:8099",
                                                                       .token = "my-super-secret-auth-token",
                                                                       .database = "hephaestus",
-                                                                      .flush_rate_hz = 1.0 });
+                                                                      .flush_period = PERIOD });
     heph::telemetry::registerMetricSink(std::move(influxdb_sink));
 
     int64_t counter = 0;
@@ -58,7 +60,7 @@ auto main(int argc, const char* argv[]) -> int {
                                       .message = heph::random::random<std::string>(mt, 4),
                                   });
         }),
-        1);
+        PERIOD);
 
     spinner.start();
     heph::utils::TerminationBlocker::waitForInterrupt();

--- a/modules/telemetry/telemetry_influxdb_sink/include/hephaestus/telemetry_influxdb_sink/influxdb_metric_sink.h
+++ b/modules/telemetry/telemetry_influxdb_sink/include/hephaestus/telemetry_influxdb_sink/influxdb_metric_sink.h
@@ -22,9 +22,11 @@ struct InfluxDBSinkConfig {
   std::string database;
   std::optional<std::size_t> batch_size{ std::nullopt };  //! If specified the sink will batch this many
                                                           //! points before sending them.
-  std::optional<double> flush_rate_hz{ std::nullopt };  //! If specified the sink will flush the batch at this
-                                                        //! rate. NOTE: setting this will invalidate the
-                                                        //! batch_size.
+  std::optional<std::chrono::duration<double>> flush_period{
+    std::nullopt
+  };  //! If specified the sink will flush the batch at this
+      //! period. NOTE: setting this will invalidate the
+      //! batch_size.
 };
 
 class InfluxDBSink final : public telemetry::IMetricSink {

--- a/modules/telemetry/telemetry_influxdb_sink/src/influxdb_metric_sink.cpp
+++ b/modules/telemetry/telemetry_influxdb_sink/src/influxdb_metric_sink.cpp
@@ -74,7 +74,7 @@ InfluxDBSink::InfluxDBSink(InfluxDBSinkConfig config) : config_(std::move(config
   heph::log(heph::DEBUG, "connecting to InfluxDB", "url", url);
   influxdb_ = influxdb::InfluxDBFactory::Get(url);
 
-  if (config_.flush_rate_hz.has_value()) {
+  if (config_.flush_period.has_value()) {
     // NOTE: we define a very large number for the batch size as we want to flush at a fixed rate.
     static constexpr std::size_t DEFAULT_BATCH_SIZE = 1e6;
     influxdb_->batchOf(DEFAULT_BATCH_SIZE);
@@ -89,7 +89,7 @@ InfluxDBSink::InfluxDBSink(InfluxDBSinkConfig config) : config_(std::move(config
 
           return concurrency::Spinner::SpinResult::CONTINUE;
         },
-        config_.flush_rate_hz.value());
+        config_.flush_period.value());
     spinner_->start();
   } else if (config_.batch_size.has_value()) {
     influxdb_->batchOf(config_.batch_size.value());

--- a/modules/telemetry/telemetry_loki_sink/include/hephaestus/telemetry/telemetry_loki_sink/loki_log_sink.h
+++ b/modules/telemetry/telemetry_loki_sink/include/hephaestus/telemetry/telemetry_loki_sink/loki_log_sink.h
@@ -20,12 +20,12 @@ namespace heph::telemetry {
 struct LokiLogSinkConfig {
   static constexpr auto DEFAULT_LOKI_PORT = 3100;
   static constexpr auto DEFAULT_LOKI_HOST = "localhost";
-  static constexpr auto DEFAULT_FLUSH_RATE_HZ = 5;
+  static constexpr std::chrono::duration<double> DEFAULT_FLUSH_PERIOD{ 0.2 };
   uint32_t loki_port = DEFAULT_LOKI_PORT;
   std::string loki_host = DEFAULT_LOKI_HOST;
   LogLevel log_level = LogLevel::TRACE;
   std::string domain;  /// Used to group logs from different binaries.
-  double flush_rate_hz = DEFAULT_FLUSH_RATE_HZ;
+  std::chrono::duration<double> flush_period = DEFAULT_FLUSH_PERIOD;
 };
 
 /// @brief A simple sink that passes the logs to ABSL.

--- a/modules/telemetry/telemetry_loki_sink/src/loki_log_sink.cpp
+++ b/modules/telemetry/telemetry_loki_sink/src/loki_log_sink.cpp
@@ -109,7 +109,7 @@ LokiLogSink::LokiLogSink(const LokiLogSinkConfig& config)
           spinOnce();
           return concurrency::Spinner::SpinResult::CONTINUE;
         },
-        config.flush_rate_hz) {
+        config.flush_period) {
   cpr_session_.SetUrl(fmt::format(LOKI_URL_FORMAT, config.loki_host, config.loki_port));
   cpr_session_.SetHeader(cpr::Header{ { "Content-Type", "application/json" } });
   spinner_.start();


### PR DESCRIPTION
# Description
Change interface to accept a period instead of a rate. Advantage: periods are represented by time, allowing for the use of `std::chrono`, which removes unit conversions.

## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [x] I updated the README and related documentation.
