### PR TITLE
[IPC] program options add topic filter to the command line flag; update `EndpointDiscovery` to input a topic filter

### DIFF
--- a/modules/bag/apps/bag_player.cpp
+++ b/modules/bag/apps/bag_player.cpp
@@ -39,7 +39,7 @@ auto main(int argc, const char* argv[]) -> int {
     const auto args = std::move(desc).parse(argc, argv);
     auto input_file = args.getOption<std::filesystem::path>("input_bag");
     auto wait_for_readers_to_connect = args.getOption<bool>("wait_for_readers_to_connect");
-    auto [config, _] = heph::ipc::zenoh::parseProgramOptions(args);
+    auto [config, _, __] = heph::ipc::zenoh::parseProgramOptions(args);
 
     heph::log(heph::DEBUG, "reading bag", "file", input_file.string());
 

--- a/modules/bag/tests/tests.cpp
+++ b/modules/bag/tests/tests.cpp
@@ -109,6 +109,7 @@ TEST(Bag, PlayAndRecord) {
                                             .topics_filter_params = {
                                                 .include_topics_only = {},
                                                 .prefix = "bag_test/",
+                                                .exclude_prefix = "",
                                                 .exclude_topics = {},
                                             } });
     {

--- a/modules/examples/examples/zenoh_action_server.cpp
+++ b/modules/examples/examples/zenoh_action_server.cpp
@@ -80,7 +80,7 @@ auto main(int argc, const char* argv[]) -> int {
     auto desc = heph::cli::ProgramDescription("Action server example");
     heph::ipc::zenoh::appendProgramOption(desc, getDefaultTopic(ExampleType::ACTION_SERVER));
     const auto args = std::move(desc).parse(argc, argv);
-    auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
+    auto [session_config, topic_config, _] = heph::ipc::zenoh::parseProgramOptions(args);
 
     auto stop_session_config = session_config;
     auto session = heph::ipc::zenoh::createSession(session_config);

--- a/modules/examples/examples/zenoh_action_server_client.cpp
+++ b/modules/examples/examples/zenoh_action_server_client.cpp
@@ -35,7 +35,7 @@ auto main(int argc, const char* argv[]) -> int {
     auto desc = heph::cli::ProgramDescription("Action server client example");
     heph::ipc::zenoh::appendProgramOption(desc, getDefaultTopic(ExampleType::ACTION_SERVER));
     const auto args = std::move(desc).parse(argc, argv);
-    auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
+    auto [session_config, topic_config, _] = heph::ipc::zenoh::parseProgramOptions(args);
 
     auto session = heph::ipc::zenoh::createSession(session_config);
 

--- a/modules/examples/examples/zenoh_pub.cpp
+++ b/modules/examples/examples/zenoh_pub.cpp
@@ -37,7 +37,7 @@ auto main(int argc, const char* argv[]) -> int {
     heph::ipc::zenoh::appendProgramOption(desc, getDefaultTopic(ExampleType::PUBSUB));
     const auto args = std::move(desc).parse(argc, argv);
 
-    auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
+    auto [session_config, topic_config, _] = heph::ipc::zenoh::parseProgramOptions(args);
     auto session = heph::ipc::zenoh::createSession(session_config);
 
     heph::ipc::zenoh::Publisher<heph::examples::types::Pose> publisher{ session, topic_config,

--- a/modules/examples/examples/zenoh_service_client.cpp
+++ b/modules/examples/examples/zenoh_service_client.cpp
@@ -36,7 +36,7 @@ auto main(int argc, const char* argv[]) -> int {
     auto desc = heph::cli::ProgramDescription("Binary service client example");
     heph::ipc::zenoh::appendProgramOption(desc, getDefaultTopic(ExampleType::SERVICE_SERVER));
     const auto args = std::move(desc).parse(argc, argv);
-    auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
+    auto [session_config, topic_config, _] = heph::ipc::zenoh::parseProgramOptions(args);
 
     auto session = heph::ipc::zenoh::createSession(session_config);
 

--- a/modules/examples/examples/zenoh_service_server.cpp
+++ b/modules/examples/examples/zenoh_service_server.cpp
@@ -33,7 +33,7 @@ auto main(int argc, const char* argv[]) -> int {
     auto desc = heph::cli::ProgramDescription("Binary service example");
     heph::ipc::zenoh::appendProgramOption(desc, getDefaultTopic(ExampleType::SERVICE_SERVER));
     const auto args = std::move(desc).parse(argc, argv);
-    auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
+    auto [session_config, topic_config, _] = heph::ipc::zenoh::parseProgramOptions(args);
     auto session = heph::ipc::zenoh::createSession(session_config);
 
     auto callback = [](const heph::examples::types::Pose& sample) {

--- a/modules/examples/examples/zenoh_string_service_client.cpp
+++ b/modules/examples/examples/zenoh_string_service_client.cpp
@@ -34,7 +34,7 @@ auto main(int argc, const char* argv[]) -> int {
     auto desc = heph::cli::ProgramDescription("String service client example");
     heph::ipc::zenoh::appendProgramOption(desc, getDefaultTopic(ExampleType::SERVICE_SERVER));
     const auto args = std::move(desc).parse(argc, argv);
-    auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
+    auto [session_config, topic_config, _] = heph::ipc::zenoh::parseProgramOptions(args);
 
     auto session = heph::ipc::zenoh::createSession(session_config);
 

--- a/modules/examples/examples/zenoh_string_service_server.cpp
+++ b/modules/examples/examples/zenoh_string_service_server.cpp
@@ -31,7 +31,7 @@ auto main(int argc, const char* argv[]) -> int {
     auto desc = heph::cli::ProgramDescription("String service server example");
     heph::ipc::zenoh::appendProgramOption(desc, getDefaultTopic(ExampleType::SERVICE_SERVER));
     const auto args = std::move(desc).parse(argc, argv);
-    auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
+    auto [session_config, topic_config, _] = heph::ipc::zenoh::parseProgramOptions(args);
 
     auto session = heph::ipc::zenoh::createSession(session_config);
 

--- a/modules/examples/examples/zenoh_sub.cpp
+++ b/modules/examples/examples/zenoh_sub.cpp
@@ -35,7 +35,7 @@ auto main(int argc, const char* argv[]) -> int {
     auto desc = heph::cli::ProgramDescription("Subscriber example");
     heph::ipc::zenoh::appendProgramOption(desc, getDefaultTopic(ExampleType::PUBSUB));
     const auto args = std::move(desc).parse(argc, argv);
-    auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
+    auto [session_config, topic_config, _] = heph::ipc::zenoh::parseProgramOptions(args);
 
     heph::log(heph::DEBUG, "opening session", "subscriber_name", topic_config.name);
 

--- a/modules/ipc/apps/zenoh_ipc_graph.cpp
+++ b/modules/ipc/apps/zenoh_ipc_graph.cpp
@@ -33,7 +33,7 @@ auto main(int argc, const char* argv[]) -> int {
     desc.defineFlag("live", 'l', "If set, the app will continue running until interrupted");
     const auto args = std::move(desc).parse(argc, argv);
 
-    auto [session_config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
+    auto [session_config, _, __] = heph::ipc::zenoh::parseProgramOptions(args);
     const auto duration_sec = args.getOption<int>("duration");
     const bool live_mode = args.getOption<bool>("live");
 

--- a/modules/ipc/apps/zenoh_string_service_client.cpp
+++ b/modules/ipc/apps/zenoh_string_service_client.cpp
@@ -36,7 +36,8 @@ auto main(int argc, const char* argv[]) -> int {
     const auto args = std::move(desc).parse(argc, argv);
     const auto value = args.getOption<std::string>("value");
 
-    auto [config, topic_config] = heph::ipc::zenoh::parseProgramOptions(args);
+    auto [config, topic_config, _] = heph::ipc::zenoh::parseProgramOptions(args);
+
     auto session = heph::ipc::zenoh::createSession(config);
     heph::log(heph::DEBUG, "opening session", "id",
               heph::ipc::zenoh::toString(session->zenoh_session.get_zid()));

--- a/modules/ipc/include/hephaestus/ipc/topic_filter.h
+++ b/modules/ipc/include/hephaestus/ipc/topic_filter.h
@@ -17,6 +17,7 @@ struct TopicFilterParams {
                                                  //!< going to be recorded. This rule has precedence
                                                  //!< over all the other
   std::string prefix;                            //!< Record all the topic sharing the prefix
+  std::string exclude_prefix;                    //!< Exclude all topics that share the prefix
   std::vector<std::string> exclude_topics;       //!< List of topics to exclude
 };
 
@@ -30,6 +31,7 @@ public:
   [[nodiscard]] auto onlyIncluding(const std::vector<std::string>& topic_names) && -> TopicFilter;
 
   [[nodiscard]] auto prefix(std::string prefix) && -> TopicFilter;
+  [[nodiscard]] auto excludePrefix(std::string prefix) && -> TopicFilter;
 
   [[nodiscard]] auto anyExcluding(const std::vector<std::string>& topic_names) && -> TopicFilter;
 

--- a/modules/ipc/include/hephaestus/ipc/zenoh/liveliness.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/liveliness.h
@@ -19,6 +19,7 @@
 
 #include "hephaestus/concurrency/message_queue_consumer.h"
 #include "hephaestus/ipc/topic.h"
+#include "hephaestus/ipc/topic_filter.h"
 #include "hephaestus/ipc/zenoh/session.h"
 
 namespace heph::ipc::zenoh {
@@ -47,7 +48,7 @@ struct EndpointInfo {
 [[nodiscard]] auto parseLivelinessToken(std::string_view keyexpr, ::zenoh::SampleKind kind)
     -> std::optional<EndpointInfo>;
 
-[[nodiscard]] auto getListOfEndpoints(const Session& session, std::string_view topic = "**")
+[[nodiscard]] auto getListOfEndpoints(const Session& session, const TopicFilter& topic_filter)
     -> std::vector<EndpointInfo>;
 
 void printEndpointInfo(const EndpointInfo& info);
@@ -57,7 +58,7 @@ void printEndpointInfo(const EndpointInfo& info);
 class EndpointDiscovery {
 public:
   using Callback = std::function<void(const EndpointInfo& info)>;
-  explicit EndpointDiscovery(SessionPtr session, TopicConfig topic_config, Callback&& callback);
+  explicit EndpointDiscovery(SessionPtr session, TopicFilter topic_filter, Callback&& callback);
   ~EndpointDiscovery();
 
   EndpointDiscovery(const EndpointDiscovery&) = delete;
@@ -70,7 +71,7 @@ private:
 
 private:
   SessionPtr session_;
-  TopicConfig topic_config_;
+  TopicFilter topic_filter_;
   Callback callback_;
 
   std::unique_ptr<::zenoh::Subscriber<void>> liveliness_subscriber_;

--- a/modules/ipc/include/hephaestus/ipc/zenoh/program_options.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/program_options.h
@@ -4,19 +4,20 @@
 #pragma once
 
 #include <string>
-#include <utility>
+#include <tuple>
 
 #include "hephaestus/cli/program_options.h"
 #include "hephaestus/ipc/topic.h"
+#include "hephaestus/ipc/topic_filter.h"
 #include "hephaestus/ipc/zenoh/session.h"
 
 namespace heph::ipc::zenoh {
 
-static constexpr auto DEFAULT_TOPIC = "**";
+static constexpr auto DEFAULT_TOPIC = "";
 void appendProgramOption(cli::ProgramDescription& program_description,
                          const std::string& default_topic = DEFAULT_TOPIC);
 
 [[nodiscard]] auto parseProgramOptions(const heph::cli::ProgramOptions& args)
-    -> std::pair<Config, TopicConfig>;
+    -> std::tuple<Config, TopicConfig, TopicFilterParams>;
 
 }  // namespace heph::ipc::zenoh

--- a/modules/ipc/src/topic_filter.cpp
+++ b/modules/ipc/src/topic_filter.cpp
@@ -30,6 +30,10 @@ auto TopicFilter::create(const TopicFilterParams& params) -> TopicFilter {
     filter = std::move(filter).prefix(params.prefix);
   }
 
+  if (!params.exclude_prefix.empty()) {
+    filter = std::move(filter).excludePrefix(params.exclude_prefix);
+  }
+
   return filter;
 }
 
@@ -51,6 +55,12 @@ auto TopicFilter::prefix(std::string prefix) && -> TopicFilter {
 
     return topic.starts_with(prefix);
   });
+  return std::move(*this);
+}
+
+auto TopicFilter::excludePrefix(std::string prefix) && -> TopicFilter {
+  match_cb_.emplace_back(
+      [prefix = std::move(prefix)](const auto& topic) { return !topic.starts_with(prefix); });
   return std::move(*this);
 }
 

--- a/modules/ipc/src/zenoh/dynamic_subscriber.cpp
+++ b/modules/ipc/src/zenoh/dynamic_subscriber.cpp
@@ -32,7 +32,7 @@ DynamicSubscriber::DynamicSubscriber(DynamicSubscriberParams&& params)
 
 [[nodiscard]] auto DynamicSubscriber::start() -> std::future<void> {
   discover_publishers_ = std::make_unique<EndpointDiscovery>(
-      session_, TopicConfig{ "**" }, [this](const EndpointInfo& info) { onEndpointDiscovered(info); });
+      session_, topic_filter_, [this](const EndpointInfo& info) { onEndpointDiscovered(info); });
 
   std::promise<void> promise;
   promise.set_value();
@@ -57,10 +57,6 @@ void DynamicSubscriber::onEndpointDiscovered(const EndpointInfo& info) {
 }
 
 void DynamicSubscriber::onPublisher(const EndpointInfo& info) {
-  if (!topic_filter_.isAcceptable(info.topic)) {
-    return;
-  }
-
   switch (info.status) {
     case ipc::zenoh::EndpointInfo::Status::ALIVE:
       onPublisherAdded(info);

--- a/modules/ipc/src/zenoh/ipc_graph.cpp
+++ b/modules/ipc/src/zenoh/ipc_graph.cpp
@@ -45,7 +45,7 @@ void IpcGraph::start() {
   topic_db_ = ipc::createZenohTopicDatabase(config_.session);
 
   discovery_ = std::make_unique<ipc::zenoh::EndpointDiscovery>(
-      config_.session, ipc::TopicConfig{ "**" },
+      config_.session, TopicFilter::create(),
       [this](const ipc::zenoh::EndpointInfo& info) { endPointInfoUpdateCallback(info); });
 
   heph::log(heph::INFO, "[IPC Graph] - ONLINE");

--- a/modules/ipc/tests/topic_filter_tests.cpp
+++ b/modules/ipc/tests/topic_filter_tests.cpp
@@ -49,9 +49,9 @@ TEST(TopicFilter, AnyExcluding) {
     runTestCases(filter, test_cases);
   }
   {
-    const ipc::TopicFilterParams params{ .include_topics_only = {},
-                                         .prefix = "",
-                                         .exclude_topics = { "topic" } };
+    const ipc::TopicFilterParams params{
+      .include_topics_only = {}, .prefix = "", .exclude_prefix = "", .exclude_topics = { "topic" }
+    };
     const auto filter = ipc::TopicFilter::create(params);
     runTestCases(filter, test_cases);
   }
@@ -69,9 +69,29 @@ TEST(TopicFilter, Prefix) {
     runTestCases(filter, test_cases);
   }
   {
-    const ipc::TopicFilterParams params{ .include_topics_only = {},
-                                         .prefix = "hostname",
-                                         .exclude_topics = {} };
+    const ipc::TopicFilterParams params{
+      .include_topics_only = {}, .prefix = "hostname", .exclude_prefix = "", .exclude_topics = {}
+    };
+    const auto filter = ipc::TopicFilter::create(params);
+    runTestCases(filter, test_cases);
+  }
+}
+
+TEST(TopicFilter, ExcludePrefix) {
+  const TestCasesT test_cases{
+    { "hostname/image", false },
+    { "hostname/video", false },
+    { "topic", true },
+  };
+
+  {
+    const auto filter = ipc::TopicFilter::create().excludePrefix({ "hostname" });
+    runTestCases(filter, test_cases);
+  }
+  {
+    const ipc::TopicFilterParams params{
+      .include_topics_only = {}, .prefix = "", .exclude_prefix = "hostname", .exclude_topics = {}
+    };
     const auto filter = ipc::TopicFilter::create(params);
     runTestCases(filter, test_cases);
   }
@@ -89,7 +109,9 @@ TEST(TopicFilter, PrefixWildcard) {
     runTestCases(filter, test_cases);
   }
   {
-    const ipc::TopicFilterParams params{ .include_topics_only = {}, .prefix = "**", .exclude_topics = {} };
+    const ipc::TopicFilterParams params{
+      .include_topics_only = {}, .prefix = "**", .exclude_prefix = "", .exclude_topics = {}
+    };
     const auto filter = ipc::TopicFilter::create(params);
     runTestCases(filter, test_cases);
   }
@@ -108,6 +130,7 @@ TEST(TopicFilter, PrefixAndExcluding) {
   {
     const ipc::TopicFilterParams params{ .include_topics_only = {},
                                          .prefix = "hostname",
+                                         .exclude_prefix = "",
                                          .exclude_topics = { "hostname/video" } };
     const auto filter = ipc::TopicFilter::create(params);
     runTestCases(filter, test_cases);
@@ -125,9 +148,9 @@ TEST(TopicFilter, IncludeOnly) {
     runTestCases(filter, test_cases);
   }
   {
-    const ipc::TopicFilterParams params{ .include_topics_only = { "hostname/video" },
-                                         .prefix = "",
-                                         .exclude_topics = {} };
+    const ipc::TopicFilterParams params{
+      .include_topics_only = { "hostname/video" }, .prefix = "", .exclude_prefix = "", .exclude_topics = {}
+    };
     auto filter = ipc::TopicFilter::create(params);
     runTestCases(filter, test_cases);
   }


### PR DESCRIPTION
# Description
* `EndpointDiscover` now takes in input `TopicFilter` to be more flexible in filtering discovered topic
* `TopicFilter` add option `exclude_prefix` to exclude all topics with a certain prefix
* ipc CLI program options now support topic filter
* `zenoh_topic_list` automatically hides all `topic_info/` topics from the print 
