### PR TITLE
Remove git override; update protobuf

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,11 +18,14 @@ bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
 
 # LLVM
 bazel_dep(name = "toolchains_llvm", version = "1.3.0")
+
 LLVM_COMMIT = "14eb90172b3c5f35bdb2699d006fe0f70e76aa24"
+
 archive_override(
     module_name = "toolchains_llvm",
-    url = "https://github.com/bazel-contrib/toolchains_llvm/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
+    sha256 = "d85f78a501d6050fa0f1fb74e1c5f971549cd6d0b9c9147857935c0346c070d0",
     strip_prefix = "toolchains_llvm-{commit}".format(commit = LLVM_COMMIT),
+    url = "https://github.com/bazel-contrib/toolchains_llvm/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
 )
 
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
@@ -61,11 +64,14 @@ use_repo(buf, "rules_buf_toolchains")
 # Hedron's Compile Commands Extractor for Bazel
 # https://github.com/hedronvision/bazel-compile-commands-extractor
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
+
 COMPILE_COMMANDS_COMMIT = "4f28899228fb3ad0126897876f147ca15026151e"
+
 archive_override(
     module_name = "hedron_compile_commands",
-    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/{commit}.tar.gz".format(commit = COMPILE_COMMANDS_COMMIT),
+    sha256 = "658122cfb1f25be76ea212b00f5eb047d8e2adc8bcf923b918461f2b1e37cdf2",
     strip_prefix = "bazel-compile-commands-extractor-{commit}".format(commit = COMPILE_COMMANDS_COMMIT),
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/{commit}.tar.gz".format(commit = COMPILE_COMMANDS_COMMIT),
 )
 
 ############################
@@ -82,12 +88,14 @@ bazel_dep(name = "eigen", version = "3.4.0")
 bazel_dep(name = "curl", version = "8.8.0.bcr.1")
 bazel_dep(name = "yaml-cpp", version = "0.8.0")
 bazel_dep(name = "range-v3", version = "0.12.0")
+
 RANGE_COMMIT = "7e6f34b1e820fb8321346888ef0558a0ec842b8e"
+
 archive_override(
     module_name = "range-v3",
-    url = "https://github.com/ericniebler/range-v3/archive/{commit}.tar.gz".format(commit = RANGE_COMMIT),
-    strip_prefix = "range-v3-{commit}".format(commit = RANGE_COMMIT),
     sha256 = "8395518e171e5873e51db9ef153a17b5bd46e69a99b64fd6c44b45b53f98d7cf",
+    strip_prefix = "range-v3-{commit}".format(commit = RANGE_COMMIT),
+    url = "https://github.com/ericniebler/range-v3/archive/{commit}.tar.gz".format(commit = RANGE_COMMIT),
 )
 
 bazel_dep(name = "boringssl", version = "0.20250114.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,10 +18,11 @@ bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
 
 # LLVM
 bazel_dep(name = "toolchains_llvm", version = "1.3.0")
-git_override(
+LLVM_COMMIT = "14eb90172b3c5f35bdb2699d006fe0f70e76aa24"
+archive_override(
     module_name = "toolchains_llvm",
-    commit = "14eb90172b3c5f35bdb2699d006fe0f70e76aa24",
-    remote = "https://github.com/bazel-contrib/toolchains_llvm.git",
+    url = "https://github.com/bazel-contrib/toolchains_llvm/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
+    strip_prefix = "toolchains_llvm-{commit}".format(commit = LLVM_COMMIT),
 )
 
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
@@ -60,12 +61,11 @@ use_repo(buf, "rules_buf_toolchains")
 # Hedron's Compile Commands Extractor for Bazel
 # https://github.com/hedronvision/bazel-compile-commands-extractor
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
-git_override(
+COMPILE_COMMANDS_COMMIT = "4f28899228fb3ad0126897876f147ca15026151e"
+archive_override(
     module_name = "hedron_compile_commands",
-    commit = "4f28899228fb3ad0126897876f147ca15026151e",
-    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
-    # Replace the commit hash (above) with the latest (https://github.com/hedronvision/bazel-compile-commands-extractor/commits/main).
-    # Even better, set up Renovate and let it do the work for you (see "Suggestion: Updates" in the README).
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/{commit}.tar.gz".format(commit = COMPILE_COMMANDS_COMMIT),
+    strip_prefix = "bazel-compile-commands-extractor-{commit}".format(commit = COMPILE_COMMANDS_COMMIT),
 )
 
 ############################
@@ -73,19 +73,21 @@ git_override(
 ############################
 
 bazel_dep(name = "googletest", version = "1.15.2")
-bazel_dep(name = "abseil-cpp", version = "20240116.2")
+bazel_dep(name = "abseil-cpp", version = "20250127.0")
 bazel_dep(name = "magic_enum", version = "0.9.5")
 bazel_dep(name = "fmt", version = "11.1.4")
-bazel_dep(name = "protobuf", version = "29.0")
+bazel_dep(name = "protobuf", version = "30.0")
 bazel_dep(name = "nlohmann_json", version = "3.11.3")
 bazel_dep(name = "eigen", version = "3.4.0")
 bazel_dep(name = "curl", version = "8.8.0.bcr.1")
 bazel_dep(name = "yaml-cpp", version = "0.8.0")
-bazel_dep(name = "range-v3", version = "")
-git_override(
+bazel_dep(name = "range-v3", version = "0.12.0")
+RANGE_COMMIT = "7e6f34b1e820fb8321346888ef0558a0ec842b8e"
+archive_override(
     module_name = "range-v3",
-    commit = "7e6f34b1e820fb8321346888ef0558a0ec842b8e",
-    remote = "https://github.com/ericniebler/range-v3",
+    url = "https://github.com/ericniebler/range-v3/archive/{commit}.tar.gz".format(commit = RANGE_COMMIT),
+    strip_prefix = "range-v3-{commit}".format(commit = RANGE_COMMIT),
+    sha256 = "8395518e171e5873e51db9ef153a17b5bd46e69a99b64fd6c44b45b53f98d7cf",
 )
 
 bazel_dep(name = "boringssl", version = "0.20250114.0")

--- a/bazel/hephaestus.bzl
+++ b/bazel/hephaestus.bzl
@@ -26,6 +26,8 @@ def heph_basic_copts():
         "-Wdouble-promotion",  # warn if float is implicit promoted to double
         "-Wformat=2",  # warn on security issues around functions that format output (ie printf)
         "-Wimplicit-fallthrough",  # warn on statements that fallthrough without an explicit annotation
+        "-Wno-nullability-extension",
+        "-Wno-private-header",
         "-Iexternal/abseil-cpp~",  # This is needed to avoid the error: file not found with <angled> include; use "quotes" instead
     ] + select({
         "@hephaestus//bazel:opt_compilation": ["-O3"],

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -75,8 +75,8 @@ add_cmake_dependency(
 
 # --------------------------------------------------------------------------------------------------
 # Abseil C++
-set(ABSEIL_VERSION 20240116)
-set(ABSEIL_TAG ${ABSEIL_VERSION}.2)
+set(ABSEIL_VERSION 20250127)
+set(ABSEIL_TAG ${ABSEIL_VERSION}.0)
 set(ABSEIL_CMAKE_ARGS -DABSL_BUILD_TESTING=OFF -DABSL_ENABLE_INSTALL=ON -DABSL_PROPAGATE_CXX_STD=ON
                       -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
 )
@@ -90,8 +90,8 @@ add_cmake_dependency(
 
 # --------------------------------------------------------------------------------------------------
 # protobuf
-set(PROTOBUF_TAG v27.2)
-set(PROTOBUF_VERSION 5.27.2)
+set(PROTOBUF_TAG v30.0)
+set(PROTOBUF_VERSION 5.30.0)
 set(PROTOBUF_CMAKE_ARGS -Dprotobuf_BUILD_EXAMPLES=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_ABSL_PROVIDER=package
                         -Dprotobuf_BUILD_CONFORMANCE=OFF
 )

--- a/modules/serdes/include/hephaestus/serdes/protobuf/protobuf_internal.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/protobuf_internal.h
@@ -60,7 +60,7 @@ template <class ProtoT>
                  [](char c) { return static_cast<std::byte>(c); });
 
   auto original_type_tmp = std::move(original_type);  // NOTE: this is need otherwise clang-tidy will complain
-  return { .name = proto_descriptor->full_name(),
+  return { .name = std::string{ proto_descriptor->full_name() },
            .schema = schema,
            .serialization = TypeInfo::Serialization::PROTOBUF,
            .original_type = std::move(original_type_tmp) };

--- a/modules/serdes/src/protobuf/protobuf_internal.cpp
+++ b/modules/serdes/src/protobuf/protobuf_internal.cpp
@@ -17,7 +17,7 @@ auto buildFileDescriptorSet(const google::protobuf::Descriptor* toplevel_descrip
   google::protobuf::FileDescriptorSet fd_set;
   std::queue<const google::protobuf::FileDescriptor*> to_add;
   to_add.push(toplevel_descriptor->file());
-  std::unordered_set<std::string> seen_dependencies;
+  std::unordered_set<std::string_view> seen_dependencies;
 
   while (!to_add.empty()) {
     const google::protobuf::FileDescriptor* next = to_add.front();

--- a/modules/serdes/src/protobuf/protobuf_internal.cpp
+++ b/modules/serdes/src/protobuf/protobuf_internal.cpp
@@ -5,7 +5,7 @@
 #include "hephaestus/serdes/protobuf/protobuf_internal.h"
 
 #include <queue>
-#include <string>
+#include <string_view>
 #include <unordered_set>
 
 #include <google/protobuf/descriptor.h>


### PR DESCRIPTION
# Description
Using `git_override` is less efficient than archive.

Also, updating protobuf as it is needed by grpc