### PR TITLE
Fix CMakeLists in format module

### DIFF
--- a/modules/format/CMakeLists.txt
+++ b/modules/format/CMakeLists.txt
@@ -4,8 +4,8 @@
 
 declare_module(
   NAME format
-  DEPENDS_ON_MODULES utils
-  DEPENDS_ON_EXTERNAL_PROJECTS reflectcpp fmt
+  DEPENDS_ON_MODULES utils containers_reflection
+  DEPENDS_ON_EXTERNAL_PROJECTS reflectcpp fmt magic_enum
 )
 
 find_package(fmt REQUIRED)


### PR DESCRIPTION
# Description

I found a cake error when bumping a more recent `forkify` version to `skid_repo` in https://gitlab.com/future_in_logistics/skid_repo/-/merge_requests/1832#437bded96a8ee86600682315def62ab0a0e33747. This MR adds `containers_reflection` as module dependency and `magic_enum` as external project dependency to `format` module. After this change it builds. 

Error: 
`CMake Error at /workspaces/skid_repo/src/modules/forkify/externals/submodules/hephaestus/cmake/05_modules.cmake:329 (target_link_libraries):
  Target "hephaestus_format" links to:

    hephaestus::containers_reflection

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  /workspaces/skid_repo/src/modules/forkify/externals/submodules/hephaestus/modules/format/CMakeLists.txt:21 (define_module_library)`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] If this is a new component I have added examples.
- [x] I updated the README and related documentation.
