### PR TITLE
Fix/telemetry record performance

### DIFF
--- a/modules/containers/include/hephaestus/containers/blocking_queue.h
+++ b/modules/containers/include/hephaestus/containers/blocking_queue.h
@@ -43,7 +43,9 @@ public:
       queue_.push_back(std::forward<U>(obj));
     }
 
-    reader_signal_.notify_one();
+    if (waiting_readers_ > 0) {
+      reader_signal_.notify_one();
+    }
     return true;
   }
 
@@ -64,7 +66,9 @@ public:
       queue_.push_back(std::forward<U>(obj));
     }
 
-    reader_signal_.notify_one();
+    if (waiting_readers_ > 0) {
+      reader_signal_.notify_one();
+    }
     return element_dropped;
   }
 
@@ -75,8 +79,10 @@ public:
   void waitAndPush(U&& obj) {
     {
       std::unique_lock<std::mutex> lock(mutex_);
+      ++waiting_writers_;
       writer_signal_.wait(lock,
                           [this]() { return !max_size_.has_value() || queue_.size() < *max_size_ || stop_; });
+      --waiting_writers_;
       if (stop_) {
         return;
       }
@@ -84,7 +90,9 @@ public:
       queue_.push_back(std::forward<U>(obj));
     }
 
-    reader_signal_.notify_one();
+    if (waiting_readers_ > 0) {
+      reader_signal_.notify_one();
+    }
   }
 
   /// Attempt to enqueue the data if there is space in the queue. Support constructing a new element
@@ -102,7 +110,9 @@ public:
       queue_.emplace_back(std::forward<Args>(args)...);
     }
 
-    reader_signal_.notify_one();
+    if (waiting_readers_ > 0) {
+      reader_signal_.notify_one();
+    }
     return true;
   }
 
@@ -123,7 +133,9 @@ public:
       queue_.emplace_back(std::forward<Args>(args)...);
     }
 
-    reader_signal_.notify_one();
+    if (waiting_readers_ > 0) {
+      reader_signal_.notify_one();
+    }
     return element_dropped;
   }
 
@@ -135,8 +147,10 @@ public:
   void waitAndEmplace(Args&&... args) {
     {
       std::unique_lock<std::mutex> lock(mutex_);
+      ++waiting_writers_;
       writer_signal_.wait(lock,
                           [this]() { return !max_size_.has_value() || queue_.size() < *max_size_ || stop_; });
+      --waiting_writers_;
       if (stop_) {
         return;
       }
@@ -144,7 +158,9 @@ public:
       queue_.emplace_back(std::forward<Args>(args)...);
     }
 
-    reader_signal_.notify_one();
+    if (waiting_readers_ > 0) {
+      reader_signal_.notify_one();
+    }
   }
 
   /// Pop data from the queue, if data is present the function returns immediately,
@@ -153,15 +169,36 @@ public:
   /// \return The first element from the queue if the queue contains data, std::nullopt otherwise.
   [[nodiscard]] auto waitAndPop() noexcept(std::is_nothrow_move_constructible_v<T>) -> std::optional<T> {
     std::unique_lock<std::mutex> lock(mutex_);
+    ++waiting_readers_;
     reader_signal_.wait(lock, [this]() { return !queue_.empty() || stop_; });
+    --waiting_readers_;
     if (stop_) {
       return {};
     }
 
     auto value = std::move(queue_.front());
     queue_.pop_front();
-    writer_signal_.notify_one();  // Notifying a writer waiting that there is an empty space.
+    if (waiting_writers_ > 0) {
+      writer_signal_.notify_one();  // Notifying a writer waiting that there is an empty space.
+    }
     return value;
+  }
+
+  [[nodiscard]] auto waitAndPopAll() noexcept(std::is_nothrow_move_constructible_v<T>) -> std::deque<T> {
+    std::unique_lock<std::mutex> lock(mutex_);
+    ++waiting_readers_;
+    reader_signal_.wait(lock, [this]() { return !queue_.empty() || stop_; });
+    --waiting_readers_;
+    if (stop_) {
+      return {};
+    }
+
+    std::deque<T> res;
+    std::swap(res, queue_);
+    if (waiting_writers_ > 0) {
+      writer_signal_.notify_one();  // Notifying a writer waiting that there is an empty space.
+    }
+    return res;
   }
 
   /// Tries to pop data from the queue, if no data is present it returns nothing.
@@ -175,7 +212,9 @@ public:
 
     auto value = std::move(queue_.front());
     queue_.pop_front();
-    writer_signal_.notify_one();  // Notifying a writer waiting that there is an empty space.
+    if (waiting_writers_ > 0) {
+      writer_signal_.notify_one();  // Notifying a writer waiting that there is an empty space.
+    }
     return value;
   }
 
@@ -205,7 +244,9 @@ private:
   std::optional<std::size_t> max_size_;
   std::condition_variable reader_signal_;
   std::condition_variable writer_signal_;
-  bool stop_{ false };
   mutable std::mutex mutex_;
+  std::size_t waiting_readers_{ 0 };
+  std::size_t waiting_writers_{ 0 };
+  bool stop_{ false };
 };
 }  // namespace heph::containers

--- a/modules/telemetry/telemetry/src/metric_record.cpp
+++ b/modules/telemetry/telemetry/src/metric_record.cpp
@@ -104,7 +104,7 @@ public:
 
   static void registerSink(std::unique_ptr<IMetricSink> sink);
 
-  static void record(heph::UniqueFunction<Metric()> metric);
+  static void record(heph::UniqueFunction<Metric()>&& metric);
 
 private:
   [[nodiscard]] static auto instance() -> MetricRecorder&;
@@ -124,7 +124,7 @@ void registerMetricSink(std::unique_ptr<IMetricSink> sink) {
   MetricRecorder::registerSink(std::move(sink));
 }
 
-void record(heph::UniqueFunction<Metric()> metric) {
+void record(heph::UniqueFunction<Metric()>&& metric) {
   MetricRecorder::record(std::move(metric));
 }
 
@@ -165,7 +165,7 @@ void MetricRecorder::registerSink(std::unique_ptr<IMetricSink> sink) {
   telemetry.sinks_.push_back(std::move(sink));
 }
 
-void MetricRecorder::record(heph::UniqueFunction<Metric()> metric) {
+void MetricRecorder::record(heph::UniqueFunction<Metric()>&& metric) {
   auto& telemetry = instance();
   telemetry.entries_.forcePush(std::move(metric));
 }
@@ -184,7 +184,7 @@ void MetricRecorder::emptyQueue() {
       return;
     }
 
-    processEntry(message.value()());
+    processEntry((*message)());
   }
 }
 

--- a/modules/telemetry/telemetry/src/metric_record.cpp
+++ b/modules/telemetry/telemetry/src/metric_record.cpp
@@ -25,6 +25,7 @@
 #include "hephaestus/telemetry/log.h"
 #include "hephaestus/telemetry/log_sink.h"
 #include "hephaestus/telemetry/metric_sink.h"
+#include "hephaestus/utils/unique_function.h"
 
 namespace heph::telemetry {
 
@@ -103,7 +104,7 @@ public:
 
   static void registerSink(std::unique_ptr<IMetricSink> sink);
 
-  static void record(const Metric& metric);
+  static void record(heph::UniqueFunction<Metric()> metric);
 
 private:
   [[nodiscard]] static auto instance() -> MetricRecorder&;
@@ -115,7 +116,7 @@ private:
 private:
   absl::Mutex sink_mutex_;
   std::vector<std::unique_ptr<IMetricSink>> sinks_ ABSL_GUARDED_BY(sink_mutex_);
-  containers::BlockingQueue<Metric> entries_;
+  containers::BlockingQueue<heph::UniqueFunction<Metric()>> entries_;
   std::future<void> message_process_future_;
 };
 
@@ -123,8 +124,12 @@ void registerMetricSink(std::unique_ptr<IMetricSink> sink) {
   MetricRecorder::registerSink(std::move(sink));
 }
 
-void record(const Metric& metric) {
-  MetricRecorder::record(metric);
+void record(heph::UniqueFunction<Metric()> metric) {
+  MetricRecorder::record(std::move(metric));
+}
+
+void record(Metric metric) {
+  MetricRecorder::record([metric = std::move(metric)] { return metric; });
 }
 
 MetricRecorder::MetricRecorder() : entries_{ std::nullopt } {
@@ -134,8 +139,7 @@ MetricRecorder::MetricRecorder() : entries_{ std::nullopt } {
       if (!message.has_value()) {
         break;
       }
-
-      processEntry(message.value());
+      processEntry((*message)());
     }
     emptyQueue();
   });
@@ -161,9 +165,9 @@ void MetricRecorder::registerSink(std::unique_ptr<IMetricSink> sink) {
   telemetry.sinks_.push_back(std::move(sink));
 }
 
-void MetricRecorder::record(const Metric& metric) {
+void MetricRecorder::record(heph::UniqueFunction<Metric()> metric) {
   auto& telemetry = instance();
-  telemetry.entries_.forcePush(metric);
+  telemetry.entries_.forcePush(std::move(metric));
 }
 
 void MetricRecorder::processEntry(const Metric& entry) {
@@ -180,7 +184,7 @@ void MetricRecorder::emptyQueue() {
       return;
     }
 
-    processEntry(message.value());
+    processEntry(message.value()());
   }
 }
 

--- a/modules/utils/BUILD
+++ b/modules/utils/BUILD
@@ -2,7 +2,7 @@
 # Copyright (C) 2023-2024 HEPHAESTUS Contributors
 # =================================================================================================
 
-load("@hephaestus//bazel:hephaestus.bzl", "heph_cc_library", "heph_cc_test")
+load("@hephaestus//bazel:hephaestus.bzl", "heph_cc_binary", "heph_cc_library", "heph_cc_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -32,6 +32,12 @@ heph_cc_library(
 #########
 # Tests #
 #########
+
+heph_cc_binary(
+    name = "unique_function_performance",
+    srcs = ["tests/unique_function_performance.cpp"],
+    deps = [":utils"],
+)
 
 heph_cc_test(
     name = "concepts_tests",

--- a/modules/utils/include/hephaestus/utils/unique_function.h
+++ b/modules/utils/include/hephaestus/utils/unique_function.h
@@ -1,0 +1,240 @@
+//=================================================================================================
+// Copyright (C) 2023-2025 HEPHAESTUS Contributors
+//=================================================================================================
+
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <functional>
+#include <type_traits>
+
+namespace heph {
+/// The `UniqueFunction` is very similar to `std::function` with the
+/// only difference that it is move only.
+template <typename Sig>
+class UniqueFunction;
+
+namespace detail {
+struct FunctorPadding {
+  void* ptr{ nullptr };
+  void* padding1{ nullptr };
+  void* padding2{ nullptr };
+  void* padding3{ nullptr };
+};
+template <typename R, typename... Args>
+auto emptyCall(FunctorPadding const& /**/, Args... /*unused*/) -> R {
+  throw std::bad_function_call{};
+}
+
+inline void destroyEmpty(FunctorPadding const& /**/) {
+}
+
+inline void moveEmpty(FunctorPadding const& /**/, FunctorPadding& /**/) {
+}
+
+template <typename T>
+static inline constexpr bool IS_INPLACE_ALLOCATED =
+    // Check that it fits
+    sizeof(T) <= sizeof(FunctorPadding)
+    // and that it will be aligned
+    && alignof(FunctorPadding) % alignof(T) == 0;
+
+template <typename T>
+auto isNull(T const& /**/) noexcept -> bool {
+  return false;
+}
+template <typename R, typename... Args>
+auto isNull(R (*func)(Args...)) noexcept -> bool {
+  return func == nullptr;
+}
+template <typename R, typename Class, typename... Args>
+auto isNull(R (Class::*func)(Args...)) noexcept -> bool {
+  return func == nullptr;
+}
+template <typename R, typename Class, typename... Args>
+auto isNull(R (Class::*func)(Args...) const) noexcept -> bool {
+  return func == nullptr;
+}
+
+template <typename R, typename... Args>
+struct Vtable {
+  using invokeFunctionT = R (*)(FunctorPadding const&, Args...);
+  using destroyFunctionT = void (*)(FunctorPadding const&);
+  using moveFunctionT = void (*)(FunctorPadding const&, FunctorPadding&);
+
+  invokeFunctionT invoke{ &emptyCall<R, Args...> };
+  destroyFunctionT destroy{ &destroyEmpty };
+  moveFunctionT move{ &moveEmpty };
+};
+
+template <typename F, typename R, typename... Args>
+auto invokeFunction(FunctorPadding const& storage, Args... args) -> R {
+  F* f{ nullptr };
+  if constexpr (detail::IS_INPLACE_ALLOCATED<F>) {
+    void const* storage_ptr = static_cast<void const*>(&storage);
+    std::memcpy(&f, &storage_ptr, sizeof(void*));
+  } else {
+    f = static_cast<F*>(storage.ptr);
+  }
+  return (*f)(static_cast<Args&&>(args)...);
+}
+
+template <typename F>
+void moveFunction(FunctorPadding const& source, FunctorPadding& destination) noexcept {
+  if constexpr (detail::IS_INPLACE_ALLOCATED<F>) {
+    if constexpr (std::is_trivially_move_constructible_v<F>) {
+      destination = source;
+    } else {
+      F* f{ nullptr };
+      void const* storage = static_cast<void const*>(&source);
+      std::memcpy(&f, &storage, sizeof(void*));
+      new (&destination) F{ std::move(*f) };
+    }
+  } else {
+    F* f = static_cast<F*>(source.ptr);
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    destination.ptr = new F{ std::move(*f) };
+  }
+}
+
+template <typename F>
+void destroyFunction(FunctorPadding const& storage) {
+  if constexpr (detail::IS_INPLACE_ALLOCATED<F>) {
+    if constexpr (!std::is_trivially_destructible_v<F>) {
+      F* f{ nullptr };
+      void const* storage_ptr = static_cast<void const*>(&storage);
+      std::memcpy(&f, &storage_ptr, sizeof(void*));
+      f->~F();
+    }
+  } else {
+    F* f = static_cast<F*>(storage.ptr);
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    delete f;
+  }
+}
+template <typename R, typename... Args>
+inline constexpr Vtable<R, Args...> EMPTY_VTABLE{};
+
+template <typename F, typename R, typename... Args>
+inline constexpr Vtable<R, Args...> VTABLE{ .invoke = &invokeFunction<F, R, Args...>,
+                                            .move = &moveFunction<F>,
+                                            .destroy = &destroyFunction<F> };
+
+template <typename F, typename R, typename... Args>
+concept invocable = !std::is_same_v<F, UniqueFunction<R(Args...)>> && std::invocable<F, Args...> &&
+                    std::is_same_v<R, std::invoke_result_t<F, Args...>>;
+
+}  // namespace detail
+
+template <typename R, typename... Args>
+class UniqueFunction<R(Args...)> {
+public:
+  UniqueFunction() noexcept : vtable_{ &detail::EMPTY_VTABLE<R, Args...> } {
+  }
+
+  ~UniqueFunction() {
+    // Delete contained object. This is save since the empty vtable
+    // is a noop.
+    vtable_->destroy(storage_);
+  }
+
+  // NOLINTBEGIN(google-explicit-constructor)
+  // NOLINTBEGIN(hicpp-explicit-conversions)
+  UniqueFunction(std::nullptr_t /**/) noexcept : vtable_{ &detail::EMPTY_VTABLE<R, Args...> } {
+  }
+
+  template <detail::invocable<R, Args...> F>
+  UniqueFunction(F&& f) noexcept(std::is_nothrow_move_constructible_v<F>)
+    : vtable_{ &detail::VTABLE<F, R, Args...> } {
+    initializeStorage(std::forward<F>(f));
+  }
+  // NOLINTEND(hicpp-explicit-conversions)
+  // NOLINTEND(google-explicit-constructor)
+
+  UniqueFunction(UniqueFunction const& other) noexcept = delete;
+  UniqueFunction(UniqueFunction&& other) noexcept : vtable_{ other.vtable_ } {
+    other.vtable_->move(other.storage_, storage_);
+    other.vtable_ = &detail::EMPTY_VTABLE<R, Args...>;
+  }
+  auto operator=(UniqueFunction const& other) noexcept -> UniqueFunction& = delete;
+  auto operator=(UniqueFunction&& other) noexcept -> UniqueFunction& {
+    if (this == &other) {
+      return *this;
+    }
+
+    // Delete contained object. This is save since the empty vtable
+    // is a noop.
+    vtable_->destroy(storage_);
+
+    vtable_ = other.vtable_;
+    other.vtable_->move(other.storage_, storage_);
+    other.vtable_ = &detail::EMPTY_VTABLE<R, Args...>;
+  }
+
+  template <detail::invocable<R, Args...> F>
+  auto operator=(F&& f) -> UniqueFunction& {
+    vtable_->destroy(storage_);
+
+    vtable_ = &detail::VTABLE<F, R, Args...>;
+    initializeStorage(std::forward<F>(f));
+
+    return *this;
+  }
+
+  auto operator=(std::nullptr_t /**/) -> UniqueFunction& {
+    vtable_->destroy(storage_);
+    vtable_ = &detail::EMPTY_VTABLE<R, Args...>;
+    return *this;
+  }
+
+  auto operator()(Args... args) -> R {
+    return vtable_->invoke(storage_, static_cast<Args&&>(args)...);
+  }
+
+  auto operator()(Args... args) const -> R {
+    return vtable_->invoke(storage_, static_cast<Args&&>(args)...);
+  }
+
+  explicit operator bool() const noexcept {
+    return vtable_ != &detail::EMPTY_VTABLE<R, Args...>;
+  }
+
+private:
+  template <typename F>
+  void initializeStorage(F&& f) {
+    if (detail::isNull(f)) {
+      vtable_ = &detail::EMPTY_VTABLE<R, Args...>;
+      return;
+    }
+    if constexpr (detail::IS_INPLACE_ALLOCATED<F>) {
+      new (&storage_) std::decay_t<F>{ std::forward<F>(f) };
+    } else {
+      // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+      storage_.ptr = new std::decay_t<F>{ std::forward<F>(f) };
+    }
+  }
+
+private:
+  detail::Vtable<R, Args...> const* vtable_;
+  detail::FunctorPadding storage_;
+};
+
+template <typename Sig>
+auto operator==(UniqueFunction<Sig> const& func, std::nullptr_t /**/) -> bool {
+  return !func;
+}
+template <typename Sig>
+auto operator==(std::nullptr_t /**/, UniqueFunction<Sig> const& func) -> bool {
+  return !func;
+}
+
+template <typename Sig>
+auto operator!=(UniqueFunction<Sig> const& func, std::nullptr_t /**/) -> bool {
+  return func;
+}
+template <typename Sig>
+auto operator!=(std::nullptr_t /**/, UniqueFunction<Sig> const& func) -> bool {
+  return func;
+}
+}  // namespace heph

--- a/modules/utils/tests/unique_function_performance.cpp
+++ b/modules/utils/tests/unique_function_performance.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <fmt/base.h>
+#include <fmt/chrono.h>  // NOLINT(misc-include-cleaner)
 
 #include "hephaestus/utils/unique_function.h"
 

--- a/modules/utils/tests/unique_function_performance.cpp
+++ b/modules/utils/tests/unique_function_performance.cpp
@@ -1,0 +1,154 @@
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <fmt/base.h>
+#include <fmt/chrono.h>
+
+#include "hephaestus/utils/unique_function.h"
+
+struct Updateable {
+  virtual ~Updateable() = default;
+  virtual void update(float dt) = 0;
+};
+
+struct UpdateableA : Updateable {
+  UpdateableA() = default;
+  void update(float /**/) override {
+    ++calls;
+  }
+
+  size_t calls{ 0 };
+};
+struct UpdateableB : Updateable {
+  void update(float /**/) override {
+    ++calls;
+  }
+
+  static size_t calls;
+};
+size_t UpdateableB::calls = 0;
+
+struct LambdaA {
+  template <typename F>
+  explicit LambdaA(std::vector<F>& update_loop) {
+    update_loop.emplace_back([this](float dt) { update(dt); });
+  }
+  void update(float /**/) {
+    ++calls;
+  }
+  size_t calls{ 0 };
+};
+
+struct LambdaB {
+  template <typename F>
+  explicit LambdaB(std::vector<F>& update_loop) {
+    update_loop.emplace_back([this](float dt) { update(dt); });
+  }
+  void update(float /*unused*/) {
+    ++calls;
+    (void)this;
+  }
+  static size_t calls;
+};
+size_t LambdaB::calls = 0;
+
+struct ScopedMeasurer {
+  ScopedMeasurer(const ScopedMeasurer&) = default;
+  ScopedMeasurer(ScopedMeasurer&&) = delete;
+  auto operator=(const ScopedMeasurer&) -> ScopedMeasurer& = default;
+  auto operator=(ScopedMeasurer&&) -> ScopedMeasurer& = delete;
+  explicit ScopedMeasurer(std::string name)
+    : name(std::move(name)), clock(), before(std::chrono::high_resolution_clock::now()) {
+  }
+  ~ScopedMeasurer() {
+    auto time_spent = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::high_resolution_clock::now() - before);
+    fmt::println("{}: {}\n", name, time_spent);
+  }
+  std::string name;
+  std::chrono::high_resolution_clock clock;
+  std::chrono::time_point<std::chrono::high_resolution_clock> before;
+};
+
+static const size_t NUM_ALLOCATIONS = 1000;
+#ifdef _DEBUG
+static const size_t num_calls = 10000;
+#else
+static const size_t NUM_CALLS = 100000;
+#endif
+static const float NUMBER = 0.016f;
+namespace {
+void measureOnlyCall(const std::vector<Updateable*>& container) {
+  const ScopedMeasurer measure("virtual function");
+  for (size_t i = 0; i < NUM_CALLS; ++i) {
+    for (const auto& updateable : container) {
+      updateable->update(NUMBER);
+    }
+  }
+}
+
+void timeVirtual(unsigned seed) {
+  std::default_random_engine generator(seed);
+  std::uniform_int_distribution<int> random_int(0, 1);
+  std::vector<std::unique_ptr<Updateable>> updateables;
+  std::vector<Updateable*> update_loop;
+  for (size_t i = 0; i < NUM_ALLOCATIONS; ++i) {
+    if (random_int(generator) != 0) {
+      // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+      updateables.emplace_back(new UpdateableA);
+    } else {
+      // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+      updateables.emplace_back(new UpdateableB);
+    }
+    update_loop.push_back(updateables.back().get());
+  }
+  measureOnlyCall(update_loop);
+}
+
+template <typename Container>
+void measureOnlyCall(const Container& container, const std::string& name) {
+  const ScopedMeasurer measure(name);
+  for (size_t i = 0; i < NUM_CALLS; ++i) {
+    for (auto& updateable : container) {
+      updateable(NUMBER);
+    }
+  }
+}
+
+template <typename FunctionT>
+void timeStdFunction(unsigned seed, const std::string& name) {
+  std::default_random_engine generator(seed);
+  std::uniform_int_distribution<int> random_int(0, 1);
+  std::vector<FunctionT> update_loop;
+  std::vector<std::unique_ptr<LambdaA>> slots_a;
+  std::vector<std::unique_ptr<LambdaB>> slots_b;
+  for (size_t i = 0; i < NUM_ALLOCATIONS; ++i) {
+    if (random_int(generator)) {
+      // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+      slots_a.emplace_back(new LambdaA(update_loop));
+    } else {
+      // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+      slots_b.emplace_back(new LambdaB(update_loop));
+    }
+  }
+  measureOnlyCall(update_loop, name);
+}
+}  // namespace
+
+auto main(int argc, char** /*argv*/) -> int {
+  try {
+    auto seed = static_cast<unsigned>(argc);
+    timeVirtual(seed);
+    timeStdFunction<heph::UniqueFunction<void(float)>>(seed, "heph::UniqueFunction");
+    timeStdFunction<std::function<void(float)>>(seed, "std::function");
+  } catch (...) {
+    fmt::println(stderr, "Unknown failure");
+    return 1;
+  }
+}

--- a/modules/utils/tests/unique_function_performance.cpp
+++ b/modules/utils/tests/unique_function_performance.cpp
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include <fmt/base.h>
-#include <fmt/chrono.h>
 
 #include "hephaestus/utils/unique_function.h"
 


### PR DESCRIPTION
# Optimizing `heph::telemetry::record`

- Making `heph::telemetry::record` lazily evaluated
    
    In order to mitigate the overhead of serialization, this patch is
    introducing the capabilities to pass a function to have the metric
    record calculated. This reduces computation time on the caller side and
    moves the costly parts to the service thread.

- Optimizing `BlockingQueue`
    
    With this, we only call notify if there are waiters.

- Adding `UniqueFunction`
    
    This utility can be used in cases where the type erased function does
    not require copying. It only supports moving. Otherwise it is equivalent
    with `std::function`.



## Type of change
Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
