### PR TITLE
blocking queue: add reset functionality

### DIFF
--- a/modules/containers/include/hephaestus/containers/blocking_queue.h
+++ b/modules/containers/include/hephaestus/containers/blocking_queue.h
@@ -271,6 +271,7 @@ public:
     while (true) {
       // We can do this with a polling loop, because we just need to wait for the condition variable to wake
       // the code for it to terminate.
+      // It is guaranteed that no new readers or writers will be added to the queue as it is stopped.
       const std::unique_lock<std::mutex> lock(mutex_);
       if (waiting_readers_ == 0 && waiting_writers_ == 0) {
         break;

--- a/modules/containers/tests/blocking_queue_tests.cpp
+++ b/modules/containers/tests/blocking_queue_tests.cpp
@@ -8,9 +8,9 @@
 #include <tuple>
 #include <utility>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "gmock/gmock.h"
 #include "hephaestus/containers/blocking_queue.h"
 
 // NOLINTNEXTLINE(google-build-using-namespace)
@@ -64,7 +64,7 @@ TEST(BlockingQueue, Push) {
 
   future = std::async([&block_queue]() { return block_queue.waitAndPop(); });
   block_queue.stop();
-  future.wait();
+  future.get();
   EXPECT_TRUE(true);
 }
 
@@ -165,6 +165,13 @@ TEST(BlockingQueue, InfiniteQueue) {
 
   res = block_queue.tryPop();
   EXPECT_FALSE(res);
+}
+
+TEST(BlockingQueue, Restart) {
+  BlockingQueue<double> block_queue{ {} };
+  block_queue.waitAndPush(0.);
+  block_queue.restart();
+  EXPECT_THAT(block_queue, IsEmpty());
 }
 
 }  // namespace heph::containers::tests


### PR DESCRIPTION
# Description
Add `reset`, which stops the queue and empties and resets it. 
