### PR TITLE
Feat/refactor panic

### DIFF
--- a/modules/bag/apps/bag_player.cpp
+++ b/modules/bag/apps/bag_player.cpp
@@ -43,8 +43,8 @@ auto main(int argc, const char* argv[]) -> int {
 
     heph::log(heph::DEBUG, "reading bag", "file", input_file.string());
 
-    heph::panicIf(!std::filesystem::exists(input_file),
-                  fmt::format("input bag file {} doesn't exist", input_file.string()));
+    heph::panicIf(!std::filesystem::exists(input_file), "input bag file {} doesn't exist",
+                  input_file.string());
     auto bag_reader = std::make_unique<mcap::McapReader>();
     const auto status = bag_reader->open(input_file.string());
     if (status.code != mcap::StatusCode::Success) {

--- a/modules/bag/apps/bag_player.cpp
+++ b/modules/bag/apps/bag_player.cpp
@@ -11,7 +11,6 @@
 #include <utility>
 
 #include <fmt/base.h>
-#include <fmt/format.h>
 #include <mcap/errors.hpp>
 #include <mcap/reader.hpp>
 

--- a/modules/bag/src/writer.cpp
+++ b/modules/bag/src/writer.cpp
@@ -14,8 +14,6 @@
 
 #include <absl/log/log.h>
 #include <absl/strings/ascii.h>
-#include <fmt/core.h>
-#include <fmt/format.h>
 #include <magic_enum.hpp>
 #include <mcap/types.hpp>
 #include <mcap/writer.hpp>

--- a/modules/bag/src/writer.cpp
+++ b/modules/bag/src/writer.cpp
@@ -55,8 +55,8 @@ private:
 McapWriter::McapWriter(McapWriterParams params) : params_(std::move(params)) {
   auto options = params_.mcap_writer_options;
   const auto status = writer_.open(params_.output_file.string(), options);
-  panicIf(!status.ok(), fmt::format("failed to create Mcap writer for file {}, with error: {}",
-                                    params_.output_file.string(), status.message));
+  panicIf(!status.ok(), "failed to create Mcap writer for file {}, with error: {}",
+          params_.output_file.string(), status.message);
 }
 
 void McapWriter::registerSchema(const serdes::TypeInfo& type_info) {
@@ -72,8 +72,7 @@ void McapWriter::registerSchema(const serdes::TypeInfo& type_info) {
 }
 
 void McapWriter::writeRecord(const ipc::zenoh::MessageMetadata& metadata, std::span<const std::byte> data) {
-  panicIf(!channel_db_.contains(metadata.topic),
-          fmt::format("no channel registered for topic {}", metadata.topic));
+  panicIf(!channel_db_.contains(metadata.topic), "no channel registered for topic {}", metadata.topic);
 
   auto channel_id = channel_db_[metadata.topic].id;
 
@@ -86,12 +85,11 @@ void McapWriter::writeRecord(const ipc::zenoh::MessageMetadata& metadata, std::s
   msg.dataSize = data.size();
 
   const auto write_res = writer_.write(msg);
-  panicIf(!write_res.ok(), fmt::format("failed to write msg from topic {} to bag", metadata.topic));
+  panicIf(!write_res.ok(), "failed to write msg from topic {} to bag", metadata.topic);
 }
 
 void McapWriter::registerChannel(const std::string& topic, const serdes::TypeInfo& type_info) {
-  panicIf(!schema_db_.contains(type_info.name),
-          fmt::format("no schema registered for type {}", type_info.name));
+  panicIf(!schema_db_.contains(type_info.name), "no schema registered for type {}", type_info.name);
 
   const auto& schema = schema_db_[type_info.name];
   mcap::Channel channel(topic, schema.encoding, schema.id);

--- a/modules/bag/src/zenoh_player.cpp
+++ b/modules/bag/src/zenoh_player.cpp
@@ -71,7 +71,7 @@ ZenohPlayer::Impl::Impl(ZenohPlayerParams params)
 
 auto ZenohPlayer::Impl::start() -> std::future<void> {
   const auto status = bag_reader_->readSummary(mcap::ReadSummaryMethod::AllowFallbackScan);
-  panicIf(!status.ok(), fmt::format("Failed to read bag summary: {}", status.message));
+  panicIf(!status.ok(), "Failed to read bag summary: {}", status.message);
 
   const auto channels = bag_reader_->channels();
   channel_count_ = channels.size();
@@ -101,7 +101,7 @@ void ZenohPlayer::Impl::wait() const {
 
 void ZenohPlayer::Impl::createPublisher(const mcap::Channel& channel) {
   panicIf(publishers_.contains(channel.topic),
-          fmt::format("failed to create publisher for topic: {}; topic already exist", channel.topic));
+          "failed to create publisher for topic: {}; topic already exist", channel.topic);
 
   const auto& schema = bag_reader_->schema(channel.schemaId);
   auto type_info = serdes::TypeInfo{

--- a/modules/bag/src/zenoh_player.cpp
+++ b/modules/bag/src/zenoh_player.cpp
@@ -16,8 +16,6 @@
 #include <unordered_set>
 #include <utility>
 
-#include <fmt/chrono.h>  // NOLINT(misc-include-cleaner)
-#include <fmt/format.h>
 #include <mcap/reader.hpp>
 #include <mcap/types.hpp>
 

--- a/modules/cli/include/hephaestus/cli/program_options.h
+++ b/modules/cli/include/hephaestus/cli/program_options.h
@@ -193,12 +193,11 @@ template <StringStreamable T>
 inline auto ProgramOptions::getOption(const std::string& option) const -> T {
   const auto it = std::find_if(options_.begin(), options_.end(),
                                [&option](const auto& opt) { return option == opt.key; });
-  panicIf(it == options_.end(), fmt::format("Undefined option '{}'", option));
+  panicIf(it == options_.end(), "Undefined option '{}'", option);
 
   const auto my_type = utils::getTypeName<T>();
-  panicIf(it->value_type != my_type,
-          fmt::format("Tried to parse option '{}' as type {} but it's specified as type {}", option, my_type,
-                      it->value_type));
+  panicIf(it->value_type != my_type, "Tried to parse option '{}' as type {} but it's specified as type {}",
+          option, my_type, it->value_type);
 
   if constexpr (std::is_same_v<T, std::string>) {
     // note: since std::istringstream extracts only up to whitespace, this special case is
@@ -212,8 +211,8 @@ inline auto ProgramOptions::getOption(const std::string& option) const -> T {
 
   T value;
   std::istringstream stream(it->value);
-  panicIf(not(stream >> std::boolalpha >> value),
-          fmt::format("Unable to parse value '{}' as type {} for option '{}'", it->value, my_type, option));
+  panicIf(not(stream >> std::boolalpha >> value), "Unable to parse value '{}' as type {} for option '{}'",
+          it->value, my_type, option);
 
   return value;
 }

--- a/modules/cli/src/program_options.cpp
+++ b/modules/cli/src/program_options.cpp
@@ -44,15 +44,14 @@ ProgramDescription::ProgramDescription(std::string brief) : brief_(std::move(bri
 
 void ProgramDescription::checkOptionAlreadyExists(const std::string& key, char k) const {
   const auto it = std::ranges::find_if(options_, [&key](const auto& opt) { return key == opt.key; });
-  panicIf(it != options_.end(), fmt::format("Attempted redefinition of option '{}'", key));
+  panicIf(it != options_.end(), "Attempted redefinition of option '{}'", key);
 
   if (k == '\0') {
     return;
   }
 
   const auto short_it = std::ranges::find_if(options_, [k](const auto& opt) { return k == opt.short_key; });
-  panicIf(short_it != options_.end(),
-          fmt::format("Attempted redefinition of short key '{}' for option '{}'", k, key));
+  panicIf(short_it != options_.end(), "Attempted redefinition of short key '{}' for option '{}'", k, key);
 }
 
 auto ProgramDescription::defineFlag(const std::string& key, char short_key, const std::string& description)
@@ -92,11 +91,10 @@ auto ProgramDescription::parse(const std::vector<std::string>& args) && -> Progr
     }
 
     ++arg_it;
-    panicIf(arg_it == args.end(),
-            fmt::format("After option --{} there is supposed to be a value", option.key));
+    panicIf(arg_it == args.end(), "After option --{} there is supposed to be a value", option.key);
     const auto is_option = arg_it->starts_with('-') && arg_it->size() > 1 && std::isdigit((*arg_it)[1]) == 0;
-    panicIf(is_option, fmt::format("Option --{} is supposed to be followed by a value, not another option {}",
-                                   option.key, *arg_it));
+    panicIf(is_option, "Option --{} is supposed to be followed by a value, not another option {}", option.key,
+            *arg_it);
 
     option.value = *arg_it;
     option.is_specified = true;
@@ -104,8 +102,7 @@ auto ProgramDescription::parse(const std::vector<std::string>& args) && -> Progr
 
   // check all required arguments are specified
   for (const auto& entry : options_) {
-    panicIf(entry.is_required and not entry.is_specified,
-            fmt::format("Required option '{}' not specified", entry.key));
+    panicIf(entry.is_required and not entry.is_specified, "Required option '{}' not specified", entry.key);
   }
 
   return ProgramOptions(std::move(options_));
@@ -116,19 +113,19 @@ auto ProgramDescription::getOptionFromArg(const std::string& arg) -> ProgramOpti
     const auto key = arg.substr(2);
     const auto it = std::ranges::find_if(options_, [&key](const auto& opt) { return key == opt.key; });
 
-    panicIf(it == options_.end(), fmt::format("Undefined option '{}'", key));
+    panicIf(it == options_.end(), "Undefined option '{}'", key);
     return *it;
   }
 
   if (arg.starts_with("-")) {
-    panicIf(arg.size() != 2, fmt::format("Undefined option '{}'", arg.substr(1)));
+    panicIf(arg.size() != 2, "Undefined option '{}'", arg.substr(1));
     const auto short_key = arg[1];
     const auto it =
         std::ranges::find_if(options_, [short_key](const auto& opt) { return short_key == opt.short_key; });
     return *it;
   }
 
-  panic(fmt::format("Arg {} is not a valid option, it must start with either '--' or '-'", arg));
+  panic("Arg {} is not a valid option, it must start with either '--' or '-'", arg);
 
   // NOTE: this will never happen as we will throw an exception before getting here, but compiler
   // wants this.

--- a/modules/concurrency/include/hephaestus/concurrency/io_ring/stoppable_io_ring_operation.h
+++ b/modules/concurrency/include/hephaestus/concurrency/io_ring/stoppable_io_ring_operation.h
@@ -9,7 +9,6 @@
 #include <system_error>
 #include <type_traits>
 
-#include <fmt/format.h>
 #include <liburing.h>
 #include <liburing/io_uring.h>
 #include <stdexec/stop_token.hpp>

--- a/modules/concurrency/include/hephaestus/concurrency/io_ring/stoppable_io_ring_operation.h
+++ b/modules/concurrency/include/hephaestus/concurrency/io_ring/stoppable_io_ring_operation.h
@@ -74,7 +74,7 @@ inline void StoppableIoRingOperation<IoRingOperationT>::StopOperation::handleCom
     return;
   }
   if (res < 0) {
-    heph::panic("StopOperation failed: {}", std::error_code(-res, std::system_category()).message());
+    panic("StopOperation failed: {}", std::error_code(-res, std::system_category()).message());
   }
   if (self->in_flight == 0) {
     self->operation.handleStopped();

--- a/modules/concurrency/include/hephaestus/concurrency/io_ring/stoppable_io_ring_operation.h
+++ b/modules/concurrency/include/hephaestus/concurrency/io_ring/stoppable_io_ring_operation.h
@@ -75,8 +75,7 @@ inline void StoppableIoRingOperation<IoRingOperationT>::StopOperation::handleCom
     return;
   }
   if (res < 0) {
-    heph::panic(
-        fmt::format("StopOperation failed: {}", std::error_code(-res, std::system_category()).message()));
+    heph::panic("StopOperation failed: {}", std::error_code(-res, std::system_category()).message());
   }
   if (self->in_flight == 0) {
     self->operation.handleStopped();

--- a/modules/concurrency/src/io_ring/io_ring.cpp
+++ b/modules/concurrency/src/io_ring/io_ring.cpp
@@ -43,8 +43,7 @@ struct DispatchOperation {
       return;
     }
     if (cqe->res < 0) {
-      heph::panic(
-          fmt::format("dispatch failed: {}", std::error_code(-cqe->res, std::system_category()).message()));
+      heph::panic("dispatch failed: {}", std::error_code(-cqe->res, std::system_category()).message());
     }
 
     dispatch_done.store(true, std::memory_order_release);
@@ -72,8 +71,7 @@ IoRing::IoRing(const IoRingConfig& config) : config_(config) {
   const int res = ::io_uring_queue_init(config_.nentries, &ring_, config_.flags);
 
   if (res < 0) {
-    heph::panic(fmt::format("::io_uring_queue_init failed: {}",
-                            std::error_code(-res, std::system_category()).message()));
+    heph::panic("::io_uring_queue_init failed: {}", std::error_code(-res, std::system_category()).message());
   }
 }
 
@@ -123,8 +121,8 @@ void IoRing::runOnce(bool block) {
     res = ::io_uring_submit_and_get_events(&ring_);
   }
   if (res < 0 && !(res == -EAGAIN || res == -EINTR)) {
-    heph::panic(fmt::format("::io_uring_submit_and_wait failed: {}",
-                            std::error_code(-res, std::system_category()).message()));
+    heph::panic("::io_uring_submit_and_wait failed: {}",
+                std::error_code(-res, std::system_category()).message());
   }
 
   for (auto* cqe = nextCompletion(); cqe != nullptr; cqe = nextCompletion()) {
@@ -147,8 +145,8 @@ void IoRing::run(const std::function<void()>& on_started, const std::function<bo
   res = ::io_uring_register_ring_fd(&ring_);
 
   if (res < 0) {
-    heph::panic(fmt::format("::io_uring_register_ring_fd failed: {}",
-                            std::error_code(-res, std::system_category()).message()));
+    heph::panic("::io_uring_register_ring_fd failed: {}",
+                std::error_code(-res, std::system_category()).message());
   }
   current_ring = this;
   running_.store(true, std::memory_order_release);
@@ -161,8 +159,8 @@ void IoRing::run(const std::function<void()>& on_started, const std::function<bo
   res = ::io_uring_unregister_ring_fd(&ring_);
 
   if (res < 0) {
-    heph::panic(fmt::format("::io_uring_unregister_ring_fd failed: {}",
-                            std::error_code(-res, std::system_category()).message()));
+    heph::panic("::io_uring_unregister_ring_fd failed: {}",
+                std::error_code(-res, std::system_category()).message());
   }
   current_ring = nullptr;
 }
@@ -200,8 +198,7 @@ auto IoRing::getSqe() -> ::io_uring_sqe* {
     }
     const int res = ::io_uring_submit(&ring_);
     if (res < 0 && !(-res == EAGAIN || -res == EINTR)) {
-      heph::panic(fmt::format("::io_uring_submit failed: {}",
-                              std::error_code(-res, std::system_category()).message()));
+      heph::panic("::io_uring_submit failed: {}", std::error_code(-res, std::system_category()).message());
     }
   }
   return nullptr;

--- a/modules/concurrency/src/io_ring/io_ring.cpp
+++ b/modules/concurrency/src/io_ring/io_ring.cpp
@@ -6,7 +6,6 @@
 #include <functional>
 #include <system_error>
 
-#include <fmt/format.h>
 #include <liburing.h>  // NOLINT(misc-include-cleaner)
 #include <liburing/io_uring.h>
 #include <stdexec/stop_token.hpp>

--- a/modules/concurrency/src/io_ring/io_ring.cpp
+++ b/modules/concurrency/src/io_ring/io_ring.cpp
@@ -42,7 +42,7 @@ struct DispatchOperation {
       return;
     }
     if (cqe->res < 0) {
-      heph::panic("dispatch failed: {}", std::error_code(-cqe->res, std::system_category()).message());
+      panic("dispatch failed: {}", std::error_code(-cqe->res, std::system_category()).message());
     }
 
     dispatch_done.store(true, std::memory_order_release);
@@ -70,7 +70,7 @@ IoRing::IoRing(const IoRingConfig& config) : config_(config) {
   const int res = ::io_uring_queue_init(config_.nentries, &ring_, config_.flags);
 
   if (res < 0) {
-    heph::panic("::io_uring_queue_init failed: {}", std::error_code(-res, std::system_category()).message());
+    panic("::io_uring_queue_init failed: {}", std::error_code(-res, std::system_category()).message());
   }
 }
 
@@ -120,8 +120,7 @@ void IoRing::runOnce(bool block) {
     res = ::io_uring_submit_and_get_events(&ring_);
   }
   if (res < 0 && !(res == -EAGAIN || res == -EINTR)) {
-    heph::panic("::io_uring_submit_and_wait failed: {}",
-                std::error_code(-res, std::system_category()).message());
+    panic("::io_uring_submit_and_wait failed: {}", std::error_code(-res, std::system_category()).message());
   }
 
   for (auto* cqe = nextCompletion(); cqe != nullptr; cqe = nextCompletion()) {
@@ -136,7 +135,7 @@ void IoRing::runOnce(bool block) {
 
 void IoRing::run(const std::function<void()>& on_started, const std::function<bool()>& on_progress) {
   if (current_ring != nullptr) {
-    heph::panic("Cannot run ring, another ring is already active for this thread");
+    panic("Cannot run ring, another ring is already active for this thread");
   }
 
   int res = 0;
@@ -144,8 +143,7 @@ void IoRing::run(const std::function<void()>& on_started, const std::function<bo
   res = ::io_uring_register_ring_fd(&ring_);
 
   if (res < 0) {
-    heph::panic("::io_uring_register_ring_fd failed: {}",
-                std::error_code(-res, std::system_category()).message());
+    panic("::io_uring_register_ring_fd failed: {}", std::error_code(-res, std::system_category()).message());
   }
   current_ring = this;
   running_.store(true, std::memory_order_release);
@@ -158,8 +156,8 @@ void IoRing::run(const std::function<void()>& on_started, const std::function<bo
   res = ::io_uring_unregister_ring_fd(&ring_);
 
   if (res < 0) {
-    heph::panic("::io_uring_unregister_ring_fd failed: {}",
-                std::error_code(-res, std::system_category()).message());
+    panic("::io_uring_unregister_ring_fd failed: {}",
+          std::error_code(-res, std::system_category()).message());
   }
   current_ring = nullptr;
 }
@@ -197,7 +195,7 @@ auto IoRing::getSqe() -> ::io_uring_sqe* {
     }
     const int res = ::io_uring_submit(&ring_);
     if (res < 0 && !(-res == EAGAIN || -res == EINTR)) {
-      heph::panic("::io_uring_submit failed: {}", std::error_code(-res, std::system_category()).message());
+      panic("::io_uring_submit failed: {}", std::error_code(-res, std::system_category()).message());
     }
   }
   return nullptr;

--- a/modules/concurrency/src/io_ring/io_ring_operation_registration.cpp
+++ b/modules/concurrency/src/io_ring/io_ring_operation_registration.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <fmt/format.h>
 #include <liburing.h>  // NOLINT(misc-include-cleaner)
 #include <liburing/io_uring.h>
 

--- a/modules/concurrency/src/io_ring/io_ring_operation_registration.cpp
+++ b/modules/concurrency/src/io_ring/io_ring_operation_registration.cpp
@@ -20,26 +20,25 @@ auto IoRingOperationRegistry::instance() -> IoRingOperationRegistry& {
 }
 void IoRingOperationRegistry::handleCompletion(std::uint8_t idx, void* operation, ::io_uring_cqe* cqe) {
   if (idx >= size) {
-    heph::panic(fmt::format("Index out of range: {} >= {}", idx, size));
+    heph::panic("Index out of range: {} >= {}", idx, size);
   }
   handle_completion_function_table.at(idx)(operation, cqe);
 }
 void IoRingOperationRegistry::prepare(std::uint8_t idx, void* operation, ::io_uring_sqe* sqe) {
   if (idx >= size) {
-    heph::panic(fmt::format("Index out of range: {} >= {}", idx, size));
+    heph::panic("Index out of range: {} >= {}", idx, size);
   }
   prepare_function_table.at(idx)(operation, sqe);
 }
 auto IoRingOperationRegistry::hasPrepare(std::uint8_t idx) -> bool {
-  heph::panicIf(idx >= size, fmt::format("Index out of range: {} >= {}", idx, size));
+  heph::panicIf(idx >= size, "Index out of range: {} >= {}", idx, size);
   return prepare_function_table.at(idx) != nullptr;
 }
 void IoRingOperationRegistry::registerOperation(std::uint8_t idx, const void* identifier,
                                                 prepare_function_t prepare_func,
                                                 handle_completion_function_t handle_completion) {
   if (idx >= CAPACITY) {
-    static auto msg = fmt::format("IoRingOperationRegistry exceeded capacity of {}", CAPACITY);
-    heph::panic(msg);
+    heph::panic("IoRingOperationRegistry exceeded capacity of {}", CAPACITY);
   }
   operation_identifier_table.at(idx) = identifier;
   prepare_function_table.at(idx) = prepare_func;

--- a/modules/concurrency/src/io_ring/io_ring_operation_registration.cpp
+++ b/modules/concurrency/src/io_ring/io_ring_operation_registration.cpp
@@ -19,25 +19,25 @@ auto IoRingOperationRegistry::instance() -> IoRingOperationRegistry& {
 }
 void IoRingOperationRegistry::handleCompletion(std::uint8_t idx, void* operation, ::io_uring_cqe* cqe) {
   if (idx >= size) {
-    heph::panic("Index out of range: {} >= {}", idx, size);
+    panic("Index out of range: {} >= {}", idx, size);
   }
   handle_completion_function_table.at(idx)(operation, cqe);
 }
 void IoRingOperationRegistry::prepare(std::uint8_t idx, void* operation, ::io_uring_sqe* sqe) {
   if (idx >= size) {
-    heph::panic("Index out of range: {} >= {}", idx, size);
+    panic("Index out of range: {} >= {}", idx, size);
   }
   prepare_function_table.at(idx)(operation, sqe);
 }
 auto IoRingOperationRegistry::hasPrepare(std::uint8_t idx) -> bool {
-  heph::panicIf(idx >= size, "Index out of range: {} >= {}", idx, size);
+  panicIf(idx >= size, "Index out of range: {} >= {}", idx, size);
   return prepare_function_table.at(idx) != nullptr;
 }
 void IoRingOperationRegistry::registerOperation(std::uint8_t idx, const void* identifier,
                                                 prepare_function_t prepare_func,
                                                 handle_completion_function_t handle_completion) {
   if (idx >= CAPACITY) {
-    heph::panic("IoRingOperationRegistry exceeded capacity of {}", CAPACITY);
+    panic("IoRingOperationRegistry exceeded capacity of {}", CAPACITY);
   }
   operation_identifier_table.at(idx) = identifier;
   prepare_function_table.at(idx) = prepare_func;

--- a/modules/concurrency/src/io_ring/timer.cpp
+++ b/modules/concurrency/src/io_ring/timer.cpp
@@ -9,7 +9,6 @@
 #include <limits>
 #include <system_error>
 
-#include <fmt/format.h>
 #include <liburing.h>  // NOLINT(misc-include-cleaner)
 #include <liburing/io_uring.h>
 

--- a/modules/concurrency/src/io_ring/timer.cpp
+++ b/modules/concurrency/src/io_ring/timer.cpp
@@ -39,8 +39,7 @@ void Timer::Operation::prepare(::io_uring_sqe* sqe) const {
 
 void Timer::Operation::handleCompletion(::io_uring_cqe* cqe) const {
   if (cqe->res < 0 && cqe->res != -ETIME) {
-    heph::panic(
-        fmt::format("timer failed: {}", std::error_code(-cqe->res, std::system_category()).message()));
+    heph::panic("timer failed: {}", std::error_code(-cqe->res, std::system_category()).message());
   }
   timer->timer_operation_.reset();
 
@@ -101,8 +100,7 @@ void Timer::UpdateOperation::handleCompletion(::io_uring_cqe* cqe) const {
       timer->tick();
       return;
     }
-    heph::panic(
-        fmt::format("timer failed: {}", std::error_code(-cqe->res, std::system_category()).message()));
+    heph::panic("timer failed: {}", std::error_code(-cqe->res, std::system_category()).message());
   }
   if (timer->next_timeout_.tv_sec != next_timeout.tv_sec ||
       timer->next_timeout_.tv_nsec != next_timeout.tv_nsec) {

--- a/modules/concurrency/src/io_ring/timer.cpp
+++ b/modules/concurrency/src/io_ring/timer.cpp
@@ -38,7 +38,7 @@ void Timer::Operation::prepare(::io_uring_sqe* sqe) const {
 
 void Timer::Operation::handleCompletion(::io_uring_cqe* cqe) const {
   if (cqe->res < 0 && cqe->res != -ETIME) {
-    heph::panic("timer failed: {}", std::error_code(-cqe->res, std::system_category()).message());
+    panic("timer failed: {}", std::error_code(-cqe->res, std::system_category()).message());
   }
   timer->timer_operation_.reset();
 
@@ -99,7 +99,7 @@ void Timer::UpdateOperation::handleCompletion(::io_uring_cqe* cqe) const {
       timer->tick();
       return;
     }
-    heph::panic("timer failed: {}", std::error_code(-cqe->res, std::system_category()).message());
+    panic("timer failed: {}", std::error_code(-cqe->res, std::system_category()).message());
   }
   if (timer->next_timeout_.tv_sec != next_timeout.tv_sec ||
       timer->next_timeout_.tv_nsec != next_timeout.tv_nsec) {

--- a/modules/concurrency/tests/context_tests.cpp
+++ b/modules/concurrency/tests/context_tests.cpp
@@ -51,12 +51,12 @@ TEST(ContextTests, scheduleException) {
   bool called{ false };
   auto sender = stdexec::schedule(context.scheduler()) | stdexec::then([&context] {
                   context.requestStop();
-                  heph::panic("testing");
+                  panic("testing");
                 }) |
                 stdexec::upon_error([&called](const std::exception_ptr& eptr) {
                   try {
                     std::rethrow_exception(eptr);
-                  } catch (heph::Panic&) {  // NOLINT (bugprone-empty-catch)
+                  } catch (Panic&) {  // NOLINT (bugprone-empty-catch)
                   }
                   called = true;
                 });

--- a/modules/concurrency/tests/io_ring/io_ring_operation_tests.cpp
+++ b/modules/concurrency/tests/io_ring/io_ring_operation_tests.cpp
@@ -68,8 +68,8 @@ TEST(IoRingTest, IoRingOperationRegistry) {
   EXPECT_TRUE(test_operation1.prepare_called);
   EXPECT_TRUE(test_operation1.handle_completion_called);
 
-  EXPECT_THROW(registry.prepare(1, nullptr, nullptr), heph::Panic);
-  EXPECT_THROW(registry.handleCompletion(1, nullptr, nullptr), heph::Panic);
+  EXPECT_THROW(registry.prepare(1, nullptr, nullptr), Panic);
+  EXPECT_THROW(registry.handleCompletion(1, nullptr, nullptr), Panic);
 
   auto idx3 = registry.registerOperation<TestOperation2>();
   EXPECT_EQ(idx3, 1);
@@ -97,8 +97,8 @@ TEST(IoRingTest, IoRingOperationRegistry) {
   EXPECT_TRUE(test_operation2.prepare_called);
   EXPECT_TRUE(test_operation2.handle_completion_called);
 
-  EXPECT_THROW(registry.prepare(2, nullptr, nullptr), heph::Panic);
-  EXPECT_THROW(registry.handleCompletion(2, nullptr, nullptr), heph::Panic);
+  EXPECT_THROW(registry.prepare(2, nullptr, nullptr), Panic);
+  EXPECT_THROW(registry.handleCompletion(2, nullptr, nullptr), Panic);
 }
 
 TEST(IoRingTest, IoRingOperationPointer) {
@@ -138,15 +138,15 @@ TEST(IoRingTest, IoRingOperationPointer) {
 
   EXPECT_THROW(
       IoRingOperationRegistry::instance().prepare(IoRingOperationRegistry::instance().size, nullptr, nullptr),
-      heph::Panic);
+      Panic);
   EXPECT_THROW(IoRingOperationRegistry::instance().handleCompletion(IoRingOperationRegistry::instance().size,
                                                                     nullptr, nullptr),
-               heph::Panic);
+               Panic);
   EXPECT_THROW(IoRingOperationRegistry::instance().prepare(IoRingOperationRegistry::instance().size + 2,
                                                            nullptr, nullptr),
-               heph::Panic);
+               Panic);
   EXPECT_THROW(IoRingOperationRegistry::instance().handleCompletion(
                    IoRingOperationRegistry::instance().size + 2, nullptr, nullptr),
-               heph::Panic);
+               Panic);
 }
 }  // namespace heph::concurrency::io_ring::tests

--- a/modules/concurrency/tests/spinner_tests.cpp
+++ b/modules/concurrency/tests/spinner_tests.cpp
@@ -5,7 +5,6 @@
 #include <atomic>
 #include <chrono>
 #include <cstddef>
-#include <source_location>
 #include <thread>
 #include <utility>
 

--- a/modules/concurrency/tests/spinner_tests.cpp
+++ b/modules/concurrency/tests/spinner_tests.cpp
@@ -90,13 +90,13 @@ TEST_F(SpinnerTest, StartStopTest) {
   auto cb = createTrivialCallback();
   Spinner spinner{ std::move(cb) };
 
-  EXPECT_THROW_OR_DEATH(spinner.stop(), heph::Panic, "");
+  EXPECT_THROW_OR_DEATH(spinner.stop(), Panic, "");
   spinner.start();
 
-  EXPECT_THROW_OR_DEATH(spinner.start(), heph::Panic, "");
+  EXPECT_THROW_OR_DEATH(spinner.start(), Panic, "");
   spinner.stop().get();
 
-  EXPECT_THROW_OR_DEATH(spinner.stop(), heph::Panic, "");
+  EXPECT_THROW_OR_DEATH(spinner.stop(), Panic, "");
 }
 
 TEST_F(SpinnerTest, SpinTest) {
@@ -168,7 +168,7 @@ TEST_F(SpinnerTest, ExceptionHandling) {
 
   spinner.start();
   spinner.wait();
-  EXPECT_THROW(spinner.stop().get(), heph::Panic);
+  EXPECT_THROW(spinner.stop().get(), Panic);
   EXPECT_TRUE(callback_called);
 }
 

--- a/modules/concurrency/tests/spinner_tests.cpp
+++ b/modules/concurrency/tests/spinner_tests.cpp
@@ -46,7 +46,7 @@ struct SpinnerTest : public ::testing::Test {
   }
 
   [[nodiscard]] static auto createThrowingCallback() -> Spinner::StoppableCallback {
-    auto cb = []() { panic("This is a test exception.", std::source_location::current()); };
+    auto cb = []() { panic("This is a test exception."); };
     return Spinner::createNeverStoppingCallback(std::move(cb));
   }
 

--- a/modules/conduit/include/hephaestus/conduit/detail/input_base.h
+++ b/modules/conduit/include/hephaestus/conduit/detail/input_base.h
@@ -108,7 +108,7 @@ public:
           node_->engine().scheduler().schedule() |
           stdexec::then([this, u = std::forward<U>(u)] { return setValue(std::move(u)); }));
       if (!res.has_value()) {
-        heph::panic("Could not set value, engine was stopped");
+        panic("Could not set value, engine was stopped");
       }
       return std::get<0>(*res);
     }

--- a/modules/conduit/tests/node_tests.cpp
+++ b/modules/conduit/tests/node_tests.cpp
@@ -141,7 +141,7 @@ struct TriggerExceptionOperation : Node<TriggerExceptionOperation, BasicOperatio
     EXPECT_FALSE(operation.data().triggered);
     EXPECT_FALSE(operation.data().executed);
     operation.data().triggered = true;
-    heph::panic("Running around with scissors is dangerous");
+    panic("Running around with scissors is dangerous");
     return stdexec::just();
   }
 
@@ -156,7 +156,7 @@ TEST(NodeTests, nodeTriggerException) {
   NodeEngine engine{ {} };
   auto dummy = engine.createNode<TriggerExceptionOperation>();
 
-  EXPECT_THROW(engine.run(), heph::Panic);
+  EXPECT_THROW(engine.run(), Panic);
   EXPECT_TRUE(dummy->data().triggered);
   EXPECT_FALSE(dummy->data().executed);
   EXPECT_FALSE(TriggerExceptionOperation::HAS_PERIOD);
@@ -174,7 +174,7 @@ struct ExecutionExceptionOperation : Node<ExecutionExceptionOperation, BasicOper
     EXPECT_TRUE(operation.data().triggered);
     EXPECT_FALSE(operation.data().executed);
     operation.data().executed = true;
-    heph::panic("Running around with scissors is dangerous");
+    panic("Running around with scissors is dangerous");
   }
 };
 
@@ -182,7 +182,7 @@ TEST(NodeTests, nodeExecutionException) {
   NodeEngine engine{ {} };
   auto dummy = engine.createNode<ExecutionExceptionOperation>();
 
-  EXPECT_THROW(engine.run(), heph::Panic);
+  EXPECT_THROW(engine.run(), Panic);
   EXPECT_TRUE(dummy->data().triggered);
   EXPECT_TRUE(dummy->data().executed);
   EXPECT_FALSE(ExecutionExceptionOperation::HAS_PERIOD);

--- a/modules/containers_reflection/include/hephaestus/containers_reflection/chrono.h
+++ b/modules/containers_reflection/include/hephaestus/containers_reflection/chrono.h
@@ -28,20 +28,18 @@ struct Reflector<std::chrono::duration<Rep, Period>> {  // NOLINT(misc-include-c
 
   static auto to(const ReflType& value) -> std::chrono::duration<Rep, Period> {
     heph::panicIf(value.empty(), "Duration string is empty.");
-    heph::panicIf(
-        value.back() != 's',
-        fmt::format("Duration string does not end with 's'. Expected format like '123.456231s', got '{}'.",
-                    value));
+    heph::panicIf(value.back() != 's',
+                  "Duration string does not end with 's'. Expected format like '123.456231s', got '{}'.",
+                  value);
     // Note that those invalid casts may throw in which case reflect-cpp will return an error
     const size_t parsed_length = value.length() - 1;  // Remove the 's' at the end
     double value_in_seconds = 0.0;
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     const auto [ptr, err] = std::from_chars(value.data(), value.data() + parsed_length, value_in_seconds,
                                             std::chars_format::general);
-    heph::panicIf(err != std::errc(), fmt::format("Error parsing duration string: {}", value));
+    heph::panicIf(err != std::errc(), "Error parsing duration string: {}", value);
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    heph::panicIf(ptr != value.data() + parsed_length,
-                  fmt::format("Only a part of the string {} was parsed.", value));
+    heph::panicIf(ptr != value.data() + parsed_length, "Only a part of the string {} was parsed.", value);
 
     const std::chrono::duration<double> duration_sec(value_in_seconds);
 

--- a/modules/ipc/include/hephaestus/ipc/zenoh/action_server/pollable_action_server.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/action_server/pollable_action_server.h
@@ -162,9 +162,9 @@ template <typename RequestT, typename StatusT, typename ReplyT>
 void PollableActionServer<RequestT, StatusT, ReplyT>::complete(ReplyT reply) {
   std::unique_lock lock(mutex_);
 
-  heph::panicIf(state_ != State::IN_PROGRESS && state_ != State::IN_PROGRESS_SHOULD_ABORT,
-                "PollableActionServer::complete should only be called when the current state is "
-                "IN_PROGRESS or IN_PROGRESS_SHOULD_ABORT.");
+  panicIf(state_ != State::IN_PROGRESS && state_ != State::IN_PROGRESS_SHOULD_ABORT,
+          "PollableActionServer::complete should only be called when the current state is "
+          "IN_PROGRESS or IN_PROGRESS_SHOULD_ABORT.");
 
   reply_ = std::move(reply);
   state_ = State::COMPLETED;
@@ -176,9 +176,9 @@ template <typename RequestT, typename StatusT, typename ReplyT>
 void PollableActionServer<RequestT, StatusT, ReplyT>::setStatus(StatusT status) {
   std::unique_lock lock(mutex_);
 
-  heph::panicIf(state_ != State::IN_PROGRESS && state_ != State::IN_PROGRESS_SHOULD_ABORT,
-                "PollableActionServer::setStatus should only be called when the current state is "
-                "IN_PROGRESS or IN_PROGRESS_SHOULD_ABORT.");
+  panicIf(state_ != State::IN_PROGRESS && state_ != State::IN_PROGRESS_SHOULD_ABORT,
+          "PollableActionServer::setStatus should only be called when the current state is "
+          "IN_PROGRESS or IN_PROGRESS_SHOULD_ABORT.");
 
   status_ = status;
   condition_variable_.notify_one();

--- a/modules/ipc/include/hephaestus/ipc/zenoh/service.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/service.h
@@ -161,10 +161,10 @@ auto deserializeRequest(const ::zenoh::Query& query) -> RequestT {
   const auto& keyexpr = query.get_keyexpr().as_string_view();
 
   const auto encoding = query.get_encoding();
-  panicIf(!encoding.has_value(), "Serivce {}: encoding is missing in query.", keyexpr);
+  panicIf(!encoding.has_value(), "Service {}: encoding is missing in query.", keyexpr);
 
   auto payload = query.get_payload();
-  panicIf(!payload.has_value(), "Serivce {}: payload is missing in query.", keyexpr);
+  panicIf(!payload.has_value(), "Service {}: payload is missing in query.", keyexpr);
 
   if constexpr (std::is_same_v<RequestT, std::string>) {
     panicIf(encoding.value().get() !=  // NOLINT(bugprone-unchecked-optional-access)
@@ -290,7 +290,7 @@ Service<RequestT, ReplyT>::Service(SessionPtr session, TopicConfig topic_config,
             generateLivelinessTokenKeyexpr(topic_config_.name, session_->zenoh_session.get_zid(),
                                            EndpointType::SERVICE_SERVER),
             ::zenoh::Session::LivelinessDeclarationOptions::create_default(), &result));
-    panicIf(result != Z_OK, "[Publisher {}] failed to create livelines token, result {}", topic_config_.name,
+    panicIf(result != Z_OK, "[Publisher {}] failed to create liveliness token, result {}", topic_config_.name,
             result);
   }
 }

--- a/modules/ipc/include/hephaestus/ipc/zenoh/service.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/service.h
@@ -18,7 +18,6 @@
 #include <variant>
 #include <vector>
 
-#include <fmt/format.h>
 #include <zenoh.h>
 #include <zenoh/api/base.hxx>
 #include <zenoh/api/channels.hxx>

--- a/modules/ipc/include/hephaestus/ipc/zenoh/service.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/service.h
@@ -162,23 +162,23 @@ auto deserializeRequest(const ::zenoh::Query& query) -> RequestT {
   const auto& keyexpr = query.get_keyexpr().as_string_view();
 
   const auto encoding = query.get_encoding();
-  panicIf(!encoding.has_value(), fmt::format("Serivce {}: encoding is missing in query.", keyexpr));
+  panicIf(!encoding.has_value(), "Serivce {}: encoding is missing in query.", keyexpr);
 
   auto payload = query.get_payload();
-  panicIf(!payload.has_value(), fmt::format("Serivce {}: payload is missing in query.", keyexpr));
+  panicIf(!payload.has_value(), "Serivce {}: payload is missing in query.", keyexpr);
 
   if constexpr (std::is_same_v<RequestT, std::string>) {
     panicIf(encoding.value().get() !=  // NOLINT(bugprone-unchecked-optional-access)
                 ::zenoh::Encoding::Predefined::zenoh_string(),
-            fmt::format("Encoding for std::string should be '{}'",
-                        ::zenoh::Encoding::Predefined::zenoh_string().as_string()));
+            "Encoding for std::string should be '{}'",
+            ::zenoh::Encoding::Predefined::zenoh_string().as_string());
 
     return payload->get().as_string();  // NOLINT(bugprone-unchecked-optional-access)
   } else {
     panicIf(encoding.value().get() !=  // NOLINT(bugprone-unchecked-optional-access)
                 ::zenoh::Encoding::Predefined::zenoh_bytes(),
-            fmt::format("Encoding for std::string should be '{}'",
-                        ::zenoh::Encoding::Predefined::zenoh_bytes().as_string()));
+            "Encoding for std::string should be '{}'",
+            ::zenoh::Encoding::Predefined::zenoh_bytes().as_string());
 
     auto buffer = toByteVector(payload->get());  // NOLINT(bugprone-unchecked-optional-access)
 
@@ -194,14 +194,14 @@ auto onReply(const ::zenoh::Sample& sample) -> ServiceResponse<ReplyT> {
 
   if constexpr (std::is_same_v<ReplyT, std::string>) {
     panicIf(sample.get_encoding() != ::zenoh::Encoding::Predefined::zenoh_string(),
-            fmt::format("Encoding for Service {} should be '{}'", server_topic,
-                        ::zenoh::Encoding::Predefined::zenoh_string().as_string()));
+            "Encoding for Service {} should be '{}'", server_topic,
+            ::zenoh::Encoding::Predefined::zenoh_string().as_string());
     auto payload = sample.get_payload().as_string();
     return ServiceResponse<ReplyT>{ .topic = server_topic, .value = std::move(payload) };
   } else {
     panicIf(sample.get_encoding() != ::zenoh::Encoding::Predefined::zenoh_bytes(),
-            fmt::format("Encoding for Service {} should be '{}'", server_topic,
-                        ::zenoh::Encoding::Predefined::zenoh_bytes().as_string()));
+            "Encoding for Service {} should be '{}'", server_topic,
+            ::zenoh::Encoding::Predefined::zenoh_bytes().as_string());
     auto buffer = toByteVector(sample.get_payload());
     ReplyT reply{};
     serdes::deserialize(buffer, reply);
@@ -282,8 +282,8 @@ Service<RequestT, ReplyT>::Service(SessionPtr session, TopicConfig topic_config,
   queryable_ = std::make_unique<::zenoh::Queryable<void>>(session_->zenoh_session.declare_queryable(
       keyexpr, std::move(on_query_cb), []() {}, ::zenoh::Session::QueryableOptions::create_default(),
       &result));
-  panicIf(result != Z_OK,
-          fmt::format("[Service '{}'] failed to create zenoh queryable, err {}", topic_config_.name, result));
+  panicIf(result != Z_OK, "[Service '{}'] failed to create zenoh queryable, err {}", topic_config_.name,
+          result);
 
   if (config.create_liveliness_token) {
     liveliness_token_ =
@@ -291,8 +291,8 @@ Service<RequestT, ReplyT>::Service(SessionPtr session, TopicConfig topic_config,
             generateLivelinessTokenKeyexpr(topic_config_.name, session_->zenoh_session.get_zid(),
                                            EndpointType::SERVICE_SERVER),
             ::zenoh::Session::LivelinessDeclarationOptions::create_default(), &result));
-    panicIf(result != Z_OK, fmt::format("[Publisher {}] failed to create livelines token, result {}",
-                                        topic_config_.name, result));
+    panicIf(result != Z_OK, "[Publisher {}] failed to create livelines token, result {}", topic_config_.name,
+            result);
   }
 }
 

--- a/modules/ipc/include/hephaestus/ipc/zenoh/service_client.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/service_client.h
@@ -53,16 +53,16 @@ ServiceClient<RequestT, ReplyT>::ServiceClient(SessionPtr session, TopicConfig t
   ::zenoh::ZResult result{};
   querier_ = std::make_unique<::zenoh::Querier>(session_->zenoh_session.declare_querier(
       keyexpr, std::move(options), &result));  // NOLINT(performance-move-const-arg, hicpp-move-const-arg)
-  panicIf(result != 0, fmt::format("[ServiceClient '{}'] failed to create zenoh querier, err {}",
-                                   topic_config_.name, result));
+  panicIf(result != 0, "[ServiceClient '{}'] failed to create zenoh querier, err {}", topic_config_.name,
+          result);
 
   liveliness_token_ =
       std::make_unique<::zenoh::LivelinessToken>(session_->zenoh_session.liveliness_declare_token(
           generateLivelinessTokenKeyexpr(topic_config_.name, session_->zenoh_session.get_zid(),
                                          EndpointType::SERVICE_CLIENT),
           ::zenoh::Session::LivelinessDeclarationOptions::create_default(), &result));
-  panicIf(result != 0, fmt::format("[ServiceClient {}] failed to create liveliness token, result {}",
-                                   topic_config_.name, result));
+  panicIf(result != 0, "[ServiceClient {}] failed to create liveliness token, result {}", topic_config_.name,
+          result);
 }
 
 template <typename RequestT, typename ReplyT>
@@ -78,7 +78,7 @@ auto ServiceClient<RequestT, ReplyT>::call(const RequestT& request) -> std::vect
   ::zenoh::ZResult result{};
   auto replies =
       querier_->get("", ::zenoh::channels::FifoChannel(FIFO_QUEUE_SIZE), std::move(get_options), &result);
-  panicIf(result != 0, fmt::format("Failed to call service on '{}'", topic_config_.name));
+  panicIf(result != 0, "Failed to call service on '{}'", topic_config_.name);
 
   return internal::getServiceCallResponses<ReplyT>(replies);
 }

--- a/modules/ipc/include/hephaestus/ipc/zenoh/service_client.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/service_client.h
@@ -10,8 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/format.h>
-
 #include "hephaestus/ipc/topic.h"
 #include "hephaestus/ipc/zenoh/liveliness.h"
 #include "hephaestus/ipc/zenoh/service.h"

--- a/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
@@ -52,8 +52,8 @@ private:
     if (metadata.type_info != serialized_type) {
       heph::log(heph::ERROR, "subscriber type mismatch; terminating", "topic", metadata.topic,
                 "subscriber_type", serialized_type, "topic_type", metadata.type_info);
-      panic(fmt::format("Topic '{}' is of type '{}', but subscriber expect type '{}'", metadata.topic,
-                        metadata.type_info, serialized_type));
+      panic("Topic '{}' is of type '{}', but subscriber expect type '{}'", metadata.topic,
+                        metadata.type_info, serialized_type);
     }
   }
 

--- a/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
@@ -50,8 +50,8 @@ private:
     if (metadata.type_info != serialized_type) {
       heph::log(heph::ERROR, "subscriber type mismatch; terminating", "topic", metadata.topic,
                 "subscriber_type", serialized_type, "topic_type", metadata.type_info);
-      panic("Topic '{}' is of type '{}', but subscriber expects type '{}'", metadata.topic, metadata.type_info,
-            serialized_type);
+      panic("Topic '{}' is of type '{}', but subscriber expects type '{}'", metadata.topic,
+            metadata.type_info, serialized_type);
     }
   }
 

--- a/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
@@ -50,7 +50,7 @@ private:
     if (metadata.type_info != serialized_type) {
       heph::log(heph::ERROR, "subscriber type mismatch; terminating", "topic", metadata.topic,
                 "subscriber_type", serialized_type, "topic_type", metadata.type_info);
-      panic("Topic '{}' is of type '{}', but subscriber expect type '{}'", metadata.topic, metadata.type_info,
+      panic("Topic '{}' is of type '{}', but subscriber expects type '{}'", metadata.topic, metadata.type_info,
             serialized_type);
     }
   }

--- a/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
@@ -52,8 +52,8 @@ private:
     if (metadata.type_info != serialized_type) {
       heph::log(heph::ERROR, "subscriber type mismatch; terminating", "topic", metadata.topic,
                 "subscriber_type", serialized_type, "topic_type", metadata.type_info);
-      panic("Topic '{}' is of type '{}', but subscriber expect type '{}'", metadata.topic,
-                        metadata.type_info, serialized_type);
+      panic("Topic '{}' is of type '{}', but subscriber expect type '{}'", metadata.topic, metadata.type_info,
+            serialized_type);
     }
   }
 

--- a/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/subscriber.h
@@ -11,8 +11,6 @@
 #include <span>
 #include <utility>
 
-#include <fmt/format.h>
-
 #include "hephaestus/ipc/topic.h"
 #include "hephaestus/ipc/zenoh/raw_subscriber.h"
 #include "hephaestus/ipc/zenoh/session.h"

--- a/modules/ipc/src/topic.cpp
+++ b/modules/ipc/src/topic.cpp
@@ -14,7 +14,7 @@
 namespace heph::ipc {
 TopicConfig::TopicConfig(std::string topic_name) : name(std::move(topic_name)) {
   if (name.empty() || name.starts_with('/') || name.ends_with('/')) {
-    panic(fmt::format("invalid topic name: '{}'", name));
+    panic("invalid topic name: '{}'", name);
   }
 }
 }  // namespace heph::ipc

--- a/modules/ipc/src/topic.cpp
+++ b/modules/ipc/src/topic.cpp
@@ -7,8 +7,6 @@
 #include <string>
 #include <utility>
 
-#include <fmt/format.h>
-
 #include "hephaestus/utils/exception.h"
 
 namespace heph::ipc {

--- a/modules/ipc/src/zenoh/program_options.cpp
+++ b/modules/ipc/src/zenoh/program_options.cpp
@@ -10,8 +10,6 @@
 #include <tuple>
 #include <utility>
 
-#include <fmt/format.h>
-
 #include "hephaestus/cli/program_options.h"
 #include "hephaestus/ipc/topic.h"
 #include "hephaestus/ipc/topic_filter.h"

--- a/modules/ipc/src/zenoh/program_options.cpp
+++ b/modules/ipc/src/zenoh/program_options.cpp
@@ -78,7 +78,7 @@ auto parseProgramOptions(const heph::cli::ProgramOptions& args)
   } else if (mode == "client") {
     config.mode = Mode::CLIENT;
   } else {
-    panic(fmt::format("invalid mode value: {}", mode));
+    panic("invalid mode value: {}", mode);
   }
 
   auto protocol = args.getOption<std::string>("protocol");
@@ -89,7 +89,7 @@ auto parseProgramOptions(const heph::cli::ProgramOptions& args)
   } else if (protocol == "tcp") {
     config.protocol = Protocol::TCP;
   } else {
-    panic(fmt::format("invalid value {} for option 'protocol'", protocol));
+    panic("invalid value {} for option 'protocol'", protocol);
   }
 
   config.router = args.getOption<std::string>("router");

--- a/modules/ipc/src/zenoh/raw_publisher.cpp
+++ b/modules/ipc/src/zenoh/raw_publisher.cpp
@@ -10,7 +10,6 @@
 #include <string>
 #include <utility>
 
-#include <fmt/format.h>
 #include <zenoh.h>
 #include <zenoh/api/base.hxx>
 #include <zenoh/api/encoding.hxx>

--- a/modules/ipc/src/zenoh/raw_publisher.cpp
+++ b/modules/ipc/src/zenoh/raw_publisher.cpp
@@ -60,8 +60,8 @@ RawPublisher::RawPublisher(SessionPtr session, TopicConfig topic_config, serdes:
             generateLivelinessTokenKeyexpr(topic_config_.name, session_->zenoh_session.get_zid(),
                                            EndpointType::PUBLISHER),
             ::zenoh::Session::LivelinessDeclarationOptions::create_default(), &result));
-    panicIf(result != Z_OK, fmt::format("[Publisher {}] failed to create livelines token, result {}",
-                                        topic_config_.name, result));
+    panicIf(result != Z_OK, "[Publisher {}] failed to create livelines token, result {}", topic_config_.name,
+            result);
   }
 
   if (match_cb_) {

--- a/modules/ipc/src/zenoh/raw_publisher.cpp
+++ b/modules/ipc/src/zenoh/raw_publisher.cpp
@@ -59,7 +59,7 @@ RawPublisher::RawPublisher(SessionPtr session, TopicConfig topic_config, serdes:
             generateLivelinessTokenKeyexpr(topic_config_.name, session_->zenoh_session.get_zid(),
                                            EndpointType::PUBLISHER),
             ::zenoh::Session::LivelinessDeclarationOptions::create_default(), &result));
-    panicIf(result != Z_OK, "[Publisher {}] failed to create livelines token, result {}", topic_config_.name,
+    panicIf(result != Z_OK, "[Publisher {}] failed to create liveliness token, result {}", topic_config_.name,
             result);
   }
 

--- a/modules/ipc/src/zenoh/raw_subscriber.cpp
+++ b/modules/ipc/src/zenoh/raw_subscriber.cpp
@@ -13,7 +13,6 @@
 #include <utility>
 
 #include <absl/strings/numbers.h>
-#include <fmt/format.h>
 #include <zenoh.h>
 #include <zenoh/api/base.hxx>
 #include <zenoh/api/ext/advanced_subscriber.hxx>

--- a/modules/ipc/src/zenoh/raw_subscriber.cpp
+++ b/modules/ipc/src/zenoh/raw_subscriber.cpp
@@ -99,8 +99,8 @@ RawSubscriber::RawSubscriber(SessionPtr session, TopicConfig topic_config, DataC
       session_->zenoh_session.ext().declare_advanced_subscriber(
           keyexpr, [this](const ::zenoh::Sample& sample) { this->callback(sample); }, []() {},
           std::move(sub_options), &result));
-  panicIf(result != Z_OK, fmt::format("[Subscriber {}] failed to create zenoh subscriber, err {}",
-                                      topic_config_.name, result));
+  panicIf(result != Z_OK, "[Subscriber {}] failed to create zenoh subscriber, err {}", topic_config_.name,
+          result);
 
   if (config.create_liveliness_token) {
     liveliness_token_ =

--- a/modules/ipc/src/zenoh/session.cpp
+++ b/modules/ipc/src/zenoh/session.cpp
@@ -38,8 +38,7 @@ void removeInvalidChar(std::string& str) {
 [[nodiscard]] auto createSessionId(std::string_view id) -> std::string {
   static constexpr std::size_t MAX_SESSION_ID_SIZE = 16;
 
-  panicIf(!isValidId(id),
-          fmt::format("invalid session id: {}, only alphanumeric and _ characters allowed", id));
+  panicIf(!isValidId(id), "invalid session id: {}, only alphanumeric and _ characters allowed", id);
 
   std::string session_id{ id };
 

--- a/modules/ipc/tests/pollable_action_server_tests.cpp
+++ b/modules/ipc/tests/pollable_action_server_tests.cpp
@@ -52,7 +52,7 @@ TEST(PollableActionServerTest, CompleteAction) {
 
     auto reply_future = callActionServer<types::DummyType, types::DummyPrimitivesType, types::DummyType>(
         session, topic_config, expected_request, [](const auto&) {}, REQUEST_TIMEOUT);
-    heph::panicIf(!reply_future.valid(), "callActionServer failed.");
+    panicIf(!reply_future.valid(), "callActionServer failed.");
 
     while (true) {
       if (reply_future.wait_for(ZERO_DURATION) != std::future_status::timeout) {
@@ -100,7 +100,7 @@ TEST(PollableActionServerTest, StopExecution) {
 
     auto reply_future = callActionServer<types::DummyType, types::DummyPrimitivesType, types::DummyType>(
         session, topic_config, expected_request, [](const auto&) {}, REQUEST_TIMEOUT);
-    heph::panicIf(!reply_future.valid(), "callActionServer failed.");
+    panicIf(!reply_future.valid(), "callActionServer failed.");
 
     while (true) {
       if (reply_future.wait_for(ZERO_DURATION) != std::future_status::timeout) {
@@ -160,7 +160,7 @@ TEST(PollableActionServerTest, CompleteActionWithStatusUpdates) {
           last_received_status.store(status);
         },
         REQUEST_TIMEOUT);
-    heph::panicIf(!reply_future.valid(), "callActionServer failed.");
+    panicIf(!reply_future.valid(), "callActionServer failed.");
 
     while (true) {
       if (reply_future.wait_for(ZERO_DURATION) != std::future_status::timeout) {
@@ -206,7 +206,7 @@ TEST(PollableActionServerTest, StopActionServer) {
 
   auto reply_future = callActionServer<types::DummyType, types::DummyPrimitivesType, types::DummyType>(
       session, topic_config, types::DummyType::random(mt), [](const auto&) {}, REQUEST_TIMEOUT);
-  heph::panicIf(!reply_future.valid(), "callActionServer failed.");
+  panicIf(!reply_future.valid(), "callActionServer failed.");
 
   while (!action_server.pollRequest().has_value()) {
     if (reply_future.wait_for(std::chrono::milliseconds{ 0 }) != std::future_status::timeout) {

--- a/modules/net/src/acceptor.cpp
+++ b/modules/net/src/acceptor.cpp
@@ -20,7 +20,7 @@ Acceptor::Acceptor(IpFamily family, Protocol protocol) : socket_(family, protoco
 void Acceptor::listen(int backlog) const {
   const int res = ::listen(socket_.nativeHandle(), backlog);
   if (res == -1) {
-    heph::panic(fmt::format("listen: {}", std::error_code(errno, std::system_category()).message()));
+    heph::panic("listen: {}", std::error_code(errno, std::system_category()).message());
   }
 }
 void Acceptor::bind(const Endpoint& endpoint) const {

--- a/modules/net/src/acceptor.cpp
+++ b/modules/net/src/acceptor.cpp
@@ -7,7 +7,6 @@
 #include <cerrno>
 #include <system_error>
 
-#include <fmt/format.h>
 #include <sys/socket.h>
 
 #include "hephaestus/net/endpoint.h"

--- a/modules/net/src/acceptor.cpp
+++ b/modules/net/src/acceptor.cpp
@@ -19,7 +19,7 @@ Acceptor::Acceptor(IpFamily family, Protocol protocol) : socket_(family, protoco
 void Acceptor::listen(int backlog) const {
   const int res = ::listen(socket_.nativeHandle(), backlog);
   if (res == -1) {
-    heph::panic("listen: {}", std::error_code(errno, std::system_category()).message());
+    panic("listen: {}", std::error_code(errno, std::system_category()).message());
   }
 }
 void Acceptor::bind(const Endpoint& endpoint) const {

--- a/modules/net/src/endpoint.cpp
+++ b/modules/net/src/endpoint.cpp
@@ -34,7 +34,7 @@ Endpoint::Endpoint(IpFamily family, const std::string& ip, std::uint16_t port)
     if (!ip.empty()) {
       const int res = ::inet_pton(AF_INET, ip.c_str(), &addr.sin_addr);
       if (res == 0) {
-        heph::panic(fmt::format("Invalid IPv4 address: {}", ip));
+        heph::panic("Invalid IPv4 address: {}", ip);
       }
       if (res == -1) {
         heph::panic("IPv4 is not supported");
@@ -49,7 +49,7 @@ Endpoint::Endpoint(IpFamily family, const std::string& ip, std::uint16_t port)
     if (!ip.empty()) {
       const int res = inet_pton(AF_INET6, ip.c_str(), &addr.sin6_addr);
       if (res == 0) {
-        heph::panic(fmt::format("Invalid IPv6 address: {}", ip));
+        heph::panic("Invalid IPv6 address: {}", ip);
       }
       if (res == -1) {
         heph::panic("IPv6 is not supported");
@@ -86,8 +86,8 @@ auto Endpoint::ip() const -> std::string {
 
   auto convert = [&](void* addr) {
     if (::inet_ntop(family(), addr, buffer.data(), static_cast<socklen_t>(buffer.size())) == nullptr) {
-      heph::panic(fmt::format("Could not convert sockaddr to ip: {}",
-                              std::error_code(errno, std::system_category()).message()));
+      heph::panic("Could not convert sockaddr to ip: {}",
+                  std::error_code(errno, std::system_category()).message());
     }
   };
 

--- a/modules/net/src/endpoint.cpp
+++ b/modules/net/src/endpoint.cpp
@@ -34,10 +34,10 @@ Endpoint::Endpoint(IpFamily family, const std::string& ip, std::uint16_t port)
     if (!ip.empty()) {
       const int res = ::inet_pton(AF_INET, ip.c_str(), &addr.sin_addr);
       if (res == 0) {
-        heph::panic("Invalid IPv4 address: {}", ip);
+        panic("Invalid IPv4 address: {}", ip);
       }
       if (res == -1) {
-        heph::panic("IPv4 is not supported");
+        panic("IPv4 is not supported");
       }
     }
     addr.sin_port = ::htons(port);
@@ -49,10 +49,10 @@ Endpoint::Endpoint(IpFamily family, const std::string& ip, std::uint16_t port)
     if (!ip.empty()) {
       const int res = inet_pton(AF_INET6, ip.c_str(), &addr.sin6_addr);
       if (res == 0) {
-        heph::panic("Invalid IPv6 address: {}", ip);
+        panic("Invalid IPv6 address: {}", ip);
       }
       if (res == -1) {
-        heph::panic("IPv6 is not supported");
+        panic("IPv6 is not supported");
       }
     }
     addr.sin6_port = ::htons(port);
@@ -86,8 +86,7 @@ auto Endpoint::ip() const -> std::string {
 
   auto convert = [&](void* addr) {
     if (::inet_ntop(family(), addr, buffer.data(), static_cast<socklen_t>(buffer.size())) == nullptr) {
-      heph::panic("Could not convert sockaddr to ip: {}",
-                  std::error_code(errno, std::system_category()).message());
+      panic("Could not convert sockaddr to ip: {}", std::error_code(errno, std::system_category()).message());
     }
   };
 

--- a/modules/net/src/socket.cpp
+++ b/modules/net/src/socket.cpp
@@ -23,7 +23,7 @@ Socket::Socket(IpFamily family, Protocol protocol)
   : fd_(::socket(family == IpFamily::V4 ? AF_INET : AF_INET6,
                  protocol == Protocol::TCP ? SOCK_STREAM : SOCK_DGRAM, 0)) {
   if (fd_ == -1) {
-    heph::panic("socket: {}", std::error_code(errno, std::system_category()).message());
+    panic("socket: {}", std::error_code(errno, std::system_category()).message());
   }
 }
 
@@ -56,7 +56,7 @@ void Socket::bind(const Endpoint& endpoint) const {
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
       ::bind(fd_, reinterpret_cast<const sockaddr*>(handle.data()), static_cast<socklen_t>(handle.size()));
   if (res == -1) {
-    heph::panic("bind: {}", std::error_code(errno, std::system_category()).message());
+    panic("bind: {}", std::error_code(errno, std::system_category()).message());
   }
 }
 
@@ -66,7 +66,7 @@ void Socket::connect(const Endpoint& endpoint) const {
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
       ::connect(fd_, reinterpret_cast<const sockaddr*>(handle.data()), static_cast<socklen_t>(handle.size()));
   if (res == -1) {
-    heph::panic("connect: {}", std::error_code(errno, std::system_category()).message());
+    panic("connect: {}", std::error_code(errno, std::system_category()).message());
   }
 }
 
@@ -76,13 +76,13 @@ auto Socket::localEndpoint() const -> Endpoint {
 
   const int res = ::getsockname(fd_, &addr, &length);
   if (res == -1) {
-    heph::panic("getsockname: {}", std::error_code(errno, std::system_category()).message());
+    panic("getsockname: {}", std::error_code(errno, std::system_category()).message());
   }
 
   Endpoint endpoint(addr.sa_family == AF_INET ? IpFamily::V4 : IpFamily::V6);
   auto handle = endpoint.nativeHandle();
   if (length != handle.size()) {
-    heph::panic("mismatch of sockaddr length got {}, expected {}", length, handle.size());
+    panic("mismatch of sockaddr length got {}, expected {}", length, handle.size());
   }
 
   std::memcpy(handle.data(), &addr, handle.size());
@@ -96,13 +96,13 @@ auto Socket::remoteEndpoint() const -> Endpoint {
 
   const int res = ::getpeername(fd_, &addr, &length);
   if (res == -1) {
-    heph::panic("getpeername: {}", std::error_code(errno, std::system_category()).message());
+    panic("getpeername: {}", std::error_code(errno, std::system_category()).message());
   }
 
   Endpoint endpoint(addr.sa_family == AF_INET ? IpFamily::V4 : IpFamily::V6);
   auto handle = endpoint.nativeHandle();
   if (length != handle.size()) {
-    heph::panic("mismatch of sockaddr length got {}, expected {}", length, handle.size());
+    panic("mismatch of sockaddr length got {}, expected {}", length, handle.size());
   }
 
   std::memcpy(handle.data(), &addr, handle.size());

--- a/modules/net/src/socket.cpp
+++ b/modules/net/src/socket.cpp
@@ -24,7 +24,7 @@ Socket::Socket(IpFamily family, Protocol protocol)
   : fd_(::socket(family == IpFamily::V4 ? AF_INET : AF_INET6,
                  protocol == Protocol::TCP ? SOCK_STREAM : SOCK_DGRAM, 0)) {
   if (fd_ == -1) {
-    heph::panic(fmt::format("socket: {}", std::error_code(errno, std::system_category()).message()));
+    heph::panic("socket: {}", std::error_code(errno, std::system_category()).message());
   }
 }
 
@@ -57,7 +57,7 @@ void Socket::bind(const Endpoint& endpoint) const {
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
       ::bind(fd_, reinterpret_cast<const sockaddr*>(handle.data()), static_cast<socklen_t>(handle.size()));
   if (res == -1) {
-    heph::panic(fmt::format("bind: {}", std::error_code(errno, std::system_category()).message()));
+    heph::panic("bind: {}", std::error_code(errno, std::system_category()).message());
   }
 }
 
@@ -67,7 +67,7 @@ void Socket::connect(const Endpoint& endpoint) const {
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
       ::connect(fd_, reinterpret_cast<const sockaddr*>(handle.data()), static_cast<socklen_t>(handle.size()));
   if (res == -1) {
-    heph::panic(fmt::format("connect: {}", std::error_code(errno, std::system_category()).message()));
+    heph::panic("connect: {}", std::error_code(errno, std::system_category()).message());
   }
 }
 
@@ -77,13 +77,13 @@ auto Socket::localEndpoint() const -> Endpoint {
 
   const int res = ::getsockname(fd_, &addr, &length);
   if (res == -1) {
-    heph::panic(fmt::format("getsockname: {}", std::error_code(errno, std::system_category()).message()));
+    heph::panic("getsockname: {}", std::error_code(errno, std::system_category()).message());
   }
 
   Endpoint endpoint(addr.sa_family == AF_INET ? IpFamily::V4 : IpFamily::V6);
   auto handle = endpoint.nativeHandle();
   if (length != handle.size()) {
-    heph::panic(fmt::format("mismatch of sockaddr length got {}, expected {}", length, handle.size()));
+    heph::panic("mismatch of sockaddr length got {}, expected {}", length, handle.size());
   }
 
   std::memcpy(handle.data(), &addr, handle.size());
@@ -97,13 +97,13 @@ auto Socket::remoteEndpoint() const -> Endpoint {
 
   const int res = ::getpeername(fd_, &addr, &length);
   if (res == -1) {
-    heph::panic(fmt::format("getpeername: {}", std::error_code(errno, std::system_category()).message()));
+    heph::panic("getpeername: {}", std::error_code(errno, std::system_category()).message());
   }
 
   Endpoint endpoint(addr.sa_family == AF_INET ? IpFamily::V4 : IpFamily::V6);
   auto handle = endpoint.nativeHandle();
   if (length != handle.size()) {
-    heph::panic(fmt::format("mismatch of sockaddr length got {}, expected {}", length, handle.size()));
+    heph::panic("mismatch of sockaddr length got {}, expected {}", length, handle.size());
   }
 
   std::memcpy(handle.data(), &addr, handle.size());

--- a/modules/net/src/socket.cpp
+++ b/modules/net/src/socket.cpp
@@ -8,7 +8,6 @@
 #include <cstring>
 #include <system_error>
 
-#include <fmt/format.h>
 #include <sys/socket.h>
 #include <unistd.h>
 

--- a/modules/net/tests/net_tests.cpp
+++ b/modules/net/tests/net_tests.cpp
@@ -58,7 +58,7 @@ TEST(Net, Ipv4Endpoint) {
   std::memcpy(handle1.data(), handle2.data(), handle2.size());
   EXPECT_EQ(ep3, ep1);
 
-  EXPECT_THROW(Endpoint(IpFamily::V4, "."), heph::Panic);
+  EXPECT_THROW(Endpoint(IpFamily::V4, "."), Panic);
 }
 
 TEST(Net, Ipv6Endpoint) {
@@ -89,7 +89,7 @@ TEST(Net, Ipv6Endpoint) {
   std::memcpy(handle1.data(), handle2.data(), handle2.size());
   EXPECT_EQ(ep3, ep1);
 
-  EXPECT_THROW(Endpoint(IpFamily::V6, ":"), heph::Panic);
+  EXPECT_THROW(Endpoint(IpFamily::V6, ":"), Panic);
 }
 
 TEST(Net, TCPOperationsSome) {

--- a/modules/random/include/hephaestus/random/random_object_creator.h
+++ b/modules/random/include/hephaestus/random/random_object_creator.h
@@ -15,7 +15,6 @@
 #include <random>
 #include <string>
 
-#include <fmt/format.h>
 #include <magic_enum.hpp>
 
 #include "hephaestus/utils/concepts.h"

--- a/modules/random/include/hephaestus/random/random_object_creator.h
+++ b/modules/random/include/hephaestus/random/random_object_creator.h
@@ -195,7 +195,7 @@ namespace internal {
     -> size_t {
   if (fixed_size.has_value()) {
     panicIf(allow_empty == false && fixed_size.value() == 0,
-            fmt::format("fixed_size must be non-zero if allow_empty == true"));
+            "fixed_size must be non-zero if allow_empty == true");
     return fixed_size.value();
   }
 

--- a/modules/serdes/include/hephaestus/serdes/protobuf/containers.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/containers.h
@@ -106,8 +106,8 @@ void toProto(google::protobuf::RepeatedPtrField<ProtoT>& proto_repeated_ptr_fiel
 template <Arithmetic T, typename ProtoT, std::size_t N>
 void fromProto(const google::protobuf::RepeatedField<ProtoT>& proto_repeated_field, std::array<T, N>& arr) {
   panicIf(proto_repeated_field.size() != N,
-          fmt::format("Mismatch between size of repeated proto field {} and size of array {}.",
-                      proto_repeated_field.size(), N));
+          "Mismatch between size of repeated proto field {} and size of array {}.",
+          proto_repeated_field.size(), N);
   // NOLINTNEXTLINE(misc-include-cleaner)
   std::ranges::transform(proto_repeated_field, arr.begin(),
                          [](const auto& proto_value) { return static_cast<T>(proto_value); });
@@ -117,8 +117,8 @@ template <typename T, typename ProtoT, std::size_t N>
 void fromProto(const google::protobuf::RepeatedPtrField<ProtoT>& proto_repeated_ptr_field,
                std::array<T, N>& arr) {
   panicIf(proto_repeated_ptr_field.size() != N,
-          fmt::format("Mismatch between size of repeated proto ptr field {} and size of array {}.",
-                      proto_repeated_ptr_field.size(), N));
+          "Mismatch between size of repeated proto ptr field {} and size of array {}.",
+          proto_repeated_ptr_field.size(), N);
   // NOLINTNEXTLINE(misc-include-cleaner)
   std::ranges::transform(proto_repeated_ptr_field, arr.begin(), [](const auto& proto_value) {
     T value;

--- a/modules/serdes/include/hephaestus/serdes/protobuf/containers.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/containers.h
@@ -11,7 +11,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <fmt/format.h>
 #include <google/protobuf/map.h>
 #include <google/protobuf/repeated_field.h>
 #include <google/protobuf/repeated_ptr_field.h>

--- a/modules/serdes/include/hephaestus/serdes/protobuf/enums.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/enums.h
@@ -60,8 +60,8 @@ template <EnumType ProtoT, EnumType T>
   const auto proto_enum = magic_enum::enum_cast<ProtoT>(proto_enum_name);
 
   panicIf(!proto_enum.has_value(),
-          fmt::format("The proto enum does not contain the requested key {}. Proto enum keys are\n{}",
-                      proto_enum_name, utils::format::toString(magic_enum::enum_names<ProtoT>())));
+          "The proto enum does not contain the requested key {}. Proto enum keys are\n{}", proto_enum_name,
+          utils::format::toString(magic_enum::enum_names<ProtoT>()));
 
   return proto_enum.value();  // NOLINT(bugprone-unchecked-optional-access)
 }
@@ -95,8 +95,8 @@ template <EnumType ProtoT, EnumType T>
 auto toProtoEnum(const T& enum_value) -> ProtoT {
   static const auto enum_to_proto_enum = internal::createEnumLookupTable<ProtoT, T>();
   const auto it = enum_to_proto_enum.find(enum_value);
-  panicIf(it == enum_to_proto_enum.end(),
-          fmt::format("Enum {} not found in the lookup table", utils::format::toString(enum_value)));
+  panicIf(it == enum_to_proto_enum.end(), "Enum {} not found in the lookup table",
+          utils::format::toString(enum_value));
   return it->second;
 }
 
@@ -105,8 +105,8 @@ void fromProto(const ProtoT& proto_enum_value, T& enum_value) {
   static const auto proto_enum_value_to_enum =
       internal::createInverseLookupTable(internal::createEnumLookupTable<ProtoT, T>());
   const auto it = proto_enum_value_to_enum.find(proto_enum_value);
-  panicIf(it == proto_enum_value_to_enum.end(),
-          fmt::format("Enum {} not found in the lookup table", utils::format::toString(proto_enum_value)));
+  panicIf(it == proto_enum_value_to_enum.end(), "Enum {} not found in the lookup table",
+          utils::format::toString(proto_enum_value));
   enum_value = it->second;
   ;
 }

--- a/modules/serdes/include/hephaestus/serdes/protobuf/protobuf.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/protobuf.h
@@ -66,8 +66,7 @@ template <class T>
   options.add_whitespace = true;
   options.always_print_fields_with_no_presence = true;
   auto status = google::protobuf::util::MessageToJsonString(proto, &json_string, options);
-  panicIf(!status.ok(),
-          fmt::format("failed to convert proto message to JSON with error: {}", status.message()));
+  panicIf(!status.ok(), "failed to convert proto message to JSON with error: {}", status.message());
 
   return json_string;
 }
@@ -96,8 +95,7 @@ void deserializeFromJSON(std::string_view buffer, T& data) {
   using Proto = ProtoAssociation<T>::Type;
   Proto proto;
   auto status = google::protobuf::util::JsonStringToMessage(buffer, &proto);
-  panicIf(!status.ok(),
-          fmt::format("failed to load proto message from JSON with error: {}", status.message()));
+  panicIf(!status.ok(), "failed to load proto message from JSON with error: {}", status.message());
 
   fromProto(proto, data);
 }

--- a/modules/serdes/include/hephaestus/serdes/protobuf/protobuf_internal.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/protobuf_internal.h
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/format.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>
 

--- a/modules/serdes/include/hephaestus/serdes/protobuf/protobuf_internal.h
+++ b/modules/serdes/include/hephaestus/serdes/protobuf/protobuf_internal.h
@@ -40,7 +40,7 @@ void fromProtobuf(DeserializerBuffer& buffer, T& data) {
   using Proto = ProtoAssociation<T>::Type;
   Proto proto;
   auto res = buffer.deserialize(proto);
-  panicIf(!res, fmt::format("Failed to parse {} from incoming buffer", utils::getTypeName<T>()));
+  panicIf(!res, "Failed to parse {} from incoming buffer", utils::getTypeName<T>());
 
   fromProto(proto, data);
 }

--- a/modules/serdes/src/protobuf/dynamic_deserializer.cpp
+++ b/modules/serdes/src/protobuf/dynamic_deserializer.cpp
@@ -24,14 +24,14 @@ void loadSchema(const heph::serdes::TypeInfo& type_info,
                 google::protobuf::SimpleDescriptorDatabase& proto_db) {
   google::protobuf::FileDescriptorSet fd_set;
   auto res = fd_set.ParseFromArray(type_info.schema.data(), static_cast<int>(type_info.schema.size()));
-  panicIf(!res, fmt::format("failed to parse schema for type: {}", type_info.name));
+  panicIf(!res, "failed to parse schema for type: {}", type_info.name);
 
   google::protobuf::FileDescriptorProto unused;
   for (int i = 0; i < fd_set.file_size(); ++i) {
     const auto& file = fd_set.file(i);
     if (!proto_db.FindFileByName(file.name(), &unused)) {
       res = proto_db.Add(file);
-      panicIf(!res, fmt::format("failed to add definition to proto DB: {}", file.name()));
+      panicIf(!res, "failed to add definition to proto DB: {}", file.name());
     }
   }
 }
@@ -55,8 +55,7 @@ auto DynamicDeserializer::toJson(const std::string& type, std::span<const std::b
   options.add_whitespace = true;
   options.unquote_int64_if_possible = true;
   const auto status = google::protobuf::util::MessageToJsonString(*message, &msg_json, options);
-  panicIf(!status.ok(),
-          fmt::format("failed to convert proto message of type {} to json: {}", type, status.message()));
+  panicIf(!status.ok(), "failed to convert proto message of type {} to json: {}", type, status.message());
 
   return msg_json;
 }
@@ -67,7 +66,7 @@ auto DynamicDeserializer::toText(const std::string& type, std::span<const std::b
   auto printer = google::protobuf::TextFormat::Printer();
   printer.SetUseShortRepeatedPrimitives(true);
   const auto success = printer.PrintToString(*message, &msg_text);
-  panicIf(!success, fmt::format("failed to convert proto message of type {} to text", type));
+  panicIf(!success, "failed to convert proto message of type {} to text", type);
 
   return msg_text;
 }
@@ -75,12 +74,11 @@ auto DynamicDeserializer::toText(const std::string& type, std::span<const std::b
 auto DynamicDeserializer::getMessage(const std::string& type, std::span<const std::byte> data)
     -> google::protobuf::Message* {
   const auto* descriptor = proto_pool_.FindMessageTypeByName(type);
-  panicIf(descriptor == nullptr,
-          fmt::format("schema for type {} was not registered, cannot deserialize data", type));
+  panicIf(descriptor == nullptr, "schema for type {} was not registered, cannot deserialize data", type);
 
   auto* message = proto_factory_.GetPrototype(descriptor)->New();
   const auto res = message->ParseFromArray(data.data(), static_cast<int>(data.size()));
-  panicIf(!res, fmt::format("failed to parse message of type {}", type));
+  panicIf(!res, "failed to parse message of type {}", type);
 
   return message;
 }

--- a/modules/serdes/src/protobuf/dynamic_deserializer.cpp
+++ b/modules/serdes/src/protobuf/dynamic_deserializer.cpp
@@ -8,7 +8,6 @@
 #include <span>
 #include <string>
 
-#include <fmt/format.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/descriptor_database.h>
 #include <google/protobuf/message.h>

--- a/modules/serdes/src/type_info.cpp
+++ b/modules/serdes/src/type_info.cpp
@@ -6,7 +6,6 @@
 
 #include <string>
 
-#include <fmt/format.h>
 #include <magic_enum.hpp>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>

--- a/modules/serdes/src/type_info.cpp
+++ b/modules/serdes/src/type_info.cpp
@@ -30,8 +30,7 @@ auto TypeInfo::fromJson(const std::string& info) -> TypeInfo {
   auto data = nlohmann::json::parse(info);
   auto serialization_str = data["serialization"].get<std::string>();
   auto serialization = magic_enum::enum_cast<TypeInfo::Serialization>(serialization_str);
-  panicIf(!serialization.has_value(),
-          fmt::format("failed to convert {} to Serialization enum", serialization_str));
+  panicIf(!serialization.has_value(), "failed to convert {} to Serialization enum", serialization_str);
   return { .name = data["name"],
            .schema = data["schema"],
            .serialization = serialization.value(),  // NOLINT(bugprone-unchecked-optional-access)

--- a/modules/utils/include/hephaestus/utils/exception.h
+++ b/modules/utils/include/hephaestus/utils/exception.h
@@ -5,11 +5,13 @@
 
 #pragma once
 
-#include <format>
 #include <source_location>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
+#include <fmt/base.h>
+#include <fmt/chrono.h>  // NOLINT(misc-include-cleaner)
 #include <fmt/format.h>
 
 #ifdef DISABLE_EXCEPTIONS
@@ -19,30 +21,33 @@
 namespace heph {
 
 namespace internal {
-///@brief Wrapper around string literals to enhance them with a location.
-///       Note that the message is not owned by this class.
-///       We need to use a const char* here in order to enable implicit conversion from
-///       `log(LogLevel::INFO,"my string");`. The standard guarantees that string literals exist for the
-///       entirety of the program lifetime, so it is fine to use it as `MessageWithLocation("my message");`
+/// @brief  Wrapper around string literals to enhance them with a location.
+///         Note that the message is not owned by this class.
+///         String literals are used to enable implicit conversion from string literals.
+///         The standard guarantees that string literals exist for the entirety of the
+///         program lifetime, making it safe to use as `StringLiteralWithLocation("my message")`.
 struct StringLiteralWithLocation final {
-  ///@brief Constructor for interface as `log(Level::Warn, "msg");`
+  /// @brief Constructor taking a string literal and optional source location
+  /// @param s The string literal message
+  /// @param l The source location (defaults to current location)
   // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
   StringLiteralWithLocation(const char* s, const std::source_location& l = std::source_location::current())
     : value(s), location(l) {
   }
 
-  const char* value;  ///< The message describing the error
-  std::source_location location;
+  const char* value;              ///< The message string literal
+  std::source_location location;  ///< Source code location information
 };
 }  // namespace internal
 
-//=================================================================================================
-/// Base class for exceptions
+/// @brief Exception class for panic situations
+///        This should not be instantiated directly, but rather through the `panic` or `panicIf` function.
 /// @include exception_example.cpp
 class Panic : public std::runtime_error {
 public:
-  /// @param message A message describing the error and what caused it
-  /// @param location Location in the source where the error was triggered at
+  /// @brief Constructs a panic exception
+  /// @param message Message describing the error cause
+  /// @param location Source location where the error occurred
   explicit Panic(std::string message, const std::source_location& location = std::source_location::current());
 };
 
@@ -69,8 +74,8 @@ inline void panic(internal::StringLiteralWithLocation message, Args... args) {
 #endif
 }
 
-/// @brief  User function to panic on condition. The whole code should be considered noexcept. Will
-/// use CHECK if DISABLE_EXCEPTIONS = ON
+/// @brief  User function to panic on condition lazily formatting the message. The whole code should be
+/// considered noexcept. Will use CHECK if DISABLE_EXCEPTIONS = ON
 /// @param condition Condition whether to panic
 /// @param message A message describing the error and what caused it
 /// @param location Location in the source where the error was triggered at

--- a/modules/utils/include/hephaestus/utils/exception.h
+++ b/modules/utils/include/hephaestus/utils/exception.h
@@ -58,7 +58,7 @@ public:
 /// @param message A message describing the error and what caused it
 /// @param location Location in the source where the error was triggered at
 template <typename... Args>
-void panic(internal::StringLiteralWithLocation message, Args... args) {
+void panic(internal::StringLiteralWithLocation message, Args&&... args) {
   std::string formatted_message;
   if constexpr (sizeof...(args) > 0) {
     formatted_message = fmt::format(fmt::runtime(message.value), std::forward<Args>(args)...);
@@ -80,7 +80,7 @@ void panic(internal::StringLiteralWithLocation message, Args... args) {
 /// @param message A message describing the error and what caused it
 /// @param location Location in the source where the error was triggered at
 template <typename... Args>
-void panicIf(bool condition, internal::StringLiteralWithLocation message, Args... args) {
+void panicIf(bool condition, internal::StringLiteralWithLocation message, Args&&... args) {
   if (condition) [[unlikely]] {
     panic(std::move(message), std::forward<Args>(args)...);
   }

--- a/modules/utils/include/hephaestus/utils/exception.h
+++ b/modules/utils/include/hephaestus/utils/exception.h
@@ -58,7 +58,7 @@ public:
 /// @param message A message describing the error and what caused it
 /// @param location Location in the source where the error was triggered at
 template <typename... Args>
-inline void panic(internal::StringLiteralWithLocation message, Args... args) {
+void panic(internal::StringLiteralWithLocation message, Args... args) {
   std::string formatted_message;
   if constexpr (sizeof...(args) > 0) {
     formatted_message = fmt::format(fmt::runtime(message.value), std::forward<Args>(args)...);
@@ -80,24 +80,10 @@ inline void panic(internal::StringLiteralWithLocation message, Args... args) {
 /// @param message A message describing the error and what caused it
 /// @param location Location in the source where the error was triggered at
 template <typename... Args>
-inline void panicIf(bool condition, internal::StringLiteralWithLocation message, Args... args) {
-  std::string formatted_message;
+void panicIf(bool condition, internal::StringLiteralWithLocation message, Args... args) {
   if (condition) [[unlikely]] {
-    if constexpr (sizeof...(args) > 0) {
-      formatted_message = fmt::format(fmt::runtime(message.value), std::forward<Args>(args)...);
-    } else {
-      formatted_message = message.value;
-    }
+    panic(std::move(message), std::forward<Args>(args)...);
   }
-#ifndef DISABLE_EXCEPTIONS
-  if (condition) [[unlikely]] {
-    throw Panic{ std::move(formatted_message), message.location };
-  }
-#else
-  auto e = Panic{ std::move(formatted_message), message.location };
-  CHECK(!condition) << fmt::format("[ERROR {}] at {}:{}", e.what(), message.location.file_name(),
-                                   message.location.line());
-#endif
 }
 
 /// @brief Macro to test if a statement throws an exception or causes a program death depending

--- a/modules/utils/src/exception.cpp
+++ b/modules/utils/src/exception.cpp
@@ -7,6 +7,7 @@
 #include <source_location>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include "hephaestus/utils/stack_trace.h"
 #include "hephaestus/utils/string/string_utils.h"

--- a/modules/utils/src/exception.cpp
+++ b/modules/utils/src/exception.cpp
@@ -13,9 +13,10 @@
 
 namespace heph {
 
-Panic::Panic(Panic::MessageWithLocation&& message)
-  : std::runtime_error("[" + std::string(utils::string::truncate(message.location.file_name(), "modules")) + ":" +
-                       std::to_string(message.location.line()) + "] " + message.value + "\n" + utils::StackTrace::print()) {
+Panic::Panic(std::string message, const std::source_location& location)
+  : std::runtime_error("[" + std::string(utils::string::truncate(location.file_name(), "modules")) + ":" +
+                       std::to_string(location.line()) + "] " + std::move(message) + "\n" +
+                       utils::StackTrace::print()) {
 }
 
 }  // namespace heph

--- a/modules/utils/src/exception.cpp
+++ b/modules/utils/src/exception.cpp
@@ -13,9 +13,9 @@
 
 namespace heph {
 
-Panic::Panic(const std::string& message, std::source_location location)
-  : std::runtime_error("[" + std::string(utils::string::truncate(location.file_name(), "modules")) + ":" +
-                       std::to_string(location.line()) + "] " + message + "\n" + utils::StackTrace::print()) {
+Panic::Panic(Panic::MessageWithLocation&& message)
+  : std::runtime_error("[" + std::string(utils::string::truncate(message.location.file_name(), "modules")) + ":" +
+                       std::to_string(message.location.line()) + "] " + message.value + "\n" + utils::StackTrace::print()) {
 }
 
 }  // namespace heph

--- a/modules/utils/tests/exception_tests.cpp
+++ b/modules/utils/tests/exception_tests.cpp
@@ -13,7 +13,7 @@ using namespace ::testing;
 namespace heph::utils::tests {
 TEST(Exception, Throw) {
 #ifndef DISABLE_EXCEPTIONS
-  auto throwing_func = []() { panic("type mismatch"); };
+  auto throwing_func = []() { panic("type mismatch {}", 42); };
   EXPECT_THROW_OR_DEATH(throwing_func(), Panic, "type mismatch");
 
   try {
@@ -21,6 +21,26 @@ TEST(Exception, Throw) {
   } catch (Panic& e) {
     EXPECT_THAT(e.what(), testing::HasSubstr("modules/utils/tests/exception_tests.cpp:16] type mismatch"));
   }
+#endif
+}
+
+TEST(Exception, ConditionalThrow) {
+#ifndef DISABLE_EXCEPTIONS
+  auto throwing_func = []() { panicIf(true, "type mismatch", 42); };
+  EXPECT_THROW_OR_DEATH(throwing_func(), Panic, "type mismatch");
+
+  try {
+    throwing_func();
+  } catch (Panic& e) {
+    EXPECT_THAT(e.what(), testing::HasSubstr("modules/utils/tests/exception_tests.cpp:16] type mismatch"));
+  }
+#endif
+}
+
+TEST(Exception, ConditionalNoThrow) {
+#ifndef DISABLE_EXCEPTIONS
+  auto throwing_func = []() { panicIf(false, "type mismatch", 42); };
+  EXPECT_NO_THROW(throwing_func());
 #endif
 }
 

--- a/modules/utils/tests/exception_tests.cpp
+++ b/modules/utils/tests/exception_tests.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2023-2024 HEPHAESTUS Contributors
 //=================================================================================================
 
+#include <fmt/format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/modules/utils/tests/exception_tests.cpp
+++ b/modules/utils/tests/exception_tests.cpp
@@ -11,35 +11,41 @@
 using namespace ::testing;
 
 namespace heph::utils::tests {
+
+static constexpr int TEST_FORMAT_VALUE = 42;
 TEST(Exception, Throw) {
 #ifndef DISABLE_EXCEPTIONS
-  auto throwing_func = []() { panic("type mismatch {}", 42); };
-  EXPECT_THROW_OR_DEATH(throwing_func(), Panic, "type mismatch");
+  auto throwing_func = []() { panic("type mismatch {}", TEST_FORMAT_VALUE); };
+  EXPECT_THROW_OR_DEATH(throwing_func(), Panic, "type mismatch 42");
 
   try {
     throwing_func();
   } catch (Panic& e) {
-    EXPECT_THAT(e.what(), testing::HasSubstr("modules/utils/tests/exception_tests.cpp:16] type mismatch"));
+    EXPECT_THAT(e.what(),
+                testing::MatchesRegex(fmt::format(
+                    "^.*modules/utils/tests/exception_tests.cpp.*type mismatch {}.*$", TEST_FORMAT_VALUE)));
   }
 #endif
 }
 
 TEST(Exception, ConditionalThrow) {
 #ifndef DISABLE_EXCEPTIONS
-  auto throwing_func = []() { panicIf(true, "type mismatch", 42); };
-  EXPECT_THROW_OR_DEATH(throwing_func(), Panic, "type mismatch");
+  auto throwing_func = []() { panicIf(true, "type mismatch {}", TEST_FORMAT_VALUE); };
+  EXPECT_THROW_OR_DEATH(throwing_func(), Panic, "type mismatch 42");
 
   try {
     throwing_func();
   } catch (Panic& e) {
-    EXPECT_THAT(e.what(), testing::HasSubstr("modules/utils/tests/exception_tests.cpp:16] type mismatch"));
+    EXPECT_THAT(e.what(),
+                testing::MatchesRegex(fmt::format(
+                    "^.*modules/utils/tests/exception_tests.cpp.*type mismatch {}.*$", TEST_FORMAT_VALUE)));
   }
 #endif
 }
 
 TEST(Exception, ConditionalNoThrow) {
 #ifndef DISABLE_EXCEPTIONS
-  auto throwing_func = []() { panicIf(false, "type mismatch", 42); };
+  auto throwing_func = []() { panicIf(false, "type mismatch", TEST_FORMAT_VALUE); };
   EXPECT_NO_THROW(throwing_func());
 #endif
 }

--- a/modules/websocket_bridge/src/websocket_bridge/ipc/ipc_entity_manager.cpp
+++ b/modules/websocket_bridge/src/websocket_bridge/ipc/ipc_entity_manager.cpp
@@ -20,7 +20,6 @@
 
 #include <absl/log/check.h>
 #include <absl/synchronization/mutex.h>
-#include <fmt/format.h>
 
 #include "hephaestus/ipc/zenoh/raw_publisher.h"
 #include "hephaestus/ipc/zenoh/raw_subscriber.h"
@@ -216,8 +215,8 @@ auto IpcEntityManager::hasPublisher(const std::string& topic) const -> bool {
 void IpcEntityManager::addPublisher(const std::string& topic, const serdes::TypeInfo& topic_type_info) {
   const absl::MutexLock lock(&mutex_pub_);
 
-  heph::panicIf(publishers_.contains(topic),
-                fmt::format("[IPC Interface] - Publisher for topic '{}' already exists!", topic));
+  heph::panicIf(publishers_.contains(topic), "[IPC Interface] - Publisher for topic '{}' already exists!",
+                topic);
 
   auto publisher_config = ipc::zenoh::PublisherConfig{ .cache_size = std::nullopt,
                                                        .create_liveliness_token = true,
@@ -236,7 +235,7 @@ void IpcEntityManager::removePublisher(const std::string& topic) {
   const absl::MutexLock lock(&mutex_pub_);
 
   heph::panicIf(!publishers_.contains(topic),
-                fmt::format("[IPC Interface] - Publisher for topic '{}' does NOT already exists!", topic));
+                "[IPC Interface] - Publisher for topic '{}' does NOT already exists!", topic);
 
   publishers_.erase(topic);
 }
@@ -245,7 +244,7 @@ auto IpcEntityManager::publishMessage(const std::string& topic, std::span<const 
   const absl::MutexLock lock(&mutex_pub_);
 
   heph::panicIf(!publishers_.contains(topic),
-                fmt::format("[IPC Interface] - Publisher for topic '{}' does NOT already exists!", topic));
+                "[IPC Interface] - Publisher for topic '{}' does NOT already exists!", topic);
 
   return publishers_[topic]->publish(data);
 }

--- a/modules/websocket_bridge/src/websocket_bridge/ipc/ipc_entity_manager.cpp
+++ b/modules/websocket_bridge/src/websocket_bridge/ipc/ipc_entity_manager.cpp
@@ -215,8 +215,7 @@ auto IpcEntityManager::hasPublisher(const std::string& topic) const -> bool {
 void IpcEntityManager::addPublisher(const std::string& topic, const serdes::TypeInfo& topic_type_info) {
   const absl::MutexLock lock(&mutex_pub_);
 
-  heph::panicIf(publishers_.contains(topic), "[IPC Interface] - Publisher for topic '{}' already exists!",
-                topic);
+  panicIf(publishers_.contains(topic), "[IPC Interface] - Publisher for topic '{}' already exists!", topic);
 
   auto publisher_config = ipc::zenoh::PublisherConfig{ .cache_size = std::nullopt,
                                                        .create_liveliness_token = true,
@@ -234,8 +233,8 @@ void IpcEntityManager::addPublisher(const std::string& topic, const serdes::Type
 void IpcEntityManager::removePublisher(const std::string& topic) {
   const absl::MutexLock lock(&mutex_pub_);
 
-  heph::panicIf(!publishers_.contains(topic),
-                "[IPC Interface] - Publisher for topic '{}' does NOT already exists!", topic);
+  panicIf(!publishers_.contains(topic), "[IPC Interface] - Publisher for topic '{}' does NOT already exists!",
+          topic);
 
   publishers_.erase(topic);
 }
@@ -243,8 +242,8 @@ void IpcEntityManager::removePublisher(const std::string& topic) {
 auto IpcEntityManager::publishMessage(const std::string& topic, std::span<const std::byte> data) -> bool {
   const absl::MutexLock lock(&mutex_pub_);
 
-  heph::panicIf(!publishers_.contains(topic),
-                "[IPC Interface] - Publisher for topic '{}' does NOT already exists!", topic);
+  panicIf(!publishers_.contains(topic), "[IPC Interface] - Publisher for topic '{}' does NOT already exists!",
+          topic);
 
   return publishers_[topic]->publish(data);
 }


### PR DESCRIPTION
# Description

For panicIf, we do not want to pay runtime cost in case the condition is false.
* Hence we introduce lazily formatted panicIf
* for consistency we change also the interface of panic
* as a positive side effect this hides fmt from the panic interface having an easier time converting to std::format at some point
* makes the panic interface less verbose

Note:
As a price we need to evaluate the string at runtime and give up the compile time checks of std::format.
Also there is a small runtime overhead caused by the impl of format (type erasure performed there) that should be negligeable.
Alternatively we could use std::format and use a template string. however the interface seems not nice:
```
panicIf<"I am panicking {}">(condition,  "just because");
```

## Type of change
- Breaking change -> interface of panic and panicIf changes

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
