### PR TITLE
add compile time checks for panic

### DIFF
--- a/modules/utils/tests/exception_tests.cpp
+++ b/modules/utils/tests/exception_tests.cpp
@@ -29,6 +29,21 @@ TEST(Exception, Throw) {
 #endif
 }
 
+TEST(Exception, ThrowNoArg) {
+#ifndef DISABLE_EXCEPTIONS
+  auto throwing_func = []() { panic("type mismatch no arg"); };
+  EXPECT_THROW_OR_DEATH(throwing_func(), Panic, "type mismatch no arg");
+
+  try {
+    throwing_func();
+  } catch (Panic& e) {
+    EXPECT_THAT(e.what(), testing::MatchesRegex(fmt::format(
+                              "^.*modules/utils/tests/exception_tests.cpp.*type mismatch no arg.*$",
+                              TEST_FORMAT_VALUE)));
+  }
+#endif
+}
+
 TEST(Exception, ConditionalThrow) {
 #ifndef DISABLE_EXCEPTIONS
   auto throwing_func = []() { panicIf(true, "type mismatch {}", TEST_FORMAT_VALUE); };

--- a/modules/utils/tests/exception_tests.cpp
+++ b/modules/utils/tests/exception_tests.cpp
@@ -37,9 +37,8 @@ TEST(Exception, ThrowNoArg) {
   try {
     throwing_func();
   } catch (Panic& e) {
-    EXPECT_THAT(e.what(), testing::MatchesRegex(fmt::format(
-                              "^.*modules/utils/tests/exception_tests.cpp.*type mismatch no arg.*$",
-                              TEST_FORMAT_VALUE)));
+    EXPECT_THAT(e.what(),
+                testing::MatchesRegex("^.*modules/utils/tests/exception_tests.cpp.*type mismatch no arg.*$"));
   }
 #endif
 }


### PR DESCRIPTION
# Description

enable compile time checks in panic format.
interface stays the same

thanks @sithhell for helping with this strance CTAD hack

## Type of change
Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
