### PR TITLE
Fixing segfault on shutdown

### DIFF
--- a/modules/conduit/src/node_engine.cpp
+++ b/modules/conduit/src/node_engine.cpp
@@ -15,13 +15,13 @@ NodeEngine::NodeEngine(NodeEngineConfig config)
 }
 void NodeEngine::run() {
   context_.run();
+  scope_.request_stop();
   stdexec::sync_wait(scope_.on_empty());
   if (exception_) {
     std::rethrow_exception(exception_);
   }
 }
 void NodeEngine::requestStop() {
-  scope_.request_stop();
   pool_.request_stop();
   context_.requestStop();
 }


### PR DESCRIPTION
# Description

Stabilizing tests. Manually confirmed with:
```
$ bazelisk test //modules/conduit:zenoh_nodes_tests -c opt  --runs_per_test 50000
INFO: Invocation ID: 819fe574-2ae5-4a48-9489-6794b8465ebd
INFO: Analyzed target //modules/conduit:zenoh_nodes_tests (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //modules/conduit:zenoh_nodes_tests up-to-date:
  bazel-bin/modules/conduit/zenoh_nodes_tests
INFO: Elapsed time: 294.705s, Critical Path: 7.02s
INFO: 50003 processes: 1 internal, 50002 processwrapper-sandbox.
INFO: Build completed successfully, 50003 total actions
//modules/conduit:zenoh_nodes_tests                                      PASSED in 0.2s
  Stats over 50000 runs: max = 0.2s, min = 0.0s, avg = 0.1s, dev = 0.0s

Executed 1 out of 1 test: 1 test passes.
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
