### PR TITLE
improve error rerport for serdes

### DIFF
--- a/modules/serdes/include/hephaestus/serdes/serdes.h
+++ b/modules/serdes/include/hephaestus/serdes/serdes.h
@@ -22,36 +22,41 @@ namespace heph::serdes {
 
 template <class T>
 [[nodiscard]] auto serialize([[maybe_unused]] const T& data) -> std::vector<std::byte> {
-  static_assert(false, "serialize is not implemented for this type, did you forget to include the header "
-                       "with the serialization implementation?");
+  static_assert(!std::is_same_v<T, void>,
+                "serialize is not implemented for this type, did you forget to include the header "
+                "with the serialization implementation?");
   __builtin_unreachable();
 }
 
 template <class T>
 [[nodiscard]] auto serializeToText([[maybe_unused]] const T& data) -> std::string {
-  static_assert(false, "serialize is not implemented for this type, did you forget to include the header "
-                       "with the serialization implementation?");
+  static_assert(!std::is_same_v<T, void>,
+                "serialize is not implemented for this type, did you forget to include the header "
+                "with the serialization implementation?");
   __builtin_unreachable();
 }
 
 template <class T>
 void deserialize([[maybe_unused]] std::span<const std::byte> buffer, [[maybe_unused]] T& data) {
-  static_assert(false, "serialize is not implemented for this type, did you forget to include the header "
-                       "with the serialization implementation?");
+  static_assert(!std::is_same_v<T, void>,
+                "serialize is not implemented for this type, did you forget to include the header "
+                "with the serialization implementation?");
   __builtin_unreachable();
 }
 
 template <class T>
 void deserializeFromText([[maybe_unused]] std::string_view buffer, [[maybe_unused]] T& data) {
-  static_assert(false, "serialize is not implemented for this type, did you forget to include the header "
-                       "with the serialization implementation?");
+  static_assert(!std::is_same_v<T, void>,
+                "serialize is not implemented for this type, did you forget to include the header "
+                "with the serialization implementation?");
   __builtin_unreachable();
 }
 
 template <class T>
 auto getSerializedTypeInfo() -> TypeInfo {
-  static_assert(false, "serialize is not implemented for this type, did you forget to include the header "
-                       "with the serialization implementation?");
+  static_assert(!std::is_same_v<T, void>,
+                "serialize is not implemented for this type, did you forget to include the header "
+                "with the serialization implementation?");
   __builtin_unreachable();
 }
 

--- a/modules/serdes/src/serdes.cpp
+++ b/modules/serdes/src/serdes.cpp
@@ -2,6 +2,4 @@
 // Copyright (C) 2023-2024 HEPHAESTUS Contributors
 //=================================================================================================
 
-#ifndef __GNUC__  // For some reason GCC fails to compile as it tries to instantiate the template
 #include "hephaestus/serdes/serdes.h"  // NOLINT(misc-include-cleaner)
-#endif


### PR DESCRIPTION
# Description
Make calles to `serdes::serialize` fail at compile time instead of link time when forgetting to include serialization header.