### PR TITLE
Feat: conduit based pub/sub

### DIFF
--- a/cmake/03_compiler_config.cmake
+++ b/cmake/03_compiler_config.cmake
@@ -11,7 +11,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 add_link_options("$<$<CONFIG:Debug>:-rdynamic>" "$<$<CONFIG:RelWithDebInfo>:-rdynamic>")
 
 # Baseline compiler warning settings for project and external targets
-set(HEPHAESTUS_COMPILER_WARNINGS -Wall -Wextra -Wpedantic -Werror)
+set(HEPHAESTUS_COMPILER_WARNINGS -Wall -Wextra -Wpedantic -Werror -Wno-error=subobject-linkage)
 set(THIRD_PARTY_COMPILER_WARNINGS -Wall -Wextra -Wpedantic)
 
 # clang warnings

--- a/cmake/03_compiler_config.cmake
+++ b/cmake/03_compiler_config.cmake
@@ -11,7 +11,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 add_link_options("$<$<CONFIG:Debug>:-rdynamic>" "$<$<CONFIG:RelWithDebInfo>:-rdynamic>")
 
 # Baseline compiler warning settings for project and external targets
-set(HEPHAESTUS_COMPILER_WARNINGS -Wall -Wextra -Wpedantic -Werror -Wno-error=subobject-linkage)
+set(HEPHAESTUS_COMPILER_WARNINGS -Wall -Wextra -Wpedantic -Werror)
 set(THIRD_PARTY_COMPILER_WARNINGS -Wall -Wextra -Wpedantic)
 
 # clang warnings
@@ -40,6 +40,7 @@ set(GCC_WARNINGS
     -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
     -Wuseless-cast # warn if you perform a cast to the same type
     -Wno-attributes
+    -Wno-subobject-linkage
 )
 
 if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -295,6 +295,24 @@ if(liburing IN_LIST EXTERNAL_PROJECTS_LIST)
 endif()
 
 # --------------------------------------------------------------------------------------------------
+# libbluetooth
+set(LIBBLUETOOTH_VERSION "5.66")
+set(LIBBLUETOOTH_TAG "bluez-${LIBBLUETOOTH_VERSION}")
+if(libbluetooth IN_LIST EXTERNAL_PROJECTS_LIST)
+  message(STATUS "    libbluetooth: Building ${LIBBLUETOOTH_VERSION} from source")
+  ExternalProject_Add(
+    libbluetooth
+    URL http://www.kernel.org/pub/linux/bluetooth/${LIBBLUETOOTH_TAG}.tar.xz 
+    BUILD_IN_SOURCE 1
+    USES_TERMINAL_BUILD TRUE # make it verbose
+    CONFIGURE_COMMAND ./configure --prefix=${CMAKE_INSTALL_PREFIX} --cc=${CMAKE_C_COMPILER} --cxx=${CMAKE_CXX_COMPILER} --enable-library --disable-tools --disable-cups --disable-monitor --disable-client
+    BUILD_COMMAND make -j
+    INSTALL_COMMAND make install DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+  )
+# endif(LIBURING_FOUND)
+endif()
+
+# --------------------------------------------------------------------------------------------------
 # stdexec
 set(STDEXEC_VERSION "0f1b477daf3ff20076ae0cfcbbf0a18ca2726be5")
 add_cmake_dependency(NAME stdexec URL https://github.com/NVIDIA/stdexec/archive/${STDEXEC_VERSION}.tar.gz)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -295,24 +295,6 @@ if(liburing IN_LIST EXTERNAL_PROJECTS_LIST)
 endif()
 
 # --------------------------------------------------------------------------------------------------
-# libbluetooth
-set(LIBBLUETOOTH_VERSION "5.66")
-set(LIBBLUETOOTH_TAG "bluez-${LIBBLUETOOTH_VERSION}")
-if(libbluetooth IN_LIST EXTERNAL_PROJECTS_LIST)
-  message(STATUS "    libbluetooth: Building ${LIBBLUETOOTH_VERSION} from source")
-  ExternalProject_Add(
-    libbluetooth
-    URL http://www.kernel.org/pub/linux/bluetooth/${LIBBLUETOOTH_TAG}.tar.xz 
-    BUILD_IN_SOURCE 1
-    USES_TERMINAL_BUILD TRUE # make it verbose
-    CONFIGURE_COMMAND ./configure --prefix=${CMAKE_INSTALL_PREFIX} --cc=${CMAKE_C_COMPILER} --cxx=${CMAKE_CXX_COMPILER} --enable-library --disable-tools --disable-cups --disable-monitor --disable-client
-    BUILD_COMMAND make -j
-    INSTALL_COMMAND make install DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-  )
-# endif(LIBURING_FOUND)
-endif()
-
-# --------------------------------------------------------------------------------------------------
 # stdexec
 set(STDEXEC_VERSION "0f1b477daf3ff20076ae0cfcbbf0a18ca2726be5")
 add_cmake_dependency(NAME stdexec URL https://github.com/NVIDIA/stdexec/archive/${STDEXEC_VERSION}.tar.gz)

--- a/modules/concurrency/include/hephaestus/concurrency/io_ring/timer.h
+++ b/modules/concurrency/include/hephaestus/concurrency/io_ring/timer.h
@@ -59,6 +59,7 @@ struct TimerEntry {
 class Timer {
 public:
   explicit Timer(IoRing& ring, TimerOptions options);
+  ~Timer() noexcept;
 
   void requestStop();
 

--- a/modules/conduit/BUILD
+++ b/modules/conduit/BUILD
@@ -19,6 +19,7 @@ heph_cc_library(
     deps = [
         "//modules/concurrency",
         "//modules/ipc",
+        "//modules/net",
     ],
 )
 
@@ -54,6 +55,29 @@ heph_cc_binary(
     ],
 )
 
+heph_cc_binary(
+    name = "conduit_publisher",
+    srcs = ["examples/conduit_publisher.cpp"],
+    deps = [
+        ":conduit",
+        "//modules/cli",
+        "//modules/types",
+        "//modules/types_proto",
+    ],
+)
+
+heph_cc_binary(
+    name = "conduit_subscriber",
+    srcs = ["examples/conduit_subscriber.cpp"],
+    deps = [
+        ":conduit",
+        "//modules/cli",
+        "//modules/format",
+        "//modules/types",
+        "//modules/types_proto",
+    ],
+)
+
 #########
 # Tests #
 #########
@@ -67,12 +91,25 @@ heph_cc_test(
 heph_cc_test(
     name = "input_output_tests",
     srcs = ["tests/input_output_tests.cpp"],
-    deps = [":conduit"],
+    deps = [
+        ":conduit",
+        "//modules/types_proto",
+    ],
 )
 
 heph_cc_test(
     name = "zenoh_nodes_tests",
     srcs = ["tests/zenoh_nodes_tests.cpp"],
+    deps = [
+        ":conduit",
+        "//modules/types",
+        "//modules/types_proto",
+    ],
+)
+
+heph_cc_test(
+    name = "remote_publisher_tests",
+    srcs = ["tests/remote_publisher_tests.cpp"],
     deps = [
         ":conduit",
         "//modules/types",

--- a/modules/conduit/CMakeLists.txt
+++ b/modules/conduit/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 declare_module(
   NAME conduit
-  DEPENDS_ON_MODULES concurrency ipc
+  DEPENDS_ON_MODULES concurrency ipc net
   DEPENDS_ON_EXTERNAL_PROJECTS ""
 )
 
@@ -14,7 +14,7 @@ file(GLOB_RECURSE SOURCES src/*.cpp src/*.h include/*.h)
 # library target
 define_module_library(
   NAME conduit
-  PUBLIC_LINK_LIBS hephaestus::concurrency hephaestus::ipc
+  PUBLIC_LINK_LIBS hephaestus::concurrency hephaestus::ipc hephaestus::net
   PRIVATE_LINK_LIBS ""
   SOURCES ${SOURCES}
   PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>

--- a/modules/conduit/examples/conduit_example.cpp
+++ b/modules/conduit/examples/conduit_example.cpp
@@ -1,0 +1,33 @@
+
+#include "hephaestus/conduit/node_engine.h"
+#include "hephaestus/conduit/queued_input.h"
+
+struct OperatorData {
+  // possible data ...
+};
+
+struct Operator : heph::conduit::Node<Operator /*, OperatorData*/> {
+  // inputs...
+  heph::conduit::QueuedInput<std::string> input{ this, "input" };
+
+  static auto name(const Operator& /*self*/) -> std::string_view {
+    return "operator";
+  };
+  static auto period(const Operator& /*self*/) {};
+  static auto trigger(const Operator& /*self*/) {
+  }
+  static auto execute(Operator& /*self*/, const std::string& input) {
+    // Access to data:
+    // self.data();
+    // Access to engine (if required):
+    // self.engine();
+    (void)input;
+  }
+};
+
+auto main() -> int {
+  heph::conduit::NodeEngine engine{ {} };
+  const auto& node = engine.createNode<Operator>(/* potentially initialize OperatorData */);
+
+  node.input.connectTo(/*...*/);
+}

--- a/modules/conduit/examples/conduit_publisher.cpp
+++ b/modules/conduit/examples/conduit_publisher.cpp
@@ -1,0 +1,73 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+#include <chrono>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <random>
+#include <string_view>
+#include <utility>
+
+#include <fmt/base.h>
+#include <fmt/ranges.h>
+#include <stdexec/execution.hpp>
+
+#include "hephaestus/cli/program_options.h"
+#include "hephaestus/conduit/node.h"
+#include "hephaestus/conduit/node_engine.h"
+#include "hephaestus/net/endpoint.h"
+#include "hephaestus/telemetry/log.h"
+#include "hephaestus/telemetry/log_sinks/absl_sink.h"
+#include "hephaestus/types/dummy_type.h"
+#include "hephaestus/types_proto/dummy_type.h"  // NOLINT(misc-include-cleaner)
+#include "hephaestus/utils/signal_handler.h"
+
+struct Generator : heph::conduit::Node<Generator> {
+  static constexpr std::string_view NAME = "generator";
+
+  static constexpr std::chrono::seconds PERIOD{ 1 };
+  std::random_device rd;
+  std::mt19937_64 mt{ rd() };
+
+  static auto trigger() {
+    return stdexec::just();
+  }
+
+  static auto execute(Generator& self) {
+    return heph::types::DummyType::random(self.mt);
+  }
+};
+
+auto main(int argc, const char* argv[]) -> int {
+  try {
+    heph::telemetry::registerLogSink(std::make_unique<heph::telemetry::AbslLogSink>());
+
+    auto desc = heph::cli::ProgramDescription("Conduit Publisher");
+    desc.defineOption<std::string>("address", "Address to bind to", "127.0.0.1");
+    desc.defineOption<std::uint16_t>("port", "Port to bind to", 0);
+
+    const auto args = std::move(desc).parse(argc, argv);
+
+    const auto address = args.getOption<std::string>("address");
+    const auto port = args.getOption<std::uint16_t>("port");
+
+    heph::conduit::NodeEngineConfig config;
+    config.endpoints = { heph::net::Endpoint::createIpV4(address, port) };
+
+    heph::conduit::NodeEngine engine{ config };
+
+    fmt::println("Publisher listening on {}", fmt::join(engine.endpoints(), ","));
+
+    engine.createNode<Generator>();
+
+    heph::utils::TerminationBlocker::registerInterruptCallback([&engine]() { engine.requestStop(); });
+
+    engine.run();
+
+    return 0;
+  } catch (const std::exception& ex) {
+    fmt::println(stderr, "main terminated with an exception: {}\n", ex.what());
+    return 1;
+  }
+}

--- a/modules/conduit/examples/conduit_publisher.cpp
+++ b/modules/conduit/examples/conduit_publisher.cpp
@@ -11,7 +11,6 @@
 
 #include <fmt/base.h>
 #include <fmt/ranges.h>
-#include <stdexec/execution.hpp>
 
 #include "hephaestus/cli/program_options.h"
 #include "hephaestus/conduit/node.h"
@@ -29,10 +28,6 @@ struct Generator : heph::conduit::Node<Generator> {
   static constexpr std::chrono::seconds PERIOD{ 1 };
   std::random_device rd;
   std::mt19937_64 mt{ rd() };
-
-  static auto trigger() {
-    return stdexec::just();
-  }
 
   static auto execute(Generator& self) {
     return heph::types::DummyType::random(self.mt);

--- a/modules/conduit/examples/conduit_subscriber.cpp
+++ b/modules/conduit/examples/conduit_subscriber.cpp
@@ -1,0 +1,73 @@
+
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <string_view>
+#include <utility>
+
+#include <fmt/base.h>
+
+#include "hephaestus/cli/program_options.h"
+#include "hephaestus/conduit/node.h"
+#include "hephaestus/conduit/node_engine.h"
+#include "hephaestus/conduit/queued_input.h"
+#include "hephaestus/conduit/remote_nodes.h"
+#include "hephaestus/format/generic_formatter.h"  // NOLINT(misc-include-cleaner)
+#include "hephaestus/net/endpoint.h"
+#include "hephaestus/telemetry/log.h"
+#include "hephaestus/telemetry/log_sinks/absl_sink.h"
+#include "hephaestus/types/dummy_type.h"
+#include "hephaestus/types_proto/dummy_type.h"  // NOLINT(misc-include-cleaner)
+#include "hephaestus/utils/signal_handler.h"
+
+struct Sink : heph::conduit::Node<Sink> {
+  static constexpr std::string_view NAME = "sink";
+  heph::conduit::QueuedInput<heph::types::DummyType> input{ this, "input" };
+
+  static auto trigger(Sink& self) {
+    return self.input.get();
+  }
+
+  static auto execute(heph::types::DummyType dummy) {
+    fmt::println("Received {}", dummy);
+  }
+};
+
+auto main(int argc, const char* argv[]) -> int {
+  try {
+    heph::telemetry::registerLogSink(std::make_unique<heph::telemetry::AbslLogSink>());
+
+    auto desc = heph::cli::ProgramDescription("Conduit Publisher");
+    desc.defineOption<std::string>("address", "Address to connect to", "127.0.0.1");
+    desc.defineOption<std::uint16_t>("port", "Port to connect to");
+
+    const auto args = std::move(desc).parse(argc, argv);
+
+    const auto address = args.getOption<std::string>("address");
+    const auto port = args.getOption<std::uint16_t>("port");
+
+    auto endpoint = heph::net::Endpoint::createIpV4(address, port);
+
+    heph::conduit::NodeEngine engine{ {} };
+
+    fmt::println("Subcribing to {}", endpoint);
+
+    auto subscriber = engine.createNode<heph::conduit::RemoteSubscriberNode<heph::types::DummyType>>(
+        endpoint, std::string{ "generator" });
+    auto node = engine.createNode<Sink>();
+
+    node->input.connectTo(subscriber);
+
+    heph::utils::TerminationBlocker::registerInterruptCallback([&engine]() { engine.requestStop(); });
+
+    engine.run();
+
+    return 0;
+  } catch (const std::exception& ex) {
+    fmt::println(stderr, "main terminated with an exception: {}\n", ex.what());
+    return 1;
+  }
+}

--- a/modules/conduit/examples/mont_blanc.cpp
+++ b/modules/conduit/examples/mont_blanc.cpp
@@ -227,8 +227,8 @@ struct Osaka : heph::conduit::Node<Osaka> {
   static auto execute(Osaka& self, const std::optional<std::string>& s, Image /**/,
                       std::optional<Image> /**/) {
     heph::log(heph::INFO, "osaka", "parana", s);
-    return stdexec::when_all(self.salween.setValue(self.engine().scheduler(), PointCloud2{}),
-                             self.godavari.setValue(self.engine().scheduler(), LaserScan{}));
+    return stdexec::when_all(self.salween.setValue(self.engine(), PointCloud2{}),
+                             self.godavari.setValue(self.engine(), LaserScan{}));
   }
 };
 
@@ -309,9 +309,9 @@ struct Mandalay : heph::conduit::Node<Mandalay> {
               "loire", fmt::format("{}", self.loire.getValue())
               //
     );
-    return stdexec::when_all(self.tagus.setValue(self.engine().scheduler(), Pose{}),
-                             self.missouri.setValue(self.engine().scheduler(), Image{}),
-                             self.brazos.setValue(self.engine().scheduler(), PointCloud2{}));
+    return stdexec::when_all(self.tagus.setValue(self.engine(), Pose{}),
+                             self.missouri.setValue(self.engine(), Image{}),
+                             self.brazos.setValue(self.engine(), PointCloud2{}));
   }
 };
 
@@ -362,8 +362,8 @@ struct Ponce : heph::conduit::Node<Ponce> {
               "volga", self.volga.getValue()
               //
     );
-    return stdexec::when_all(self.congo.setValue(self.engine().scheduler(), Twist{}),
-                             self.meckong.setValue(self.engine().scheduler(), TwistWithCovarianceStamped{}));
+    return stdexec::when_all(self.congo.setValue(self.engine(), Twist{}),
+                             self.meckong.setValue(self.engine(), TwistWithCovarianceStamped{}));
   }
 };
 

--- a/modules/conduit/examples/mont_blanc.cpp
+++ b/modules/conduit/examples/mont_blanc.cpp
@@ -227,8 +227,8 @@ struct Osaka : heph::conduit::Node<Osaka> {
   static auto execute(Osaka& self, const std::optional<std::string>& s, Image /**/,
                       std::optional<Image> /**/) {
     heph::log(heph::INFO, "osaka", "parana", s);
-    return stdexec::when_all(self.salween.setValue(self.engine(), PointCloud2{}),
-                             self.godavari.setValue(self.engine(), LaserScan{}));
+    return stdexec::when_all(self.salween.setValue(self.engine().scheduler(), PointCloud2{}),
+                             self.godavari.setValue(self.engine().scheduler(), LaserScan{}));
   }
 };
 
@@ -309,9 +309,9 @@ struct Mandalay : heph::conduit::Node<Mandalay> {
               "loire", fmt::format("{}", self.loire.getValue())
               //
     );
-    return stdexec::when_all(self.tagus.setValue(self.engine(), Pose{}),
-                             self.missouri.setValue(self.engine(), Image{}),
-                             self.brazos.setValue(self.engine(), PointCloud2{}));
+    return stdexec::when_all(self.tagus.setValue(self.engine().scheduler(), Pose{}),
+                             self.missouri.setValue(self.engine().scheduler(), Image{}),
+                             self.brazos.setValue(self.engine().scheduler(), PointCloud2{}));
   }
 };
 
@@ -362,8 +362,8 @@ struct Ponce : heph::conduit::Node<Ponce> {
               "volga", self.volga.getValue()
               //
     );
-    return stdexec::when_all(self.congo.setValue(self.engine(), Twist{}),
-                             self.meckong.setValue(self.engine(), TwistWithCovarianceStamped{}));
+    return stdexec::when_all(self.congo.setValue(self.engine().scheduler(), Twist{}),
+                             self.meckong.setValue(self.engine().scheduler(), TwistWithCovarianceStamped{}));
   }
 };
 

--- a/modules/conduit/include/hephaestus/conduit/detail/input_base.h
+++ b/modules/conduit/include/hephaestus/conduit/detail/input_base.h
@@ -104,9 +104,10 @@ public:
   auto setValue(U&& u) -> InputState {
     if (!node_->runsOnEngine()) {
       // Dispatch to the engine scheduler to avoid race conditions
-      auto res = stdexec::sync_wait(
-          node_->engine().scheduler().schedule() |
-          stdexec::then([this, u = std::forward<U>(u)] { return setValue(std::move(u)); }));
+      auto res =
+          stdexec::sync_wait(node_->scheduler().schedule() | stdexec::then([this, u = std::forward<U>(u)] {
+                               return setValue(std::move(u));
+                             }));
       if (!res.has_value()) {
         panic("Could not set value, engine was stopped");
       }

--- a/modules/conduit/include/hephaestus/conduit/detail/node_base.h
+++ b/modules/conduit/include/hephaestus/conduit/detail/node_base.h
@@ -9,9 +9,11 @@
 #include <string>
 #include <string_view>
 
+#include <hephaestus/concurrency/context.h>
 #include <stdexec/stop_token.hpp>
 
 #include "hephaestus/concurrency/io_ring/timer.h"
+#include "hephaestus/conduit/detail/output_connections.h"
 
 // Forward declarations
 namespace heph::conduit {
@@ -29,6 +31,7 @@ public:
   virtual ~NodeBase() = default;
   [[nodiscard]] virtual auto nodeName() const -> std::string = 0;
   [[nodiscard]] virtual auto nodePeriod() -> std::chrono::nanoseconds = 0;
+  virtual void removeOutputConnection(void* node) = 0;
 
   auto engine() -> NodeEngine& {
     return *engine_;
@@ -37,8 +40,17 @@ public:
   [[nodiscard]] auto engine() const -> const NodeEngine& {
     return *engine_;
   }
+  auto enginePtr() -> NodeEngine* {
+    return engine_;
+  }
+
+  [[nodiscard]] auto enginePtr() const -> const NodeEngine* {
+    return engine_;
+  }
 
   [[nodiscard]] auto runsOnEngine() const -> bool;
+
+  [[nodiscard]] auto scheduler() const -> concurrency::Context::Scheduler;
 
   auto getStopToken() -> stdexec::inplace_stop_token;
 
@@ -74,5 +86,4 @@ private:
   NodeBase* self_;
   std::chrono::high_resolution_clock::time_point start_;
 };
-
 }  // namespace heph::conduit::detail

--- a/modules/conduit/include/hephaestus/conduit/detail/output_connections.h
+++ b/modules/conduit/include/hephaestus/conduit/detail/output_connections.h
@@ -117,7 +117,6 @@ inline auto OutputConnections::propagate(NodeEngine& engine) {
                        if (inputs_.empty()) {
                          return true;
                        }
-                       // fmt::println(stderr, "GOTCHA");
                        //  Extract result: In case of an optional without a value, we
                        //  get a nullptr and return immediately without propagating
                        //  anything.

--- a/modules/conduit/include/hephaestus/conduit/detail/output_connections.h
+++ b/modules/conduit/include/hephaestus/conduit/detail/output_connections.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstddef>
@@ -16,16 +17,16 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <stdexec/execution.hpp>
 
+#include "hephaestus/concurrency/context.h"
 #include "hephaestus/concurrency/repeat_until.h"
-#include "hephaestus/conduit/detail/node_base.h"
 #include "hephaestus/conduit/input.h"
-#include "hephaestus/conduit/node_engine.h"
-#include "hephaestus/telemetry/log_sink.h"
-#include "node_base.h"
+#include "hephaestus/telemetry/log.h"
 
 namespace heph::conduit::detail {
+class NodeBase;
 
 template <typename T>
 auto extractResult(T& t) -> T* {
@@ -46,8 +47,32 @@ class OutputConnections {
     void* ptr;
     SetValueT set_value;
     NameT name;
+    detail::NodeBase* node;
     std::size_t generation;
   };
+
+  using SchedulerT = concurrency::Context::Scheduler;
+
+private:
+  auto retryTimeout(SchedulerT scheduler) {
+    // TODO: find better way to timeout based on the inputs timing...
+    // Currently doing floor(retry^1.5)
+    static constexpr float EXP = 1.5f;
+    std::chrono::milliseconds timeout{ 0 };
+    if (retry_ > 0) {
+      timeout = std::chrono::milliseconds(
+          static_cast<std::chrono::milliseconds::rep>(std::floor(std::pow(static_cast<float>(retry_), EXP))));
+
+      auto remaining_inputs =
+          inputs_ |
+          std::views::filter([this](const InputEntry& entry) { return entry.generation <= generation_; }) |
+          std::views::transform([](InputEntry& entry) { return entry.name(entry.ptr); });
+
+      heph::log(heph::WARN, std::string(INPUT_OVERFLOW_WARNING), "output", name(), "inputs",
+                fmt::format("[{}]", fmt::join(remaining_inputs, ", ")), "retry", retry_, "delay", timeout);
+    }
+    return scheduler.scheduleAfter(timeout);
+  }
 
 public:
   static constexpr std::string_view INPUT_OVERFLOW_WARNING =
@@ -56,71 +81,55 @@ public:
   explicit OutputConnections(detail::NodeBase* node, std::string name) : node_(node), name_(std::move(name)) {
   }
 
-  auto propagate(NodeEngine& engine) {
-    return stdexec::let_value([this, &engine]<typename... Ts>(Ts&&... ts) {
+  auto propagate(SchedulerT scheduler) {
+    return stdexec::let_value([this, scheduler]<typename... Ts>(Ts&&... ts) {
       // If the continuation didn't get any parameters, the operator
       // return void, and we can move on ...
       // Otherwise, we attempt to set the result to connected inputs.
       if constexpr (sizeof...(Ts) == 1) {
         auto args = std::make_tuple(std::forward<Ts>(ts)...);
-        return heph::concurrency::repeatUntil(
-            stdexec::just() | stdexec::let_value([this, &engine]() {
-              // TODO: find better way to timeout based on the inputs timing...
-              // Currently doing floor(retry^1.5)
-              static constexpr float EXP = 1.5f;
-              std::chrono::milliseconds timeout{ 0 };
-              if (retry_ > 0) {
-                timeout = std::chrono::milliseconds(static_cast<std::chrono::milliseconds::rep>(
-                    std::floor(std::pow(static_cast<float>(retry_), EXP))));
+        return heph::concurrency::repeatUntil([this, scheduler, args = std::move(args)]() {
+          return stdexec::just() |
+                 stdexec::let_value([this, scheduler]() { return retryTimeout(scheduler); }) |
+                 stdexec::then([this, args = std::move(args)] {
+                   bool done = std::apply(
+                       [this]<typename T>(T result) {
+                         if (inputs_.empty()) {
+                           return true;
+                         }
+                         // fmt::println(stderr, "GOTCHA");
+                         //  Extract result: In case of an optional without a value, we
+                         //  get a nullptr and return immediately without propagating
+                         //  anything.
+                         auto* result_ptr = extractResult(result);
+                         if (result_ptr == nullptr) {
+                           return true;
+                         }
 
-                auto remaining_inputs =
-                    inputs_ | std::views::filter([this](const InputEntry& entry) {
-                      return entry.generation <= generation_;
-                    }) |
-                    std::views::transform([](InputEntry& entry) { return entry.name(entry.ptr); });
-
-                heph::log(heph::WARN, std::string(INPUT_OVERFLOW_WARNING), "output", name(), "inputs",
-                          fmt::format("[{}]", fmt::join(remaining_inputs, ", ")), "retry", retry_, "delay",
-                          timeout);
-              }
-              return engine.scheduler().scheduleAfter(timeout);
-            }) |
-            stdexec::then([this, args = std::move(args)] {
-              bool done = std::apply(
-                  [this]<typename T>(T result) {
-                    // Extract result: In case of an optional without a value, we
-                    // get a nullptr and return immediately without propagating
-                    // anything.
-                    auto* result_ptr = extractResult(result);
-                    if (result_ptr == nullptr) {
-                      return true;
-                    }
-
-                    std::size_t propagated_count{ 0 };
-                    for (InputEntry& entry : inputs_) {
-                      if (entry.generation != generation_) {
-                        ++propagated_count;
-                        continue;
-                      }
-                      if (entry.set_value(entry.ptr, result_ptr) == InputState::OK) {
-                        ++propagated_count;
-                        ++entry.generation;
-                      }
-                    }
-                    if (propagated_count == inputs_.size()) {
-                      // Everything is propagated, now reset...
-                      generation_++;
-                      retry_ = 0;
-                      return true;
-                    }
-                    ++retry_;
-                    return false;
-                  },
-                  args);
-              return done;
-            })
-
-        );
+                         std::size_t propagated_count{ 0 };
+                         for (InputEntry& entry : inputs_) {
+                           if (entry.generation != generation_) {
+                             ++propagated_count;
+                             continue;
+                           }
+                           if (entry.set_value(entry.ptr, result_ptr) == InputState::OK) {
+                             ++propagated_count;
+                             ++entry.generation;
+                           }
+                         }
+                         if (propagated_count == inputs_.size()) {
+                           // Everything is propagated, now reset...
+                           generation_++;
+                           retry_ = 0;
+                           return true;
+                         }
+                         ++retry_;
+                         return false;
+                       },
+                       args);
+                   return done;
+                 });
+        });
       } else {
         (void)this;
         static_assert(sizeof...(Ts) == 0, "Node returning more than one output should be impossible");
@@ -129,9 +138,7 @@ public:
     });
   }
 
-  [[nodiscard]] auto name() const -> std::string {
-    return fmt::format("{}/{}", node_->nodeName(), name_);
-  }
+  [[nodiscard]] auto name() const -> std::string;
 
   template <typename Input>
   void registerInput(Input* input) {
@@ -140,7 +147,18 @@ public:
         [](void* input_ptr, void* ptr) {
           return static_cast<Input*>(input_ptr)->setValue(*static_cast<typename Input::ValueT*>(ptr));
         },
-        [](void* input_ptr) { return std::string{ static_cast<Input*>(input_ptr)->name() }; }, 0);
+        [](void* input_ptr) { return std::string{ static_cast<Input*>(input_ptr)->name() }; }, input->node(),
+        generation_);
+  }
+
+  void removeConnection(void* node) {
+    while (true) {
+      auto it = std::ranges::find_if(inputs_, [node](const InputEntry& entry) { return entry.node == node; });
+      if (it == inputs_.end()) {
+        return;
+      }
+      inputs_.erase(it);
+    }
   }
 
 private:

--- a/modules/conduit/include/hephaestus/conduit/detail/output_connections.h
+++ b/modules/conduit/include/hephaestus/conduit/detail/output_connections.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -25,6 +26,10 @@
 #include "hephaestus/conduit/input.h"
 #include "hephaestus/telemetry/log.h"
 
+namespace heph::conduit {
+class NodeEngine;
+auto scheduler(NodeEngine& engine) -> concurrency::Context::Scheduler;
+}  // namespace heph::conduit
 namespace heph::conduit::detail {
 class NodeBase;
 
@@ -53,27 +58,6 @@ class OutputConnections {
 
   using SchedulerT = concurrency::Context::Scheduler;
 
-private:
-  auto retryTimeout(SchedulerT scheduler) {
-    // TODO: find better way to timeout based on the inputs timing...
-    // Currently doing floor(retry^1.5)
-    static constexpr float EXP = 1.5f;
-    std::chrono::milliseconds timeout{ 0 };
-    if (retry_ > 0) {
-      timeout = std::chrono::milliseconds(
-          static_cast<std::chrono::milliseconds::rep>(std::floor(std::pow(static_cast<float>(retry_), EXP))));
-
-      auto remaining_inputs =
-          inputs_ |
-          std::views::filter([this](const InputEntry& entry) { return entry.generation <= generation_; }) |
-          std::views::transform([](InputEntry& entry) { return entry.name(entry.ptr); });
-
-      heph::log(heph::WARN, std::string(INPUT_OVERFLOW_WARNING), "output", name(), "inputs",
-                fmt::format("[{}]", fmt::join(remaining_inputs, ", ")), "retry", retry_, "delay", timeout);
-    }
-    return scheduler.scheduleAfter(timeout);
-  }
-
 public:
   static constexpr std::string_view INPUT_OVERFLOW_WARNING =
       "Delaying Output operation because receiving input would overflow";
@@ -81,62 +65,7 @@ public:
   explicit OutputConnections(detail::NodeBase* node, std::string name) : node_(node), name_(std::move(name)) {
   }
 
-  auto propagate(SchedulerT scheduler) {
-    return stdexec::let_value([this, scheduler]<typename... Ts>(Ts&&... ts) {
-      // If the continuation didn't get any parameters, the operator
-      // return void, and we can move on ...
-      // Otherwise, we attempt to set the result to connected inputs.
-      if constexpr (sizeof...(Ts) == 1) {
-        auto args = std::make_tuple(std::forward<Ts>(ts)...);
-        return heph::concurrency::repeatUntil([this, scheduler, args = std::move(args)]() {
-          return stdexec::just() |
-                 stdexec::let_value([this, scheduler]() { return retryTimeout(scheduler); }) |
-                 stdexec::then([this, args = std::move(args)] {
-                   bool done = std::apply(
-                       [this]<typename T>(T result) {
-                         if (inputs_.empty()) {
-                           return true;
-                         }
-                         // fmt::println(stderr, "GOTCHA");
-                         //  Extract result: In case of an optional without a value, we
-                         //  get a nullptr and return immediately without propagating
-                         //  anything.
-                         auto* result_ptr = extractResult(result);
-                         if (result_ptr == nullptr) {
-                           return true;
-                         }
-
-                         std::size_t propagated_count{ 0 };
-                         for (InputEntry& entry : inputs_) {
-                           if (entry.generation != generation_) {
-                             ++propagated_count;
-                             continue;
-                           }
-                           if (entry.set_value(entry.ptr, result_ptr) == InputState::OK) {
-                             ++propagated_count;
-                             ++entry.generation;
-                           }
-                         }
-                         if (propagated_count == inputs_.size()) {
-                           // Everything is propagated, now reset...
-                           generation_++;
-                           retry_ = 0;
-                           return true;
-                         }
-                         ++retry_;
-                         return false;
-                       },
-                       args);
-                   return done;
-                 });
-        });
-      } else {
-        (void)this;
-        static_assert(sizeof...(Ts) == 0, "Node returning more than one output should be impossible");
-        return stdexec::just();
-      }
-    });
-  }
+  auto propagate(NodeEngine& engine);
 
   [[nodiscard]] auto name() const -> std::string;
 
@@ -162,10 +91,90 @@ public:
   }
 
 private:
+  using ScheduleAfterResultT = std::decay_t<decltype(std::declval<SchedulerT>().scheduleAfter(
+      std::declval<std::chrono::milliseconds>()))>;
+  auto retryTimeout(NodeEngine& engine) -> ScheduleAfterResultT;
+
+private:
   std::vector<InputEntry> inputs_;
   std::size_t generation_{ 0 };
   std::size_t retry_{ 0 };
   detail::NodeBase* node_;
   std::string name_;
 };
+
+inline auto OutputConnections::propagate(NodeEngine& engine) {
+  return stdexec::let_value([this, &engine]<typename... Ts>(Ts&&... ts) {
+    // If the continuation didn't get any parameters, the operator
+    // return void, and we can move on ...
+    // Otherwise, we attempt to set the result to connected inputs.
+    if constexpr (sizeof...(Ts) == 1) {
+      auto args = std::make_tuple(std::forward<Ts>(ts)...);
+      return heph::concurrency::repeatUntil([this, &engine, args = std::move(args)]() {
+        return retryTimeout(engine) | stdexec::then([this, args = std::move(args)] {
+                 bool done = std::apply(
+                     [this]<typename T>(T result) {
+                       if (inputs_.empty()) {
+                         return true;
+                       }
+                       // fmt::println(stderr, "GOTCHA");
+                       //  Extract result: In case of an optional without a value, we
+                       //  get a nullptr and return immediately without propagating
+                       //  anything.
+                       auto* result_ptr = extractResult(result);
+                       if (result_ptr == nullptr) {
+                         return true;
+                       }
+
+                       std::size_t propagated_count{ 0 };
+                       for (InputEntry& entry : inputs_) {
+                         if (entry.generation != generation_) {
+                           ++propagated_count;
+                           continue;
+                         }
+                         if (entry.set_value(entry.ptr, result_ptr) == InputState::OK) {
+                           ++propagated_count;
+                           ++entry.generation;
+                         }
+                       }
+                       if (propagated_count == inputs_.size()) {
+                         // Everything is propagated, now reset...
+                         generation_++;
+                         retry_ = 0;
+                         return true;
+                       }
+                       ++retry_;
+                       return false;
+                     },
+                     args);
+                 return done;
+               });
+      });
+    } else {
+      (void)this;
+      static_assert(sizeof...(Ts) == 0, "Node returning more than one output should be impossible");
+      return stdexec::just();
+    }
+  });
+}
+
+inline auto OutputConnections::retryTimeout(NodeEngine& engine) -> ScheduleAfterResultT {
+  // TODO: find better way to timeout based on the inputs timing...
+  // Currently doing floor(retry^1.5)
+  static constexpr float EXP = 1.5f;
+  std::chrono::milliseconds timeout{ 0 };
+  if (retry_ > 0) {
+    timeout = std::chrono::milliseconds(
+        static_cast<std::chrono::milliseconds::rep>(std::floor(std::pow(static_cast<float>(retry_), EXP))));
+
+    auto remaining_inputs =
+        inputs_ |
+        std::views::filter([this](const InputEntry& entry) { return entry.generation <= generation_; }) |
+        std::views::transform([](InputEntry& entry) { return entry.name(entry.ptr); });
+
+    heph::log(heph::WARN, std::string(INPUT_OVERFLOW_WARNING), "output", name(), "inputs",
+              fmt::format("[{}]", fmt::join(remaining_inputs, ", ")), "retry", retry_, "delay", timeout);
+  }
+  return heph::conduit::scheduler(engine).scheduleAfter(timeout);
+}
 }  // namespace heph::conduit::detail

--- a/modules/conduit/include/hephaestus/conduit/node.h
+++ b/modules/conduit/include/hephaestus/conduit/node.h
@@ -86,7 +86,7 @@ private:
   auto executeSender() {
     auto invoke_operation = invokeOperation();
 
-    auto trigger = stdexec::continues_on(operationTrigger(), engine().scheduler());
+    auto trigger = stdexec::continues_on(operationTrigger(), heph::conduit::scheduler(engine()));
     using TriggerT = decltype(trigger);
     using TriggerValuesVariantT = stdexec::value_types_of_t<TriggerT>;
     // static_assert(std::variant_size_v<TriggerValuesVariantT> == 1);
@@ -102,7 +102,7 @@ private:
   }
 
   auto triggerExecute() {
-    return executeSender() | implicit_output_->propagate(engine().scheduler()) |
+    return executeSender() | implicit_output_->propagate(engine()) |
            stdexec::then([this] { operationEnd(); });
   }
 
@@ -122,7 +122,7 @@ private:
   auto operationTrigger() {
     auto period_trigger = [&](detail::NodeBase::ClockT::time_point start_at) {
       if constexpr (HAS_PERIOD) {
-        return engine().scheduler().scheduleAt(start_at);
+        return heph::conduit::scheduler(engine()).scheduleAt(start_at);
       } else {
         return stdexec::just();
       }

--- a/modules/conduit/include/hephaestus/conduit/node_engine.h
+++ b/modules/conduit/include/hephaestus/conduit/node_engine.h
@@ -4,32 +4,48 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <memory>
 #include <stdexcept>
+#include <string>
+#include <tuple>
 #include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <variant>
 #include <vector>
 
 #include <exec/async_scope.hpp>
 #include <exec/static_thread_pool.hpp>
+#include <exec/task.hpp>
+#include <hephaestus/conduit/detail/input_base.h>
+#include <hephaestus/net/acceptor.h>
+#include <hephaestus/net/socket.h>
+#include <hephaestus/serdes/serdes.h>
+#include <hephaestus/utils/unique_function.h>
 #include <stdexec/execution.hpp>
 
 #include "hephaestus/concurrency/context.h"
 #include "hephaestus/concurrency/repeat_until.h"
 #include "hephaestus/conduit/detail/node_base.h"
 #include "hephaestus/conduit/node_handle.h"
+#include "hephaestus/conduit/remote_nodes.h"
+#include "hephaestus/net/endpoint.h"
 #include "hephaestus/telemetry/log.h"
 
 namespace heph::conduit {
 struct NodeEngineConfig {
   heph::concurrency::ContextConfig context_config;
   std::uint32_t number_of_threads{ 1 };
+  std::vector<heph::net::Endpoint> endpoints;
 };
 
 class NodeEngine {
 public:
-  explicit NodeEngine(NodeEngineConfig config);
+  explicit NodeEngine(const NodeEngineConfig& config);
 
   void run();
   void requestStop();
@@ -54,42 +70,141 @@ public:
     return context_.elapsed();
   }
 
-  template <typename OperatorT, typename... Ts>
-  auto createNode(Ts&&... ts) -> NodeHandle<OperatorT> {
-    std::unique_ptr<OperatorT> node_ptr;
-    if constexpr (std::is_constructible_v<OperatorT, NodeEngine&>) {
-      node_ptr = std::make_unique<OperatorT>(*this);
-    } else {
-      node_ptr = std::make_unique<OperatorT>();
-    }
-    auto* node = node_ptr.get();
-    nodes_.emplace_back(std::move(node_ptr));
-    node->data_.emplace(std::forward<Ts>(ts)...);
+  auto endpoints() const -> std::vector<heph::net::Endpoint>;
 
-    // Late initialize special members. This is required for tow reasons:
-    //  1. We don't want to impose a ctor taking the engine parameter on
-    //     an  Operator
-    //  2. The name might only be fully valid after the node is fully constructed.
-    node->implicit_output_.emplace(node, "");
-    node->engine_ = this;
-    scope_.spawn(createNodeRunner(*node));
-    return NodeHandle{ node };
-  }
+  template <typename OperatorT, typename... Ts>
+  auto createNode(Ts&&... ts) -> NodeHandle<OperatorT>;
+
+  template <typename Output>
+  void registerOutput(Output& output);
+
+  template <typename Node>
+  void registerImplicitOutput(Node& node);
 
 private:
   auto uponError();
+  template <typename Node>
+  auto uponStopped(Node* node);
 
   template <typename Node>
   auto createNodeRunner(Node& node);
+
+  template <typename T, typename Node>
+  auto createPublisherNode(Node& node, heph::net::Socket socket, std::string name) {
+    auto publisher = createNode<RemotePublisherNode<T>>(std::move(socket), std::move(name));
+    publisher->input.connectTo(node);
+  }
+
+  auto acceptClients(std::size_t index) -> exec::task<void>;
+  auto handleClient(heph::net::Socket client) -> exec::task<void>;
+
+  struct OutputRegistryEntry {
+    std::string type_info;
+    heph::UniqueFunction<void(heph::net::Socket)> publisher_factory;
+  };
 
 private:  // Optimal fields order: pool_, exception_, scope_, context_
   exec::static_thread_pool pool_;
   std::exception_ptr exception_;
   exec::async_scope scope_;
   heph::concurrency::Context context_{ {} };
+  std::vector<heph::net::Endpoint> endpoints_;
+  std::unordered_map<std::string, OutputRegistryEntry> registered_outputs_;
 
   std::vector<std::unique_ptr<detail::NodeBase>> nodes_;
+
+  std::vector<heph::net::Acceptor> acceptors_;
 };
+
+template <typename OperatorT, typename... Ts>
+inline auto NodeEngine::createNode(Ts&&... ts) -> NodeHandle<OperatorT> {
+  std::unique_ptr<OperatorT> node_ptr;
+  if constexpr (std::is_constructible_v<OperatorT, NodeEngine&>) {
+    node_ptr = std::make_unique<OperatorT>(*this);
+  } else {
+    node_ptr = std::make_unique<OperatorT>();
+  }
+  auto* node = node_ptr.get();
+  nodes_.emplace_back(std::move(node_ptr));
+  using OperationDataT = std::decay_t<decltype(node->data_)>::value_type;
+  if constexpr (std::is_constructible_v<OperationDataT, NodeEngine&, Ts...>) {
+    node->data_.emplace(*this, std::forward<Ts>(ts)...);
+  } else {
+    node->data_.emplace(std::forward<Ts>(ts)...);
+  }
+
+  // Late initialize special members. This is required for tow reasons:
+  //  1. We don't want to impose a ctor taking the engine parameter on
+  //     an  Operator
+  //  2. The name might only be fully valid after the node is fully constructed.
+  node->implicit_output_.emplace(node, "");
+  node->engine_ = this;
+
+  registerImplicitOutput(*node);
+
+  scope_.spawn(createNodeRunner(*node));
+  return NodeHandle{ node };
+}
+
+template <typename Output>
+inline void NodeEngine::registerOutput(Output& output) {
+  using ResultT = typename Output::ResultT;
+  if constexpr (detail::ISOPTIONAL<ResultT>) {
+    using ValueT = typename ResultT::value_type;
+    registered_outputs_.emplace(
+        output.name(),
+        OutputRegistryEntry{ .type_info = heph::serdes::getSerializedTypeInfo<ValueT>().toJson(),
+                             .publisher_factory =
+                                 [this, &output](heph::net::Socket socket) {
+                                   createPublisherNode<ValueT>(output, std::move(socket), output.name());
+                                 }
+
+        });
+  } else {
+    if constexpr (!std::is_same_v<void, ResultT>) {
+      registered_outputs_.emplace(
+          output.name(),
+          OutputRegistryEntry{ .type_info = heph::serdes::getSerializedTypeInfo<ResultT>().toJson(),
+                               .publisher_factory = [this, &output](heph::net::Socket socket) {
+                                 createPublisherNode<ResultT>(output, std::move(socket), output.name());
+                               } });
+    }
+  }
+}
+
+template <typename Node>
+inline void NodeEngine::registerImplicitOutput(Node& node) {
+  using ExecuteOperationT = decltype(node.executeSender());
+  using ExecuteResultVariantT = stdexec::value_types_of_t<ExecuteOperationT>;
+  static_assert(std::variant_size_v<ExecuteResultVariantT> == 1);
+  using ExecuteResultTupleT = std::variant_alternative_t<0, ExecuteResultVariantT>;
+
+  if constexpr (std::tuple_size_v<ExecuteResultTupleT> == 1) {
+    using ResultT = std::tuple_element_t<0, ExecuteResultTupleT>;
+
+    if constexpr (detail::ISOPTIONAL<ResultT>) {
+      using ValueT = typename ResultT::value_type;
+      registered_outputs_.emplace(
+          node.nodeName(),
+          OutputRegistryEntry{ .type_info = heph::serdes::getSerializedTypeInfo<ValueT>().toJson(),
+                               .publisher_factory =
+                                   [this, &node](heph::net::Socket socket) {
+                                     createPublisherNode<ValueT>(node, std::move(socket), node.nodeName());
+                                   }
+
+          });
+    } else {
+      if constexpr (!std::is_same_v<void, ResultT>) {
+        registered_outputs_.emplace(
+            node.nodeName(),
+            OutputRegistryEntry{ .type_info = heph::serdes::getSerializedTypeInfo<ResultT>().toJson(),
+                                 .publisher_factory = [this, &node](heph::net::Socket socket) {
+                                   createPublisherNode<ResultT>(node, std::move(socket), node.nodeName());
+                                 } });
+      }
+    }
+  }
+}
 
 inline auto NodeEngine::uponError() {
   return stdexec::upon_error([&]<typename Error>(Error error) noexcept {
@@ -112,11 +227,29 @@ inline auto NodeEngine::uponError() {
 }
 
 template <typename Node>
+inline auto NodeEngine::uponStopped(Node* node) {
+  return stdexec::upon_stopped([this, node] {
+    if (context_.stopRequested()) {
+      return;
+    }
+    auto it = std::ranges::find_if(nodes_, [node](auto& other) { return other.get() == node; });
+    if (it != nodes_.end()) {
+      auto node_ptr = std::move(*it);
+      // Remove connected inputs...
+      nodes_.erase(it);
+      for (it = nodes_.begin(); it != nodes_.end(); ++it) {
+        it->get()->removeOutputConnection(node);
+      }
+    }
+  });
+}
+
+template <typename Node>
 inline auto NodeEngine::createNodeRunner(Node& node) {
   auto runner = heph::concurrency::repeatUntil([&node, this] {
                   return node.triggerExecute() | stdexec::then([this] { return context_.stopRequested(); });
                 }) |
-                uponError();
+                uponError() | uponStopped(&node);
   return std::move(runner);
 }
 }  // namespace heph::conduit

--- a/modules/conduit/include/hephaestus/conduit/node_engine.h
+++ b/modules/conduit/include/hephaestus/conduit/node_engine.h
@@ -21,21 +21,21 @@
 #include <exec/async_scope.hpp>
 #include <exec/static_thread_pool.hpp>
 #include <exec/task.hpp>
-#include <hephaestus/conduit/detail/input_base.h>
-#include <hephaestus/net/acceptor.h>
-#include <hephaestus/net/socket.h>
-#include <hephaestus/serdes/serdes.h>
-#include <hephaestus/utils/unique_function.h>
 #include <stdexec/execution.hpp>
 
 #include "hephaestus/concurrency/context.h"
 #include "hephaestus/concurrency/repeat_until.h"
+#include "hephaestus/conduit/detail/input_base.h"
 #include "hephaestus/conduit/detail/node_base.h"
 #include "hephaestus/conduit/detail/output_connections.h"
 #include "hephaestus/conduit/node_handle.h"
 #include "hephaestus/conduit/remote_nodes.h"
+#include "hephaestus/net/acceptor.h"
 #include "hephaestus/net/endpoint.h"
+#include "hephaestus/net/socket.h"
+#include "hephaestus/serdes/serdes.h"
 #include "hephaestus/telemetry/log.h"
+#include "hephaestus/utils/unique_function.h"
 
 namespace heph::conduit {
 struct NodeEngineConfig {

--- a/modules/conduit/include/hephaestus/conduit/node_engine.h
+++ b/modules/conduit/include/hephaestus/conduit/node_engine.h
@@ -31,6 +31,7 @@
 #include "hephaestus/concurrency/context.h"
 #include "hephaestus/concurrency/repeat_until.h"
 #include "hephaestus/conduit/detail/node_base.h"
+#include "hephaestus/conduit/detail/output_connections.h"
 #include "hephaestus/conduit/node_handle.h"
 #include "hephaestus/conduit/remote_nodes.h"
 #include "hephaestus/net/endpoint.h"
@@ -252,4 +253,5 @@ inline auto NodeEngine::createNodeRunner(Node& node) {
                 uponError() | uponStopped(&node);
   return std::move(runner);
 }
+
 }  // namespace heph::conduit

--- a/modules/conduit/include/hephaestus/conduit/output.h
+++ b/modules/conduit/include/hephaestus/conduit/output.h
@@ -9,11 +9,12 @@
 
 #include <stdexec/execution.hpp>
 
-#include "hephaestus/concurrency/context.h"
 #include "hephaestus/conduit/detail/output_connections.h"
 #include "hephaestus/conduit/node.h"
 
 namespace heph::conduit {
+
+class NodeEngine;
 
 template <typename T>
 class Output {
@@ -29,8 +30,8 @@ public:
     return outputs_.name();
   }
 
-  auto setValue(heph::concurrency::Context::Scheduler scheduler, T t) {
-    return stdexec::just(std::move(t)) | outputs_.propagate(scheduler);
+  auto setValue(NodeEngine& engine, T t) {
+    return stdexec::just(std::move(t)) | outputs_.propagate(engine);
   }
 
   template <typename Input>

--- a/modules/conduit/include/hephaestus/conduit/output.h
+++ b/modules/conduit/include/hephaestus/conduit/output.h
@@ -9,23 +9,28 @@
 
 #include <stdexec/execution.hpp>
 
-#include "detail/node_base.h"
+#include "hephaestus/concurrency/context.h"
 #include "hephaestus/conduit/detail/output_connections.h"
 #include "hephaestus/conduit/node.h"
-#include "hephaestus/conduit/node_engine.h"
 
 namespace heph::conduit {
+
 template <typename T>
 class Output {
 public:
+  using ResultT = T;
   template <typename OperationT, typename DataT>
   explicit Output(Node<OperationT, DataT>* node, std::string name) : outputs_(node, std::move(name)) {
+    if (node != nullptr && node->enginePtr() != nullptr) {
+      node->engine().registerOutput(*this);
+    }
   }
   auto name() {
     return outputs_.name();
   }
-  auto setValue(NodeEngine& engine, T t) {
-    return stdexec::just(std::move(t)) | outputs_.propagate(engine);
+
+  auto setValue(heph::concurrency::Context::Scheduler scheduler, T t) {
+    return stdexec::just(std::move(t)) | outputs_.propagate(scheduler);
   }
 
   template <typename Input>

--- a/modules/conduit/include/hephaestus/conduit/remote_nodes.h
+++ b/modules/conduit/include/hephaestus/conduit/remote_nodes.h
@@ -1,0 +1,240 @@
+//=================================================================================================
+// Copyright (C) 2023-2025 HEPHAESTUS Contributors
+//=================================================================================================
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <limits>
+#include <memory_resource>
+#include <optional>
+#include <span>
+#include <string>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <exec/task.hpp>
+#include <fmt/format.h>
+#include <stdexec/execution.hpp>
+
+#include "hephaestus/concurrency/context.h"
+#include "hephaestus/conduit/input.h"
+#include "hephaestus/conduit/node.h"
+#include "hephaestus/conduit/queued_input.h"
+#include "hephaestus/net/connect.h"
+#include "hephaestus/net/endpoint.h"
+#include "hephaestus/net/recv.h"
+#include "hephaestus/net/send.h"
+#include "hephaestus/net/socket.h"
+#include "hephaestus/serdes/serdes.h"
+#include "hephaestus/telemetry/log_sink.h"
+#include "hephaestus/utils/exception.h"
+
+namespace heph::conduit {
+namespace internal {
+template <typename T>
+auto createNetEntity(const heph::net::Endpoint& endpoint, heph::concurrency::Context& context) {
+  switch (endpoint.type()) {
+    case heph::net::EndpointType::BT:
+      return T::createL2cap(context);
+    case heph::net::EndpointType::IPV4:
+      return T::createTcpIpV4(context);
+    case heph::net::EndpointType::IPV6:
+      return T::createTcpIpV6(context);
+    default:
+      heph::panic("Unknown endpoint type");
+  }
+  __builtin_unreachable();
+}
+}  // namespace internal
+
+class RemoteSubscriberOperator {
+  auto connect(std::string* type_info) {
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    return heph::net::connect(socket_.value(), endpoint_) |
+           stdexec::let_value([this, size = static_cast<std::uint16_t>(name_.size())]() {
+             return heph::net::sendAll(socket_.value(), std::as_bytes(std::span{ &size, 1 })) |
+                    stdexec::let_value([this](auto /*unused*/) {
+                      return heph::net::sendAll(socket_.value(), std::as_bytes(std::span{ name_ }));
+                    });
+           }) |
+           stdexec::let_value(
+               [this, type_info, size = static_cast<std::uint16_t>(type_info->size())](auto /*unused*/) {
+                 return heph::net::sendAll(socket_.value(), std::as_bytes(std::span{ &size, 1 })) |
+                        stdexec::let_value([this, type_info](auto /*unused*/) {
+                          return heph::net::sendAll(socket_.value(), std::as_bytes(std::span{ *type_info }));
+                        });
+               });
+  }
+
+public:
+  using MsgT = std::pmr::vector<std::byte>;
+
+  explicit RemoteSubscriberOperator(heph::net::Endpoint endpoint, std::string name)
+    : endpoint_(std::move(endpoint)), name_(std::move(name)) {
+  }
+
+  [[nodiscard]] auto name() const -> std::string {
+    return fmt::format("{}/{}", endpoint_, name_);
+  }
+
+  auto trigger(heph::concurrency::Context* context, std::string* type_info) -> exec::task<MsgT> {
+    try {
+      if (!socket_.has_value()) {
+        socket_.emplace(internal::createNetEntity<heph::net::Socket>(endpoint_, *context));
+
+        co_await connect(type_info);
+      }
+
+      // NOLINTNEXTLINE (readability-static-accessed-through-instance)
+      auto msg = co_await receiveData();
+      if (!msg.empty()) {
+        co_return msg;
+      }
+      heph::log(heph::ERROR, "Reconnecting subscriber, connection was closed", "node", name());
+
+    } catch (std::exception& exception) {
+      std::string error = exception.what();
+      if (last_error_.has_value()) {
+        if (*last_error_ == error) {
+          error.clear();
+        } else {
+          last_error_.emplace(error);
+        }
+      } else {
+        last_error_.emplace(error);
+      }
+
+      if (!error.empty()) {
+        heph::log(heph::ERROR, "Retrying", "node", name(), "error", error);
+      }
+    }
+
+    socket_.reset();
+    co_return {};
+  }
+
+private:
+  auto receiveData() -> exec::task<MsgT> {
+    std::uint16_t size = 0;
+    auto size_buffer = std::as_writable_bytes(std::span{ &size, 1 });
+    auto size_result =
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+        co_await (heph::net::recvAll(socket_.value(), size_buffer) | stdexec::stopped_as_optional());
+    if (!size_result.has_value()) {
+      co_return {};
+    }
+    std::pmr::vector<std::byte> msg(size, &memory_resource_);
+    auto msg_result =
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+        co_await (heph::net::recvAll(socket_.value(), std::span{ msg }) | stdexec::stopped_as_optional());
+    if (!msg_result.has_value()) {
+      co_return {};
+    }
+
+    co_return msg;
+  }
+
+private:
+  std::optional<heph::net::Socket> socket_;
+  heph::net::Endpoint endpoint_;
+  std::string name_;
+  std::pmr::unsynchronized_pool_resource memory_resource_;
+  std::string type_info_;
+  std::optional<std::string> last_error_;
+};
+
+template <typename T>
+struct RemoteSubscriberNode : heph::conduit::Node<RemoteSubscriberNode<T>, RemoteSubscriberOperator> {
+  std::string type_info = heph::serdes::getSerializedTypeInfo<T>().toJson();
+
+  static auto name(const RemoteSubscriberNode& self) {
+    return self.data().name();
+  }
+
+  static auto trigger(RemoteSubscriberNode* self) {
+    return self->data().trigger(&self->engine().scheduler().context(), &self->type_info);
+  }
+
+  static auto execute(RemoteSubscriberOperator::MsgT msg) -> std::optional<T> {
+    auto msg_buffer = std::span{ msg };
+    if (msg_buffer.empty()) {
+      // No data received...
+      return std::nullopt;
+    }
+
+    T value;
+    heph::serdes::deserialize(msg_buffer, value);
+    return value;
+  }
+};
+
+class RemotePublisherOperator {
+public:
+  explicit RemotePublisherOperator(heph::net::Socket client, std::string name)
+    : client_(std::move(client)), remote_endpoint_(client_.remoteEndpoint()), name_(std::move(name)) {
+  }
+
+  [[nodiscard]] auto name() const -> std::string {
+    return fmt::format("{}/{}", remote_endpoint_, name_);
+  }
+
+  auto publish(std::vector<std::byte> msg) {
+    const auto msg_size = msg.size();
+    if (msg_size > std::numeric_limits<std::uint16_t>::max()) {
+      heph::panic("Message size too big");
+    }
+    return stdexec::just(static_cast<std::uint16_t>(msg_size)) |
+           stdexec::let_value([this](std::uint16_t& size) {
+             auto size_buffer = std::as_bytes(std::span{ &size, 1 });
+             return heph::net::sendAll(client_, size_buffer);
+           }) |
+           stdexec::let_value([this, msg = std::move(msg)](auto /*unused*/) {
+             auto msg_buffer = std::span{ msg };
+             return heph::net::sendAll(client_, msg_buffer) | stdexec::then([](auto /*unused*/) {});
+           }) |
+           stdexec::let_error([this]<typename Error>(const Error& error) {
+             if constexpr (std::is_same_v<std::error_code, Error>) {
+               heph::log(heph::INFO, "Stop publishing", "node", name(), "reason", error.message());
+
+             } else {
+               try {
+                 std::rethrow_exception(error);
+               } catch (std::exception& exception) {
+                 heph::log(heph::INFO, "Stop publishing", "node", name(), "reason", exception.what());
+
+               } catch (...) {
+                 heph::log(heph::INFO, "Stop publishing", "node", name(), "reason", "unknown");
+               }
+             }
+             return stdexec::just_stopped();
+           });
+  }
+
+private:
+  heph::net::Socket client_;
+  heph::net::Endpoint remote_endpoint_;
+  std::string name_;
+};
+
+template <typename T, typename InputPolicyT = InputPolicy<>>
+struct RemotePublisherNode : conduit::Node<RemotePublisherNode<T, InputPolicyT>, RemotePublisherOperator> {
+  QueuedInput<T, InputPolicyT> input{ this, "input" };
+
+  static auto name(const RemotePublisherNode& self) {
+    return self.data().name();
+  }
+
+  static auto trigger(RemotePublisherNode& self) {
+    return self.input.get();
+  }
+
+  static auto execute(RemotePublisherNode& self, const T& t) {
+    return self.data().publish(heph::serdes::serialize(t));
+  }
+};
+}  // namespace heph::conduit

--- a/modules/conduit/include/hephaestus/conduit/remote_nodes.h
+++ b/modules/conduit/include/hephaestus/conduit/remote_nodes.h
@@ -39,8 +39,10 @@ namespace internal {
 template <typename T>
 auto createNetEntity(const heph::net::Endpoint& endpoint, heph::concurrency::Context& context) {
   switch (endpoint.type()) {
+#ifndef DISABLE_BLUETOOTH
     case heph::net::EndpointType::BT:
       return T::createL2cap(context);
+#endif
     case heph::net::EndpointType::IPV4:
       return T::createTcpIpV4(context);
     case heph::net::EndpointType::IPV6:

--- a/modules/conduit/src/detail/node_base.cpp
+++ b/modules/conduit/src/detail/node_base.cpp
@@ -9,6 +9,7 @@
 #include <fmt/format.h>
 #include <stdexec/stop_token.hpp>
 
+#include "hephaestus/concurrency/context.h"
 #include "hephaestus/conduit/node_engine.h"
 #include "hephaestus/telemetry/log.h"
 #include "hephaestus/telemetry/log_sink.h"
@@ -102,6 +103,13 @@ auto NodeBase::getStopToken() -> stdexec::inplace_stop_token {
     return stdexec::inplace_stop_token{};
   }
   return engine_->getStopToken();
+}
+
+auto NodeBase::scheduler() const -> concurrency::Context::Scheduler {
+  if (engine_ == nullptr) {
+    return { nullptr };
+  }
+  return engine_->scheduler();
 }
 auto NodeBase::runsOnEngine() const -> bool {
   if (engine_ == nullptr) {

--- a/modules/conduit/src/detail/output_connections.cpp
+++ b/modules/conduit/src/detail/output_connections.cpp
@@ -5,4 +5,16 @@
 
 #include "hephaestus/conduit/detail/output_connections.h"
 
-namespace heph::conduit::detail {}
+#include <string>
+
+#include <fmt/format.h>
+
+#include "hephaestus/conduit/detail/node_base.h"
+
+namespace heph::conduit::detail {
+
+auto OutputConnections::name() const -> std::string {
+  return fmt::format("{}/{}", node_->nodeName(), name_);
+}
+
+}  // namespace heph::conduit::detail

--- a/modules/conduit/src/node_engine.cpp
+++ b/modules/conduit/src/node_engine.cpp
@@ -149,4 +149,8 @@ auto NodeEngine::endpoints() const -> std::vector<heph::net::Endpoint> {
   }
   return res;
 }
+
+auto scheduler(NodeEngine& engine) -> concurrency::Context::Scheduler {
+  return engine.scheduler();
+}
 }  // namespace heph::conduit

--- a/modules/conduit/src/node_engine.cpp
+++ b/modules/conduit/src/node_engine.cpp
@@ -4,16 +4,58 @@
 
 #include "hephaestus/conduit/node_engine.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <exception>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
 
+#include <exec/task.hpp>
 #include <stdexec/execution.hpp>
+
+#include "hephaestus/conduit/detail/node_base.h"
+#include "hephaestus/net/accept.h"
+#include "hephaestus/net/acceptor.h"
+#include "hephaestus/net/endpoint.h"
+#include "hephaestus/net/recv.h"
+#include "hephaestus/net/socket.h"
+#include "hephaestus/telemetry/log.h"
+#include "hephaestus/telemetry/log_sink.h"
+#include "hephaestus/utils/exception.h"
 
 namespace heph::conduit {
 
-NodeEngine::NodeEngine(NodeEngineConfig config)
+NodeEngine::NodeEngine(const NodeEngineConfig& config)
   : pool_(config.number_of_threads), context_(config.context_config) {
+  acceptors_.reserve(config.endpoints.size());
+
+  auto create_acceptor = [&](net::EndpointType type) {
+    switch (type) {
+      case heph::net::EndpointType::BT:
+        return heph::net::Acceptor::createL2cap(context_);
+      case heph::net::EndpointType::IPV4:
+        return heph::net::Acceptor::createTcpIpV4(context_);
+      case heph::net::EndpointType::IPV6:
+        return heph::net::Acceptor::createTcpIpV6(context_);
+      default:
+        heph::panic("Unknown endpoint type");
+    }
+    __builtin_unreachable();
+  };
+
+  for (const auto& endpoint : config.endpoints) {
+    acceptors_.push_back(create_acceptor(endpoint.type()));
+    acceptors_.back().bind(endpoint);
+    acceptors_.back().listen();
+  }
 }
 void NodeEngine::run() {
+  for (std::size_t i = 0; i != acceptors_.size(); ++i) {
+    scope_.spawn(acceptClients(i));
+  }
+
   context_.run();
   scope_.request_stop();
   stdexec::sync_wait(scope_.on_empty());
@@ -24,5 +66,85 @@ void NodeEngine::run() {
 void NodeEngine::requestStop() {
   pool_.request_stop();
   context_.requestStop();
+}
+auto NodeEngine::acceptClients(std::size_t index) -> exec::task<void> {
+  const heph::net::Acceptor& server = acceptors_[index];
+
+  while (true) {
+    auto client = co_await heph::net::accept(server);
+    scope_.spawn(handleClient(std::move(client)));
+  }
+}
+auto NodeEngine::handleClient(heph::net::Socket client) -> exec::task<void> {
+  // The protocol is as follows:
+  // Datatypes:
+  //  - int: int16_t
+  //  - string: int length, char[length]
+  //
+  // Flow:
+  // 1. Negotiation:
+  //  1. Receive name of node/output (string)
+  //  2. Receive expected input type (string)
+  //
+  // 2. Value loop:
+  //  1. Send Data
+
+  std::uint16_t size = 0;
+  if (auto res = co_await (heph::net::recvAll(client, std::as_writable_bytes(std::span{ &size, 1 })) |
+                           stdexec::stopped_as_optional());
+      !res.has_value()) {
+    heph::log(heph::WARN, "Connection closed");
+    co_return;
+  }
+  std::string name(size, 0);
+  if (auto res = co_await (heph::net::recvAll(client, std::as_writable_bytes(std::span{ name })) |
+                           stdexec::stopped_as_optional());
+      !res.has_value()) {
+    heph::log(heph::WARN, "Connection closed", "name", name);
+    co_return;
+  }
+
+  if (auto res = co_await (heph::net::recvAll(client, std::as_writable_bytes(std::span{ &size, 1 })) |
+                           stdexec::stopped_as_optional());
+      !res.has_value()) {
+    heph::log(heph::WARN, "Connection closed", "name", name);
+    co_return;
+  }
+  std::string type_info(size, 0);
+  if (auto res = co_await (heph::net::recvAll(client, std::as_writable_bytes(std::span{ type_info })) |
+                           stdexec::stopped_as_optional());
+      !res.has_value()) {
+    heph::log(heph::WARN, "Connection closed", "name", name);
+    co_return;
+  }
+
+  auto it = registered_outputs_.find(name);
+
+  if (it == registered_outputs_.end()) {
+    heph::log(heph::ERROR, "Output not found", "name", name);
+    co_return;
+  }
+
+  auto& [_, entry] = *it;
+
+  if (type_info != entry.type_info) {
+    heph::log(heph::ERROR, "Output type mismatch", "name", name, "expected", type_info, "actual",
+              entry.type_info);
+    co_return;
+  }
+
+  heph::log(heph::INFO, "Connected output forwarding client", "name", name);
+  entry.publisher_factory(std::move(client));
+
+  co_return;
+}
+
+auto NodeEngine::endpoints() const -> std::vector<heph::net::Endpoint> {
+  std::vector<heph::net::Endpoint> res;
+  res.reserve(acceptors_.size());
+  for (const auto& acceptor : acceptors_) {
+    res.push_back(acceptor.localEndpoint());
+  }
+  return res;
 }
 }  // namespace heph::conduit

--- a/modules/conduit/src/node_engine.cpp
+++ b/modules/conduit/src/node_engine.cpp
@@ -5,21 +5,21 @@
 #include "hephaestus/conduit/node_engine.h"
 
 #include <cstddef>
-#include <cstdint>
 #include <exception>
-#include <span>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
 #include <exec/task.hpp>
+#include <fmt/format.h>
 #include <stdexec/execution.hpp>
 
 #include "hephaestus/conduit/detail/node_base.h"
+#include "hephaestus/conduit/remote_nodes.h"
 #include "hephaestus/net/accept.h"
 #include "hephaestus/net/acceptor.h"
 #include "hephaestus/net/endpoint.h"
-#include "hephaestus/net/recv.h"
 #include "hephaestus/net/socket.h"
 #include "hephaestus/telemetry/log.h"
 #include "hephaestus/telemetry/log_sink.h"
@@ -77,6 +77,7 @@ auto NodeEngine::acceptClients(std::size_t index) -> exec::task<void> {
     scope_.spawn(handleClient(std::move(client)));
   }
 }
+
 auto NodeEngine::handleClient(heph::net::Socket client) -> exec::task<void> {
   // The protocol is as follows:
   // Datatypes:
@@ -91,51 +92,34 @@ auto NodeEngine::handleClient(heph::net::Socket client) -> exec::task<void> {
   // 2. Value loop:
   //  1. Send Data
 
-  std::uint16_t size = 0;
-  if (auto res = co_await (heph::net::recvAll(client, std::as_writable_bytes(std::span{ &size, 1 })) |
-                           stdexec::stopped_as_optional());
-      !res.has_value()) {
-    heph::log(heph::WARN, "Connection closed");
-    co_return;
-  }
-  std::string name(size, 0);
-  if (auto res = co_await (heph::net::recvAll(client, std::as_writable_bytes(std::span{ name })) |
-                           stdexec::stopped_as_optional());
-      !res.has_value()) {
-    heph::log(heph::WARN, "Connection closed", "name", name);
-    co_return;
-  }
-
-  if (auto res = co_await (heph::net::recvAll(client, std::as_writable_bytes(std::span{ &size, 1 })) |
-                           stdexec::stopped_as_optional());
-      !res.has_value()) {
-    heph::log(heph::WARN, "Connection closed", "name", name);
-    co_return;
-  }
-  std::string type_info(size, 0);
-  if (auto res = co_await (heph::net::recvAll(client, std::as_writable_bytes(std::span{ type_info })) |
-                           stdexec::stopped_as_optional());
-      !res.has_value()) {
-    heph::log(heph::WARN, "Connection closed", "name", name);
-    co_return;
-  }
+  auto name = co_await internal::recv<std::string>(client);
+  auto type_info = co_await internal::recv<std::string>(client);
 
   auto it = registered_outputs_.find(name);
 
   if (it == registered_outputs_.end()) {
-    heph::log(heph::ERROR, "Output not found", "name", name);
+    const std::string error = "Output not found";
+    heph::log(heph::ERROR, error, "name", name);
+    co_await internal::send(client, error);
+
     co_return;
   }
 
   auto& [_, entry] = *it;
 
   if (type_info != entry.type_info) {
-    heph::log(heph::ERROR, "Output type mismatch", "name", name, "expected", type_info, "actual",
-              entry.type_info);
+    heph::log(heph::ERROR, "Type mismatch", "name", name, "expected", type_info, "actual", entry.type_info,
+              "client", client.remoteEndpoint());
+    auto error = fmt::format("Type mismatch: Expected {}, got {}", entry.type_info, type_info);
+    co_await internal::send(client, error);
     co_return;
   }
 
-  heph::log(heph::INFO, "Connected output forwarding client", "name", name);
+  // No error, just send back a "zero" string. to acknowledge the full negotiation.
+  static constexpr std::string_view SUCCESS{ "success" };
+  co_await internal::send(client, SUCCESS);
+
+  heph::log(heph::INFO, "Connected subscriber", "name", name, "client", client.remoteEndpoint());
   entry.publisher_factory(std::move(client));
 
   co_return;

--- a/modules/conduit/src/node_engine.cpp
+++ b/modules/conduit/src/node_engine.cpp
@@ -33,8 +33,10 @@ NodeEngine::NodeEngine(const NodeEngineConfig& config)
 
   auto create_acceptor = [&](net::EndpointType type) {
     switch (type) {
+#ifndef DISABLE_BLUETOOTH
       case heph::net::EndpointType::BT:
         return heph::net::Acceptor::createL2cap(context_);
+#endif
       case heph::net::EndpointType::IPV4:
         return heph::net::Acceptor::createTcpIpV4(context_);
       case heph::net::EndpointType::IPV6:

--- a/modules/conduit/tests/input_output_tests.cpp
+++ b/modules/conduit/tests/input_output_tests.cpp
@@ -135,8 +135,7 @@ TEST(InputOutput, QueuedInputExplicitOutput) {
   QueuedInput<std::string> input{ &dummy, "input" };
   Output<std::string> output{ &dummy, "output" };
   input.connectTo(output);
-  scope.spawn(output.setValue(engine.scheduler(), "Hello World!") |
-              stdexec::then([&] { engine.requestStop(); }));
+  scope.spawn(output.setValue(engine, "Hello World!") | stdexec::then([&] { engine.requestStop(); }));
   engine.run();
   auto res = input.getValue();
   EXPECT_TRUE(res.has_value());
@@ -172,8 +171,7 @@ TEST(InputOutput, QueuedInputOutputDelay) {
   input.connectTo(output);
   EXPECT_EQ(input.setValue("Hello World!"), InputState::OK);
   std::optional<std::string> res;
-  scope.spawn(output.setValue(engine.scheduler(), "Hello World Again!") |
-              stdexec::then([&] { engine.requestStop(); }));
+  scope.spawn(output.setValue(engine, "Hello World Again!") | stdexec::then([&] { engine.requestStop(); }));
   scope.spawn(engine.scheduler().scheduleAfter(TIMEOUT) | stdexec::let_value([&] { return input.get(); }) |
               stdexec::then([&](std::string value) { res.emplace(std::move(value)); }));
   // scope.spawn(output.setValue(engine, "Hello World!"));
@@ -206,8 +204,7 @@ TEST(InputOutput, QueuedInputOutputDelaySimulated) {
   input.connectTo(output);
   EXPECT_EQ(input.setValue("Hello World!"), InputState::OK);
   std::optional<std::string> res;
-  scope.spawn(output.setValue(engine.scheduler(), "Hello World Again!") |
-              stdexec::then([&] { engine.requestStop(); }));
+  scope.spawn(output.setValue(engine, "Hello World Again!") | stdexec::then([&] { engine.requestStop(); }));
   scope.spawn(engine.scheduler().scheduleAfter(TIMEOUT) | stdexec::let_value([&] { return input.get(); }) |
               stdexec::then([&](std::string value) { res.emplace(std::move(value)); }));
   // scope.spawn(output.setValue(engine, "Hello World!"));
@@ -288,7 +285,7 @@ TEST(InputOutput, QueuedInputWhenAny) {
 
     std::variant<int, std::string> res;
     scope.spawn(engine.scheduler().scheduleAfter(TIMEOUT) |
-                stdexec::let_value([&] { return output.setValue(engine.scheduler(), "..."); }));
+                stdexec::let_value([&] { return output.setValue(engine, "..."); }));
     scope.spawn(exec::when_any(input2.get(), input4.get()) |
                 stdexec::then([&]<typename ValueT>(ValueT value) {
                   engine.requestStop();

--- a/modules/conduit/tests/remote_publisher_tests.cpp
+++ b/modules/conduit/tests/remote_publisher_tests.cpp
@@ -1,0 +1,226 @@
+//=================================================================================================
+// Copyright (C) 2023-2024 HEPHAESTUS Contributors
+//=================================================================================================
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string_view>
+#include <thread>
+
+#include <gtest/gtest.h>
+#include <stdexec/execution.hpp>
+
+#include "hephaestus/conduit/node.h"
+#include "hephaestus/conduit/node_engine.h"
+#include "hephaestus/conduit/queued_input.h"
+#include "hephaestus/conduit/remote_nodes.h"
+#include "hephaestus/net/endpoint.h"
+#include "hephaestus/telemetry/log_sink.h"
+#include "hephaestus/telemetry/log_sinks/absl_sink.h"
+#include "hephaestus/types/dummy_type.h"
+#include "hephaestus/types_proto/dummy_type.h"  // NOLINT(misc-include-cleaner)
+#include "hephaestus/utils/stack_trace.h"
+#include "modules/types/include/hephaestus/types/dummy_type.h"
+
+namespace heph::conduit::tests {
+
+class MyEnvironment final : public testing::Environment {
+public:
+  ~MyEnvironment() override = default;
+  void SetUp() override {
+    heph::telemetry::registerLogSink(std::make_unique<heph::telemetry::AbslLogSink>(heph::DEBUG));
+  }
+  void TearDown() override {
+  }
+
+private:
+  heph::utils::StackTrace stack_trace_;
+};
+// NOLINTNEXTLINE
+const auto* const my_env = dynamic_cast<MyEnvironment*>(AddGlobalTestEnvironment(new MyEnvironment{}));
+
+struct Generator : heph::conduit::Node<Generator> {
+  static constexpr std::string_view NAME = "generator";
+
+  static constexpr std::chrono::milliseconds PERIOD{ 10 };
+
+  static auto trigger() {
+    return stdexec::just();
+  }
+
+  static auto execute() {
+    return types::DummyType{};
+  }
+};
+
+struct ReceivingOperationData {
+  std::size_t iterations{ 0 };
+  std::size_t executed{ 0 };
+  std::optional<types::DummyType> dummy;
+};
+
+struct ReceivingOperation : Node<ReceivingOperation, ReceivingOperationData> {
+  QueuedInput<types::DummyType> input{ this, "input" };
+
+  static auto trigger(ReceivingOperation& operation) {
+    return operation.input.get();
+  }
+
+  static auto execute(ReceivingOperation& operation, types::DummyType dummy) {
+    ++operation.data().executed;
+    // operation.data().dummy.emplace(dummy);
+    if (operation.data().iterations == operation.data().executed) {
+      operation.engine().requestStop();
+    }
+    return dummy;
+  }
+};
+
+TEST(RemoteNodeTests, nodeBasic) {
+  NodeEngineConfig config1;
+  config1.endpoints = { heph::net::Endpoint::createIpV4("127.0.0.1") };
+  NodeEngine engine1{ config1 };
+
+  NodeEngineConfig config2;
+  config2.endpoints = { heph::net::Endpoint::createIpV4("127.0.0.1") };
+  NodeEngine engine2{ config2 };
+
+  auto endpoints1 = engine1.endpoints();
+  auto endpoints2 = engine2.endpoints();
+
+  // Publisher
+  std::thread t1{ [&engine = engine1] {
+    [[maybe_unused]] auto node = engine.createNode<Generator>();
+
+    engine.run();
+  } };
+
+  // Subscriber
+  std::thread t2{ [&engine = engine2, remote_endpoints = engine1.endpoints()] {
+    static constexpr std::size_t NUM_ITERATIONS = 10;
+    auto node = engine.createNode<ReceivingOperation>(NUM_ITERATIONS, 0, std::nullopt);
+
+    EXPECT_EQ(remote_endpoints.size(), 1);
+    for (const auto& endpoint : remote_endpoints) {
+      auto subscriber = engine.createNode<RemoteSubscriberNode<heph::types::DummyType>>(
+          endpoint, std::string{ Generator::NAME });
+      node->input.connectTo(subscriber);
+    }
+    engine.run();
+    EXPECT_EQ(node->data().executed, NUM_ITERATIONS);
+    EXPECT_EQ(node->data().iterations, NUM_ITERATIONS);
+  } };
+  t2.join();
+  engine1.requestStop();
+  t1.join();
+}
+
+TEST(RemoteNodeTests, subscriberRestart) {
+  NodeEngineConfig config1;
+  config1.endpoints = { heph::net::Endpoint::createIpV4("127.0.0.1") };
+  NodeEngine engine1{ config1 };
+
+  // Publisher
+  std::thread t1{ [&engine = engine1] {
+    [[maybe_unused]] auto node = engine.createNode<Generator>();
+
+    engine.run();
+  } };
+
+  // Subscriber
+  std::thread t2{ [remote_endpoints = engine1.endpoints()] {
+    static constexpr std::size_t NUM_ITERATIONS = 100;
+    for (std::size_t i = 0; i != NUM_ITERATIONS; ++i) {
+      NodeEngine engine{ {} };
+      auto node = engine.createNode<ReceivingOperation>(1, 0, std::nullopt);
+
+      EXPECT_EQ(remote_endpoints.size(), 1);
+      for (const auto& endpoint : remote_endpoints) {
+        auto subscriber = engine.createNode<RemoteSubscriberNode<heph::types::DummyType>>(
+            endpoint, std::string{ Generator::NAME });
+        node->input.connectTo(subscriber);
+      }
+      engine.run();
+      EXPECT_EQ(node->data().executed, 1);
+      EXPECT_EQ(node->data().iterations, 1);
+    }
+  } };
+
+  t2.join();
+  engine1.requestStop();
+  t1.join();
+}
+
+TEST(RemoteNodeTests, publisherRestart) {
+  static constexpr std::size_t NUM_ITERATIONS = 100;
+  std::mutex endpoint_mtx;
+  std::condition_variable endpoint_cv;
+  std::optional<heph::net::Endpoint> endpoint;
+
+  NodeEngine subscriber_engine{ {} };
+  // Publisher
+  std::thread t1{ [&] {
+    for (std::size_t i = 0; i != NUM_ITERATIONS; ++i) {
+      NodeEngineConfig config;
+      {
+        const std::scoped_lock l{ endpoint_mtx };
+        if (!endpoint.has_value()) {
+          config.endpoints = { heph::net::Endpoint::createIpV4("127.0.0.1") };
+
+        } else {
+          config.endpoints = { endpoint.value() };
+        }
+      }
+      try {
+        NodeEngine engine{ config };
+
+        {
+          const std::scoped_lock l{ endpoint_mtx };
+          endpoint.emplace(engine.endpoints().front());
+          endpoint_cv.notify_all();
+        }
+
+        auto generator = engine.createNode<Generator>();
+        auto stopper = engine.createNode<ReceivingOperation>(NUM_ITERATIONS, 0, std::nullopt);
+
+        stopper->input.connectTo(generator);
+
+        engine.run();
+
+      } catch (std::exception& exception) {
+        std::this_thread::yield();
+      }
+    }
+  } };
+
+  // Subscriber
+  std::thread t2{ [&] {
+    auto node =
+        subscriber_engine.createNode<ReceivingOperation>(NUM_ITERATIONS * NUM_ITERATIONS, 0, std::nullopt);
+
+    heph::net::Endpoint remote_endpoint;
+    {
+      std::unique_lock l{ endpoint_mtx };
+      endpoint_cv.wait(l, [&]() { return endpoint.has_value(); });
+      remote_endpoint = endpoint.value();
+    }
+
+    auto subscriber = subscriber_engine.createNode<RemoteSubscriberNode<heph::types::DummyType>>(
+        remote_endpoint, std::string{ Generator::NAME });
+    node->input.connectTo(subscriber);
+    subscriber_engine.run();
+    EXPECT_GT(node->data().executed, 0);
+    EXPECT_LT(node->data().executed, NUM_ITERATIONS * NUM_ITERATIONS);
+  } };
+
+  t1.join();
+  subscriber_engine.requestStop();
+  t2.join();
+}
+
+}  // namespace heph::conduit::tests

--- a/modules/net/CMakeLists.txt
+++ b/modules/net/CMakeLists.txt
@@ -1,0 +1,25 @@
+# =================================================================================================
+# Copyright (C) 2023-2024 HEPHAESTUS Contributors
+# =================================================================================================
+
+declare_module(
+  NAME net
+  DEPENDS_ON_MODULES concurrency
+  DEPENDS_ON_EXTERNAL_PROJECTS ""
+)
+
+# library sources
+file(GLOB_RECURSE SOURCES src/*.cpp src/*.h include/*.h)
+
+# library target
+define_module_library(
+  NAME net
+  PUBLIC_LINK_LIBS hephaestus::concurrency
+  PRIVATE_LINK_LIBS ""
+  SOURCES ${SOURCES}
+  PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
+  PRIVATE_INCLUDE_PATHS ""
+  SYSTEM_PRIVATE_INCLUDE_PATHS ""
+)
+
+# Subprojects add_subdirectory(tests) add_subdirectory(examples)

--- a/modules/net/CMakeLists.txt
+++ b/modules/net/CMakeLists.txt
@@ -5,11 +5,8 @@
 declare_module(
   NAME net
   DEPENDS_ON_MODULES concurrency
-  DEPENDS_ON_EXTERNAL_PROJECTS libbluetooth
+  DEPENDS_ON_EXTERNAL_PROJECTS ""
 )
-
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(LIBBLUETOOTH REQUIRED IMPORTED_TARGET libbluetooth)
 
 # library sources
 file(GLOB_RECURSE SOURCES src/*.cpp src/*.h include/*.h)
@@ -17,12 +14,15 @@ file(GLOB_RECURSE SOURCES src/*.cpp src/*.h include/*.h)
 # library target
 define_module_library(
   NAME net
-  PUBLIC_LINK_LIBS hephaestus::concurrency PkgConfig::LIBBLUETOOTH
+  PUBLIC_LINK_LIBS hephaestus::concurrency
   PRIVATE_LINK_LIBS ""
   SOURCES ${SOURCES}
   PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
   PRIVATE_INCLUDE_PATHS ""
   SYSTEM_PRIVATE_INCLUDE_PATHS ""
 )
+
+# TODO: figure out how to properly add libbluetooth as a dependency
+target_compile_definitions(hephaestus_net PUBLIC DISABLE_BLUETOOTH)
 
 # Subprojects add_subdirectory(tests) add_subdirectory(examples)

--- a/modules/net/CMakeLists.txt
+++ b/modules/net/CMakeLists.txt
@@ -5,8 +5,11 @@
 declare_module(
   NAME net
   DEPENDS_ON_MODULES concurrency
-  DEPENDS_ON_EXTERNAL_PROJECTS ""
+  DEPENDS_ON_EXTERNAL_PROJECTS libbluetooth
 )
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBBLUETOOTH REQUIRED IMPORTED_TARGET libbluetooth)
 
 # library sources
 file(GLOB_RECURSE SOURCES src/*.cpp src/*.h include/*.h)
@@ -14,7 +17,7 @@ file(GLOB_RECURSE SOURCES src/*.cpp src/*.h include/*.h)
 # library target
 define_module_library(
   NAME net
-  PUBLIC_LINK_LIBS hephaestus::concurrency
+  PUBLIC_LINK_LIBS hephaestus::concurrency PkgConfig::LIBBLUETOOTH
   PRIVATE_LINK_LIBS ""
   SOURCES ${SOURCES}
   PUBLIC_INCLUDE_PATHS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>

--- a/modules/net/examples/bt_server.cpp
+++ b/modules/net/examples/bt_server.cpp
@@ -60,14 +60,17 @@ auto pong(heph::net::Socket socket) -> exec::task<void> {
   }
 }
 
+// NOLINTNEXTLINE (readability-static-accessed-through-instance)
 auto server(heph::net::Acceptor acceptor) -> exec::task<void> {
   exec::async_scope scope;
 
+  // NOLINTNEXTLINE
   while (true) {
     auto socket = co_await heph::net::accept(acceptor);
     scope.spawn(pong(std::move(socket)));
   }
 }
+
 }  // namespace
 
 auto main(int argc, const char* argv[]) -> int {
@@ -92,8 +95,7 @@ auto main(int argc, const char* argv[]) -> int {
 
     scope.spawn(server(std::move(acceptor)));
 
-    heph::utils::TerminationBlocker::registerInterruptCallback([&context] { context.requestStop(); });
-
+    heph::utils::TerminationBlocker::registerInterruptCallback([&context]() { context.requestStop(); });
     context.run();
 
     return 0;

--- a/modules/net/include/hephaestus/net/acceptor.h
+++ b/modules/net/include/hephaestus/net/acceptor.h
@@ -17,7 +17,9 @@ public:
 
   static auto createTcpIpV4(concurrency::Context& context) -> Acceptor;
   static auto createTcpIpV6(concurrency::Context& context) -> Acceptor;
+#ifndef DISABLE_BLUETOOTH
   static auto createL2cap(concurrency::Context& context) -> Acceptor;
+#endif
 
   void listen(int backlog = DEFAULT_BACKLOG) const;
   void bind(const Endpoint& endpoint) const;

--- a/modules/net/include/hephaestus/net/connect.h
+++ b/modules/net/include/hephaestus/net/connect.h
@@ -44,7 +44,7 @@ struct ConnectOperation {
     auto addr = endpoint->nativeHandle();
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     ::io_uring_prep_connect(sqe, socket->nativeHandle(), reinterpret_cast<const sockaddr*>(addr.data()),
-                            addr.size());
+                            static_cast<socklen_t>(addr.size()));
   }
   void handleCompletion(::io_uring_cqe* cqe) {
     if (cqe->res < 0) {

--- a/modules/net/include/hephaestus/net/connect.h
+++ b/modules/net/include/hephaestus/net/connect.h
@@ -1,0 +1,92 @@
+//=================================================================================================
+// Copyright (C) 2023-2025 HEPHAESTUS Contributors
+//=================================================================================================
+
+#pragma once
+
+#include <system_error>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include <liburing.h>  // NOLINT(misc-include-cleaner)
+#include <liburing/io_uring.h>
+#include <stdexec/__detail/__execution_fwd.hpp>
+#include <stdexec/execution.hpp>
+#include <sys/socket.h>
+
+#include "hephaestus/concurrency/basic_sender.h"
+#include "hephaestus/net/detail/operation_state.h"
+#include "hephaestus/net/endpoint.h"
+#include "hephaestus/net/socket.h"
+
+namespace heph::net {
+template <typename TagT>
+struct ConnectT {
+  auto operator()(const Socket& socket, const Endpoint& endpoint) const {
+    return concurrency::makeSenderExpression<ConnectT>(std::tuple{ &socket, &endpoint });
+  }
+};
+
+// NOLINTNEXTLINE (readability-identifier-naming)
+inline constexpr ConnectT<void> connect{};
+
+namespace internal {
+template <typename Receiver>
+struct ConnectOperation {
+  using StopTokenT = stdexec::stop_token_of_t<stdexec::env_of_t<Receiver>>;
+
+  const Socket* socket{ nullptr };
+  const Endpoint* endpoint{ nullptr };
+  Receiver receiver;
+
+  void prepare(::io_uring_sqe* sqe) const {
+    auto addr = endpoint->nativeHandle();
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    ::io_uring_prep_connect(sqe, socket->nativeHandle(), reinterpret_cast<const sockaddr*>(addr.data()),
+                            addr.size());
+  }
+  void handleCompletion(::io_uring_cqe* cqe) {
+    if (cqe->res < 0) {
+      stdexec::set_error(std::move(receiver), std::error_code(-cqe->res, std::system_category()));
+      return;
+    }
+    stdexec::set_value(std::move(receiver));
+  }
+
+  void handleStopped() {
+    stdexec::set_stopped(std::move(receiver));
+  }
+
+  auto getStopToken() {
+    return stdexec::get_stop_token(stdexec::get_env(receiver));
+  }
+};
+
+struct ConnectSender : heph::concurrency::DefaultSenderExpressionImpl {
+  static constexpr auto GET_COMPLETION_SIGNATURES =
+      []<typename Sender>(Sender&&, heph::concurrency::Ignore = {}) noexcept {
+        return stdexec::completion_signatures<stdexec::set_value_t(), stdexec::set_error_t(std::error_code),
+                                              stdexec::set_stopped_t()>{};
+      };
+
+  static constexpr auto GET_STATE = []<typename Sender, typename Receiver>(Sender&& sender,
+                                                                           Receiver&& receiver) noexcept {
+    auto [_, data] = std::forward<Sender>(sender);
+    auto [socket, endpoint] = data;
+    auto* ring = socket->context().ring();
+    using ConnectOperationT = ConnectOperation<std::decay_t<Receiver>>;
+    using OperationStateT = detail::OperationState<ConnectOperationT>;
+    return OperationStateT{ ring, ConnectOperationT{ socket, std::move(endpoint),
+                                                     std::forward<Receiver>(receiver) } };
+  };
+
+  static constexpr auto START = [](auto& operation, heph::concurrency::Ignore) { operation.submit(); };
+};
+}  // namespace internal
+}  // namespace heph::net
+
+namespace heph::concurrency {
+template <>
+struct SenderExpressionImpl<heph::net::ConnectT<void>> : heph::net::internal::ConnectSender {};
+}  // namespace heph::concurrency

--- a/modules/net/include/hephaestus/net/detail/operation_state.h
+++ b/modules/net/include/hephaestus/net/detail/operation_state.h
@@ -19,7 +19,7 @@ public:
   struct StopCallback {
     OperationState* self;
     void operator()() const noexcept {
-      self->stop_source_.request_stop();
+      self->requestStop();
     }
   };
 
@@ -35,6 +35,13 @@ public:
     env_stop_.emplace(operation_.operation.getStopToken(), StopCallback{ this });
     ring_stop_.emplace(ring->getStopToken(), StopCallback{ this });
     ring->submit(&operation_);
+  }
+
+private:
+  void requestStop() {
+    env_stop_.reset();
+    ring_stop_.reset();
+    stop_source_.request_stop();
   }
 
 private:

--- a/modules/net/include/hephaestus/net/endpoint.h
+++ b/modules/net/include/hephaestus/net/endpoint.h
@@ -13,7 +13,11 @@
 
 namespace heph::net {
 
+#ifndef DISABLE_BLUETOOTH
 enum struct EndpointType : std::uint8_t { IPV4, IPV6, BT, INVALID };
+#else
+enum struct EndpointType : std::uint8_t { IPV4, IPV6, INVALID };
+#endif
 
 class Endpoint {
 public:
@@ -30,7 +34,9 @@ public:
 
   static auto createIpV6(const std::string& ip = "", std::uint16_t port = 0) -> Endpoint;
 
+#ifndef DISABLE_BLUETOOTH
   static auto createBt(const std::string& mac = "", std::uint16_t psm = 0) -> Endpoint;
+#endif
 
   [[nodiscard]] auto nativeHandle() const -> std::span<const std::byte>;
   [[nodiscard]] auto nativeHandle() -> std::span<std::byte>;

--- a/modules/net/include/hephaestus/net/recv.h
+++ b/modules/net/include/hephaestus/net/recv.h
@@ -59,7 +59,7 @@ struct RecvOperation {
       stdexec::set_stopped(std::move(receiver));
       return true;
     }
-    transferred += cqe->res;
+    transferred += static_cast<std::size_t>(cqe->res);
     if constexpr (RecvAll) {
       if (transferred != buffer.size()) {
         return false;

--- a/modules/net/include/hephaestus/net/recv.h
+++ b/modules/net/include/hephaestus/net/recv.h
@@ -47,7 +47,7 @@ struct RecvOperation {
   void prepare(::io_uring_sqe* sqe) const {
     auto recv_size = std::min(socket->maximumRecvSize(), buffer.size() - transferred);
     auto to_transfer = buffer.subspan(transferred, recv_size);
-    ::io_uring_prep_recv(sqe, socket->nativeHandle(), to_transfer.data(), to_transfer.size(), 0);
+    ::io_uring_prep_recv(sqe, socket->nativeHandle(), to_transfer.data(), to_transfer.size(), MSG_NOSIGNAL);
   }
 
   auto handleCompletion(::io_uring_cqe* cqe) -> bool {

--- a/modules/net/include/hephaestus/net/send.h
+++ b/modules/net/include/hephaestus/net/send.h
@@ -47,7 +47,7 @@ struct SendOperation {
   void prepare(::io_uring_sqe* sqe) const {
     auto send_size = std::min(socket->maximumSendSize(), buffer.size() - transferred);
     auto to_transfer = buffer.subspan(transferred, send_size);
-    ::io_uring_prep_send(sqe, socket->nativeHandle(), to_transfer.data(), to_transfer.size(), 0);
+    ::io_uring_prep_send(sqe, socket->nativeHandle(), to_transfer.data(), to_transfer.size(), MSG_NOSIGNAL);
   }
 
   auto handleCompletion(::io_uring_cqe* cqe) -> bool {

--- a/modules/net/include/hephaestus/net/send.h
+++ b/modules/net/include/hephaestus/net/send.h
@@ -55,7 +55,7 @@ struct SendOperation {
       stdexec::set_error(std::move(receiver), std::error_code(-cqe->res, std::system_category()));
       return true;
     }
-    transferred += cqe->res;
+    transferred += static_cast<std::size_t>(cqe->res);
     if constexpr (SendAll) {
       if (transferred != buffer.size()) {
         return false;

--- a/modules/net/include/hephaestus/net/socket.h
+++ b/modules/net/include/hephaestus/net/socket.h
@@ -17,7 +17,11 @@ template <typename>
 struct AcceptOperation;
 }
 
+#ifndef DISABLE_BLUETOOTH
 enum struct SocketType : std::uint8_t { TCP, UDP, L2CAP, INVALID };
+#else
+enum struct SocketType : std::uint8_t { TCP, UDP, INVALID };
+#endif
 
 class Socket {
 public:
@@ -33,7 +37,9 @@ public:
   static auto createTcpIpV6(concurrency::Context& context) -> Socket;
   static auto createUdpIpV4(concurrency::Context& context) -> Socket;
   static auto createUdpIpV6(concurrency::Context& context) -> Socket;
+#ifndef DISABLE_BLUETOOTH
   static auto createL2cap(concurrency::Context& context) -> Socket;
+#endif
 
   [[nodiscard]] auto type() const {
     return type_;
@@ -67,7 +73,9 @@ public:
 
 private:
   Socket(concurrency::Context* context, int fd, SocketType type);
+#ifndef DISABLE_BLUETOOTH
   void setupL2capSocket(bool set_mtu);
+#endif
   void setupUDPSocket();
 
   template <typename>

--- a/modules/net/src/acceptor.cpp
+++ b/modules/net/src/acceptor.cpp
@@ -21,9 +21,11 @@ auto Acceptor::createTcpIpV4(concurrency::Context& context) -> Acceptor {
 auto Acceptor::createTcpIpV6(concurrency::Context& context) -> Acceptor {
   return Acceptor{ Socket::createTcpIpV6(context) };
 }
+#ifndef DISABLE_BLUETOOTH
 auto Acceptor::createL2cap(concurrency::Context& context) -> Acceptor {
   return Acceptor{ Socket::createL2cap(context) };
 }
+#endif
 
 void Acceptor::listen(int backlog) const {
   const int res = ::listen(socket_.nativeHandle(), backlog);

--- a/modules/net/src/endpoint.cpp
+++ b/modules/net/src/endpoint.cpp
@@ -16,8 +16,10 @@
 #include <vector>
 
 #include <arpa/inet.h>
+#ifndef DISABLE_BLUETOOTH
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/l2cap.h>
+#endif
 #include <fmt/format.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -63,6 +65,7 @@ auto Endpoint::createIpV6(const std::string& ip, std::uint16_t port) -> Endpoint
   return Endpoint{ EndpointType::IPV6, std::move(address) };
 }
 
+#ifndef DISABLE_BLUETOOTH
 auto Endpoint::createBt(const std::string& mac, std::uint16_t psm) -> Endpoint {
   sockaddr_l2 addr{};
   addr.l2_family = AF_BLUETOOTH;
@@ -79,6 +82,7 @@ auto Endpoint::createBt(const std::string& mac, std::uint16_t psm) -> Endpoint {
   std::memcpy(address.data(), &addr, sizeof(addr));
   return Endpoint{ EndpointType::BT, std::move(address) };
 }
+#endif
 
 namespace {
 auto getPortIpV4(const std::vector<std::byte>& address) -> std::uint16_t {
@@ -91,11 +95,13 @@ auto getPortIpV6(const std::vector<std::byte>& address) -> std::uint16_t {
   std::memcpy(&addr, address.data(), sizeof(addr));
   return ::ntohs(addr.sin6_port);
 }
+#ifndef DISABLE_BLUETOOTH
 auto getPortBt(const std::vector<std::byte>& address) -> std::uint16_t {
   sockaddr_l2 addr{};
   std::memcpy(&addr, address.data(), sizeof(addr));
   return btohs(addr.l2_psm);
 }
+#endif
 }  // namespace
 
 auto Endpoint::port() const -> std::uint16_t {
@@ -104,8 +110,10 @@ auto Endpoint::port() const -> std::uint16_t {
       return getPortIpV4(address_);
     case heph::net::EndpointType::IPV6:
       return getPortIpV6(address_);
+#ifndef DISABLE_BLUETOOTH
     case heph::net::EndpointType::BT:
       return getPortBt(address_);
+#endif
     default:
       heph::panic("Unknown family");
   }
@@ -136,6 +144,7 @@ auto getAddressIpV6(const std::vector<std::byte>& address) -> std::string {
 
   return std::string{ buffer.data() };
 }
+#ifndef DISABLE_BLUETOOTH
 auto getAddressBt(const std::vector<std::byte>& address) -> std::string {
   static constexpr std::size_t BT_ADDRSTRLEN = 18;
   std::array<char, BT_ADDRSTRLEN> buffer{};
@@ -149,6 +158,7 @@ auto getAddressBt(const std::vector<std::byte>& address) -> std::string {
 
   return std::string{ buffer.data() };
 }
+#endif
 }  // namespace
 
 auto Endpoint::address() const -> std::string {
@@ -157,8 +167,10 @@ auto Endpoint::address() const -> std::string {
       return getAddressV4(address_);
     case heph::net::EndpointType::IPV6:
       return getAddressIpV6(address_);
+#ifndef DISABLE_BLUETOOTH
     case heph::net::EndpointType::BT:
       return getAddressBt(address_);
+#endif
     default:
       heph::panic("Unknown family");
   }

--- a/modules/net/src/endpoint.cpp
+++ b/modules/net/src/endpoint.cpp
@@ -100,13 +100,13 @@ auto getPortBt(const std::vector<std::byte>& address) -> std::uint16_t {
 
 auto Endpoint::port() const -> std::uint16_t {
   switch (type()) {
-    case EndpointType::IPV4:
+    case heph::net::EndpointType::IPV4:
       return getPortIpV4(address_);
-    case EndpointType::IPV6:
+    case heph::net::EndpointType::IPV6:
       return getPortIpV6(address_);
-    case EndpointType::BT:
+    case heph::net::EndpointType::BT:
       return getPortBt(address_);
-    case EndpointType::INVALID:
+    default:
       heph::panic("Unknown family");
   }
   __builtin_unreachable();
@@ -159,7 +159,7 @@ auto Endpoint::address() const -> std::string {
       return getAddressIpV6(address_);
     case heph::net::EndpointType::BT:
       return getAddressBt(address_);
-    case EndpointType::INVALID:
+    default:
       heph::panic("Unknown family");
   }
   __builtin_unreachable();

--- a/modules/net/src/socket.cpp
+++ b/modules/net/src/socket.cpp
@@ -45,6 +45,7 @@ Socket::Socket(concurrency::Context* context, int fd, SocketType type)
   if (fd_ == -1) {
     panic("socket: {}", std::error_code(errno, std::system_category()).message());
   }
+
   switch (type) {
     case SocketType::L2CAP:
       setupL2capSocket(true);
@@ -81,7 +82,8 @@ Socket::Socket(Socket&& other) noexcept
   : context_(other.context_)
   , maximum_recv_size_(other.maximum_recv_size_)
   , maximum_send_size_(other.maximum_send_size_)
-  , fd_(other.fd_) {
+  , fd_(other.fd_)
+  , type_(other.type_) {
   other.fd_ = -1;
 }
 
@@ -91,6 +93,7 @@ auto Socket::operator=(Socket&& other) noexcept -> Socket& {
   maximum_recv_size_ = other.maximum_recv_size_;
   maximum_send_size_ = other.maximum_send_size_;
   fd_ = other.fd_;
+  type_ = other.type_;
   other.fd_ = -1;
 
   return *this;
@@ -98,6 +101,7 @@ auto Socket::operator=(Socket&& other) noexcept -> Socket& {
 
 void Socket::close() noexcept {
   if (fd_ != -1) {
+    ::shutdown(fd_, SHUT_RDWR);
     ::close(fd_);
     fd_ = -1;
   }

--- a/modules/net/src/socket.cpp
+++ b/modules/net/src/socket.cpp
@@ -13,8 +13,10 @@
 #include <vector>
 
 #include <asm-generic/socket.h>
+#ifndef DISABLE_BLUETOOTH
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/l2cap.h>
+#endif
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -31,8 +33,10 @@ auto familyToEndpointType(int domain) {
       return heph::net::EndpointType::IPV4;
     case AF_INET6:
       return heph::net::EndpointType::IPV6;
+#ifndef DISABLE_BLUETOOTH
     case AF_BLUETOOTH:
       return heph::net::EndpointType::BT;
+#endif
     default:
       heph::panic("Unknown domain {}", domain);
   }
@@ -47,9 +51,11 @@ Socket::Socket(concurrency::Context* context, int fd, SocketType type)
   }
 
   switch (type) {
+#ifndef DISABLE_BLUETOOTH
     case SocketType::L2CAP:
       setupL2capSocket(true);
       break;
+#endif
     case SocketType::UDP:
       setupUDPSocket();
       break;
@@ -70,9 +76,12 @@ auto Socket::createUdpIpV4(concurrency::Context& context) -> Socket {
 auto Socket::createUdpIpV6(concurrency::Context& context) -> Socket {
   return Socket{ &context, socket(AF_INET6, SOCK_DGRAM, 0), SocketType::UDP };
 }
+
+#ifndef DISABLE_BLUETOOTH
 auto Socket::createL2cap(concurrency::Context& context) -> Socket {
   return Socket{ &context, socket(AF_BLUETOOTH, SOCK_SEQPACKET, 0), SocketType::L2CAP };
 }
+#endif
 
 Socket::~Socket() noexcept {
   close();
@@ -173,6 +182,7 @@ auto Socket::remoteEndpoint() const -> Endpoint {
   return Endpoint{ familyToEndpointType(addr.sa_family), std::move(address) };
 }
 
+#ifndef DISABLE_BLUETOOTH
 void Socket::setupL2capSocket(bool set_mtu) {
   static constexpr std::uint16_t BT_TX_WIN_SIZE = 256;
   static constexpr std::uint16_t BT_MAX_TX = 100;
@@ -208,6 +218,7 @@ void Socket::setupL2capSocket(bool set_mtu) {
     panic("unable to set send buffer size: {}", std::error_code(errno, std::system_category()).message());
   }
 }
+#endif
 
 void Socket::setupUDPSocket() {
   static constexpr std::size_t MAX_UDP_PACKET_SIZE = 65507;


### PR DESCRIPTION
# Description


Adding capability to subscribe to conduit outputs served by a node engine.

Flyby:
 - Fixing issues with stopping send/recv
 - Adding `heph::net::connect` to perform async connect
 - Fixing an issue with `heph::concurrency::TimerClock`
 - Minor fixes to `heph::net::socket`


## Type of change
Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)


## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
