### PR TITLE
make the it consumer consume messages instead of referencing them

### DIFF
--- a/modules/concurrency/include/hephaestus/concurrency/message_queue_consumer.h
+++ b/modules/concurrency/include/hephaestus/concurrency/message_queue_consumer.h
@@ -89,7 +89,7 @@ void MessageQueueConsumer<T>::consume() {
     return;
   }
 
-  callback_(std::forward<T>(message.value()));
+  callback_(std::move(message.value()));
 }
 
 }  // namespace heph::concurrency

--- a/modules/concurrency/include/hephaestus/concurrency/message_queue_consumer.h
+++ b/modules/concurrency/include/hephaestus/concurrency/message_queue_consumer.h
@@ -19,7 +19,7 @@ namespace heph::concurrency {
 template <typename T>
 class MessageQueueConsumer {
 public:
-  using Callback = std::function<void(const T&)>;
+  using Callback = std::function<void(T&&)>;
   [[nodiscard]] MessageQueueConsumer(Callback&& callback, std::optional<std::size_t> max_queue_size);
   ~MessageQueueConsumer() = default;
   MessageQueueConsumer(const MessageQueueConsumer&) = delete;
@@ -72,7 +72,7 @@ auto MessageQueueConsumer<T>::stop() -> std::future<void> {
         return;
       }
 
-      callback_(message.value());
+      callback_(std::forward<T>(message.value()));
     }
   });
 }
@@ -89,7 +89,7 @@ void MessageQueueConsumer<T>::consume() {
     return;
   }
 
-  callback_(message.value());
+  callback_(std::forward<T>(message.value()));
 }
 
 }  // namespace heph::concurrency

--- a/modules/concurrency/include/hephaestus/concurrency/message_queue_consumer.h
+++ b/modules/concurrency/include/hephaestus/concurrency/message_queue_consumer.h
@@ -72,7 +72,7 @@ auto MessageQueueConsumer<T>::stop() -> std::future<void> {
         return;
       }
 
-      callback_(std::forward<T>(message.value()));
+      callback_(std::move(message.value()));
     }
   });
 }


### PR DESCRIPTION
# Description

At the moment the callback in the message_queue:_consumer is calling the elements of the queue by ref.
A. logically they should be consumed
B. consuming might help in some cases (f.e.the elements want to be send somewhere else

## Type of change
Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
