### PR TITLE
Fix: Timer cancelation from receiver environment

### DIFF
--- a/modules/concurrency/include/hephaestus/concurrency/context.h
+++ b/modules/concurrency/include/hephaestus/concurrency/context.h
@@ -67,6 +67,7 @@ private:
   template <typename Receiver, typename Context>
   friend struct TimedTask;
   void enqueueAt(TaskBase* task, io_ring::TimerClock::time_point start_time);
+  void dequeueTimer(TaskBase* task);
 
   auto runTimedTasks() -> bool;
   auto runTasks() -> bool;

--- a/modules/concurrency/include/hephaestus/concurrency/io_ring/timer.h
+++ b/modules/concurrency/include/hephaestus/concurrency/io_ring/timer.h
@@ -6,9 +6,7 @@
 
 #include <chrono>
 #include <cstdint>
-#include <functional>
 #include <optional>
-#include <queue>
 #include <vector>
 
 #include <liburing.h>  // NOLINT(misc-include-cleaner)
@@ -66,6 +64,7 @@ public:
   void tick();
 
   void startAt(TaskBase* task, TimerClock::time_point start_time);
+  void dequeue(TaskBase* task);
 
   auto now() -> TimerClock::time_point {
     return last_tick_;
@@ -113,7 +112,7 @@ private:
   __kernel_timespec next_timeout_{};
   std::optional<StoppableIoRingOperation<Operation>> timer_operation_;
   std::optional<StoppableIoRingOperation<UpdateOperation>> update_timer_operation_;
-  std::priority_queue<TimerEntry, std::vector<TimerEntry>, std::greater<>> tasks_;
+  std::vector<TimerEntry> tasks_;
 
   TimerClock::time_point start_;
   TimerClock::time_point last_tick_;

--- a/modules/concurrency/src/context.cpp
+++ b/modules/concurrency/src/context.cpp
@@ -51,6 +51,10 @@ void Context::enqueueAt(TaskBase* task, io_ring::TimerClock::time_point start_ti
   ring_.submit(&task->dispatch_operation);
 }
 
+void Context::dequeueTimer(TaskBase* task) {
+  timer_.dequeue(task);
+}
+
 auto Context::runTasks() -> bool {
   if (tasks_.empty()) {
     return false;


### PR DESCRIPTION
# Description

This is implementing timer cancelation support used in for example `exec::when_all`.

## Type of change
Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
