### PR TITLE
Fix: Improve FIFO queue, stabilize timer

### DIFF
--- a/modules/concurrency/include/hephaestus/concurrency/context_scheduler.h
+++ b/modules/concurrency/include/hephaestus/concurrency/context_scheduler.h
@@ -109,6 +109,7 @@ struct TaskBase {
 
   TaskDispatchOperation dispatch_operation{ this };
   TaskBase* next{ nullptr };
+  TaskBase* prev{ nullptr };
 };
 
 template <typename Receiver, typename Context>

--- a/modules/concurrency/include/hephaestus/concurrency/io_ring/timer.h
+++ b/modules/concurrency/include/hephaestus/concurrency/io_ring/timer.h
@@ -59,6 +59,10 @@ public:
   explicit Timer(IoRing& ring, TimerOptions options);
   ~Timer() noexcept;
 
+  auto empty() const -> bool {
+    return tasks_.empty();
+  }
+
   void requestStop();
 
   void tick();
@@ -88,7 +92,7 @@ private:
   struct Operation {
     void prepare(::io_uring_sqe* sqe) const;
     void handleCompletion(::io_uring_cqe* cqe) const;
-    void handleStopped();
+    void handleStopped() const;
 
     Timer* timer{ nullptr };
   };

--- a/modules/concurrency/src/context.cpp
+++ b/modules/concurrency/src/context.cpp
@@ -76,7 +76,7 @@ auto Context::runTasksSimulated() -> bool {
 
   runTasks();
 
-  if (tasks_.empty() && stopRequested()) {
+  if (tasks_.empty() && timer_.empty() && stopRequested()) {
     return false;
   }
   return true;

--- a/modules/concurrency/tests/context_tests.cpp
+++ b/modules/concurrency/tests/context_tests.cpp
@@ -36,6 +36,7 @@ TEST(ContextTests, SchedulerBasics) {
                 });
   scope.spawn(sender);
   context.run();
+  stdexec::sync_wait(scope.on_empty());
   EXPECT_TRUE(called);
 
   EXPECT_TRUE(stdexec::sender<decltype(sender)>);
@@ -63,6 +64,7 @@ TEST(ContextTests, scheduleException) {
                 });
   scope.spawn(sender);
   context.run();
+  stdexec::sync_wait(scope.on_empty());
   EXPECT_TRUE(called);
 }
 
@@ -126,6 +128,7 @@ TEST(ContextTests, scheduleAfter) {
     scope.spawn(sender);
   }
   context.run();
+  stdexec::sync_wait(scope.on_empty());
   auto end = std::chrono::steady_clock::now();
   EXPECT_EQ(called, 2);
   EXPECT_EQ(call_sequence, call_sequence_ref);
@@ -169,6 +172,7 @@ TEST(ContextTests, scheduleAfterStopWaitingAny) {
               stdexec::then([&] { context.requestStop(); }));
 
   context.run();
+  stdexec::sync_wait(scope.on_empty());
   auto end = std::chrono::steady_clock::now();
   auto duration = end - begin;
   EXPECT_LT(duration, DELAY_TIME);
@@ -199,6 +203,7 @@ TEST(ContextTests, scheduleAfterSimulated) {
     scope.spawn(sender);
   }
   context.run();
+  stdexec::sync_wait(scope.on_empty());
   auto end = std::chrono::system_clock::now();
   EXPECT_EQ(called, 2);
   EXPECT_EQ(call_sequence, call_sequence_ref);
@@ -225,10 +230,11 @@ TEST(ContextTests, scheduleAfterStopWaitingSimulated) {
   auto begin = std::chrono::steady_clock::now();
   context.run();
   auto end = std::chrono::steady_clock::now();
+  stdexec::sync_wait(scope.on_empty());
   EXPECT_EQ(called, 1);
   EXPECT_LE(end - begin, delay_time);
   EXPECT_GE(context.elapsed(), delay_time);
-  EXPECT_LT(context.elapsed(), delay_time * 2);
+  EXPECT_LE(context.elapsed(), delay_time * 2);
 }
 
 }  // namespace heph::concurrency::tests

--- a/modules/conduit/include/hephaestus/conduit/detail/awaiter.h
+++ b/modules/conduit/include/hephaestus/conduit/detail/awaiter.h
@@ -18,6 +18,7 @@ public:
 private:
   friend struct containers::IntrusiveFifoQueueAccess;
   [[maybe_unused]] AwaiterBase* next_{ nullptr };
+  [[maybe_unused]] AwaiterBase* prev_{ nullptr };
 };
 
 template <typename InputT, typename ReceiverT>

--- a/modules/containers/tests/intrusive_fifo_queue_tests.cpp
+++ b/modules/containers/tests/intrusive_fifo_queue_tests.cpp
@@ -10,6 +10,7 @@ namespace heph::containers {
 
 struct Dummy {
   Dummy* next{ nullptr };
+  Dummy* prev{ nullptr };
 };
 
 TEST(IntrusiveFifoQueue, Empty) {
@@ -144,6 +145,7 @@ class DummyPrivate {
 private:
   friend struct IntrusiveFifoQueueAccess;
   [[maybe_unused]] DummyPrivate* next_{ nullptr };
+  [[maybe_unused]] DummyPrivate* prev_{ nullptr };
 };
 TEST(IntrusiveFifoQueue, Access) {
   IntrusiveFifoQueue<DummyPrivate> queue;


### PR DESCRIPTION
# Description

- FIFO is now a doubly linked circular list (avoids linear time complexity for task removal)
- Minor adjustements for timer

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
