### PR TITLE
Fix: Accepting BT sockets

### DIFF
--- a/modules/net/include/hephaestus/net/accept.h
+++ b/modules/net/include/hephaestus/net/accept.h
@@ -45,7 +45,8 @@ struct AcceptOperation {
       stdexec::set_error(std::move(receiver), std::error_code(-cqe->res, std::system_category()));
       return;
     }
-    stdexec::set_value(std::move(receiver), Socket{ &acceptor->context(), cqe->res, acceptor->type() });
+    stdexec::set_value(std::move(receiver),
+                       Socket{ &acceptor->context(), cqe->res, acceptor->type(), false });
   }
 
   void handleStopped() {

--- a/modules/net/include/hephaestus/net/socket.h
+++ b/modules/net/include/hephaestus/net/socket.h
@@ -72,7 +72,7 @@ public:
   }
 
 private:
-  Socket(concurrency::Context* context, int fd, SocketType type);
+  Socket(concurrency::Context* context, int fd, SocketType type, bool set_mtu = true);
 #ifndef DISABLE_BLUETOOTH
   void setupL2capSocket(bool set_mtu);
 #endif

--- a/modules/net/src/socket.cpp
+++ b/modules/net/src/socket.cpp
@@ -44,7 +44,7 @@ auto familyToEndpointType(int domain) {
 }
 }  // namespace
 
-Socket::Socket(concurrency::Context* context, int fd, SocketType type)
+Socket::Socket(concurrency::Context* context, int fd, SocketType type, bool set_mtu)
   : context_(context), fd_(fd), type_(type) {
   if (fd_ == -1) {
     panic("socket: {}", std::error_code(errno, std::system_category()).message());
@@ -53,7 +53,7 @@ Socket::Socket(concurrency::Context* context, int fd, SocketType type)
   switch (type) {
 #ifndef DISABLE_BLUETOOTH
     case SocketType::L2CAP:
-      setupL2capSocket(true);
+      setupL2capSocket(set_mtu);
       break;
 #endif
     case SocketType::UDP:


### PR DESCRIPTION
# Description

This is fixing accepts of L2CAP sockets. When accepting, we can't set the l2cap options to alter the MTU as this only works with unconnected sockets.

Unfortunately, this is not easily testable so far.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
