### PR TITLE
Fix/Action Server: Lifecycle of stop service

### DIFF
--- a/modules/ipc/include/hephaestus/ipc/zenoh/action_server/action_server.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/action_server/action_server.h
@@ -169,12 +169,11 @@ ActionServer<RequestT, StatusT, ReplyT>::ActionServer(SessionPtr session, TopicC
   , request_consumer_([this](const Request<RequestT>& request) { return execute(request); }, std::nullopt)
   , stop_service_(std::make_unique<Service<std::string, std::string>>(
         session_, internal::getStopServiceTopic(topic_config_),
-        [this](const std::string&) {  // Main callback using 'this'
+        [this](const std::string&) {
           this->stop_requested_ = true;
           return "stopped";
         },
-        []() {},  // Failure callback (empty)
-        []() {},  // Post-reply callback (empty)
+        []() {}, []() {},
         ServiceConfig{
             .create_liveliness_token = false,
             .create_type_info_service = false,


### PR DESCRIPTION
# Description
The ActionServer::execute method created its stop_service as a local variable on the stack. When the execute method returned, the Service object was destroyed, but its callback remained registered within Zenoh. A subsequent call to the stop service would invoke a dangling function pointer, resulting in a stack-use-after-return in address sanitizer.

The stop_service has been promoted to a class member of ActionServer, owned by a std::unique_ptr. It is now created in the ActionServer's constructor, tying its lifetime to the ActionServer itself and ensuring its callback is always valid.

## Type of change
Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] If this is a new component I have added examples.
- [ ] I updated the README and related documentation.
