### PR TITLE
Add telemetry recording for missed deadline warnings in NodeBase

### DIFF
--- a/modules/conduit/src/detail/node_base.cpp
+++ b/modules/conduit/src/detail/node_base.cpp
@@ -92,6 +92,14 @@ auto NodeBase::nextStartTime(bool has_period) -> ClockT::time_point {
 
     heph::log(heph::WARN, std::string{ MISSED_DEADLINE_WARNING }, "node", nodeName(), "period", period,
               "tick_duration", last_duration, "execution_duration", last_execution_duration_);
+
+    heph::telemetry::record([name = nodeName(), timestamp = now] {
+      return heph::telemetry::Metric{ .component = fmt::format("conduit/{}", name),
+                                      .tag = "node_warnings",
+                                      .timestamp = timestamp,
+                                      .values = { { "missing_deadline", true } } };
+    });
+
     return now;
   }
   return next_time_point;


### PR DESCRIPTION
# Description
Adding Telemetry Log for node warnings, in this case missing execution deadline

## Type of change
Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

Example Visualization
<img width="3238" height="1583" alt="image" src="https://github.com/user-attachments/assets/b21b41e5-70ab-47e3-971d-b9cae445c614" />


## Checklist before requesting a review
- [x] I have performed a self-review of my code.
