### PR TITLE
add bazel support to gcc and upgrade to C++23

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,8 @@
 startup --output_user_root=~/.cache/bazel/output/
 
+build --extra_toolchains=@llvm_toolchain//:all
+build:gcc --extra_toolchains="@gcc_toolchain_x86_64//:cc_toolchain"
+
 build --disk_cache=~/.cache/bazel/cache
 build --repository_cache=~/.cache/bazel/repos/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,30 +83,6 @@ jobs:
         # Build your program with the given configuration
         run: cmake --build ${{github.workspace}}/build -- all examples
 
-  build-gcc:
-    needs: docker_build_and_publish
-    # TODO: use the docker image published at the step over
-    runs-on: ubuntu-latest
-    permissions: read-all
-    container:
-      image: ghcr.io/olympus-robotics/x86_64/hephaestus-dev:latest
-      credentials:
-        username: ${{ github.actor}}
-        password: ${{secrets.GITHUB_TOKEN}}
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Install Rust
-        run: |
-          export PATH=/usr/local/cargo/bin:$PATH
-          echo $(rustup toolchain install stable)
-          echo $(rustup default stable)
-          echo $(rustup show)
-      - name: Configure CMake
-        run: export PATH=/usr/local/cargo/bin:$PATH && cmake -B ${{github.workspace}}/build --preset gcc
-      - name: Build
-        # Build your program with the given configuration
-        run: cmake --build ${{github.workspace}}/build -- all examples
-
   format:
     runs-on: ubuntu-latest
     permissions: read-all
@@ -147,4 +123,12 @@ jobs:
     with:
       config: "sanitizer"
       compilation-mode: "opt"
+    secrets: inherit
+
+  bazel-gcc:
+    permissions: read-all
+    uses: ./.github/workflows/build-bazel.yml
+    with:
+      config: "gcc"
+      compilation-mode: "fastbuild"
     secrets: inherit

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,37 +18,42 @@ bazel_dep(name = "platforms", version = "1.0.0", dev_dependency = True)
 # Toolchains #
 ##############
 
+CPP_STANDARD = "c++23"
+
 # LLVM
-bazel_dep(name = "toolchains_llvm", version = "1.3.0")
-
-LLVM_COMMIT = "14eb90172b3c5f35bdb2699d006fe0f70e76aa24"
-
-archive_override(
-    module_name = "toolchains_llvm",
-    sha256 = "d85f78a501d6050fa0f1fb74e1c5f971549cd6d0b9c9147857935c0346c070d0",
-    strip_prefix = "toolchains_llvm-{commit}".format(commit = LLVM_COMMIT),
-    url = "https://github.com/bazel-contrib/toolchains_llvm/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
-)
+bazel_dep(name = "toolchains_llvm", version = "1.5.0")
 
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
-
 LLVM_VERSIONS = {
     "": "20.1.0",
-    "linux-aarch64": "20.1.0",
-    "linux-x86_64": "20.1.0",
 }
-
 llvm.toolchain(
     name = "llvm_toolchain",
     cxx_standard = {
-        "": "c++20",
+        "": CPP_STANDARD,
     },
     llvm_versions = LLVM_VERSIONS,
 )
 use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")
-
 register_toolchains(
     "@llvm_toolchain//:all",
+    dev_dependency = True,
+)
+
+# GCC
+bazel_dep(name = "gcc_toolchain", version = "0.9.0")
+
+ARCH = "x86_64"
+gcc = use_extension("@gcc_toolchain//toolchain:module_extensions.bzl", "gcc_toolchains", dev_dependency = True)
+gcc.toolchain(
+    name = "gcc_toolchain_{}".format(ARCH),
+    gcc_version = "13.4.0",
+    extra_cxxflags = ["-std={}".format(CPP_STANDARD)],
+    target_arch = ARCH,
+)
+use_repo(gcc, "gcc_toolchain_{}".format(ARCH))
+register_toolchains(
+    "@gcc_toolchain_{}//:cc_toolchain".format(ARCH),
     dev_dependency = True,
 )
 

--- a/bazel/hephaestus.bzl
+++ b/bazel/hephaestus.bzl
@@ -52,6 +52,8 @@ def heph_gcc_copts():
         "-Wlogical-op",
         "-Wuseless-cast",
         "-fdiagnostics-color=always",
+        "-fPIC",
+        "-Wshadow",
     ]
 
 def heph_copts():


### PR DESCRIPTION
# Description
Add GCC toolchain and upgrade to GCC 13 and C++23.

Issue: GCC uses `iquote` instead of `isystem` for abseil dependency and the compiler doesn't find it.
It happens only for abseil and not for fmt or others. No idea what is happening.

To reproduce: `bazel build //modules/utils/... --config gcc` 
